### PR TITLE
test fix: wait on ingest to stop

### DIFF
--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -301,4 +301,10 @@ export const pcapIngestSample = async (app: Application) => {
   await appStep("wait for viewer to appear", () =>
     app.client.waitForVisible(selectors.viewer.results_base)
   )
+  await appStep("wait for ingest to finish", () =>
+    retryUntil(
+      () => app.client.isExisting(selectors.status.ingestProgress),
+      (ingesting) => ingesting === false
+    )
+  )
 }

--- a/src/js/components/PacketPostProgress.js
+++ b/src/js/components/PacketPostProgress.js
@@ -6,6 +6,7 @@ import {isNumber} from "../lib/is"
 import ProgressIndicator from "./ProgressIndicator"
 import Spaces from "../state/Spaces"
 import Tab from "../state/Tab"
+import {reactElementProps} from "../test/integration"
 
 export default function PacketPostProgress() {
   let id = useSelector(Tab.clusterId)
@@ -14,7 +15,10 @@ export default function PacketPostProgress() {
   if (!isNumber(value)) return null
 
   return (
-    <div className="packet-post-progress">
+    <div
+      className="packet-post-progress"
+      {...reactElementProps("ingestProgress")}
+    >
       <label>Processing Packets...</label>
       <ProgressIndicator percent={value} />
     </div>

--- a/src/js/test/integration.js
+++ b/src/js/test/integration.js
@@ -16,6 +16,7 @@ const dataAttrs = {
   debugProgram: "debugProgram",
   downloadMessage: "downloadMessage",
   histogram: "histogram-chart",
+  ingestProgress: "ingestProgress",
   killHistogramSearch: "killHistogramSearch",
   killViewerSearch: "killViewerSearch",
   logCellMenu: "logCellMenu",
@@ -133,6 +134,9 @@ export const selectors = {
     button: dataAttrSelector("span_button"),
     menu: dataAttrSelector("span_menu"),
     menuItem: genSelectorForTextUnderElement("span_menu")
+  },
+  status: {
+    ingestProgress: dataAttrSelector("ingestProgress")
   },
   viewer: {
     header_base: dataAttrSelector("viewer_header"),


### PR DESCRIPTION
Wait for the ingest progress indicator not to exist as a clue that ingest is complete. This helps reduce test races in cases where we want ingest to succeed.