### PR TITLE
Initial changelog, including Windows limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This is the same as v0.5.1, but addresses a CI issue that stopped the creation o
 Brim on Windows can currently be considered beta quality. There's two
 significant known limitations:
 
-* On Windows, generation of Zeek logs from pcaps is slower than we'd like it to be. This is due to lack of formal support for Zeek on Windows. We got it working with our own Zeek port, but the best we could do in our first take uses 32-bit [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
+* On Windows, generation of Zeek logs from pcaps is slower than we'd like it to be. This is due to lack of formal support for Zeek on Windows. We got it working with [our own Zeek port](https://github.com/brimsec/zeek/tree/master/brim/windows), but the best we could do in our first take uses 32-bit [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
 * We don't yet have the necessary Windows certifications in place to provide a warning-free install experience. Your anti-virus software is likely to jump in with "Are you sure you want to run this?" warnings and scans for viruses. Rest assured that we've not put viruses in our code, but we understand if you're concerned about installing under such conditions. You may want to install on a scratch Windows VM if that feels safer, or you can wait until we've secured the certifications in an upcoming release.
 
 ## v0.5.1
@@ -21,6 +21,6 @@ significant known limitations:
 Brim on Windows can currently be considered beta quality. There's two
 significant known limitations:
 
-* On Windows, generation of Zeek logs from pcaps is slower than we'd like it to be. This is due to lack of formal support for Zeek on Windows. We got it working with our own Zeek port, but the best we could do in our first take uses 32-bit [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
+* On Windows, generation of Zeek logs from pcaps is slower than we'd like it to be. This is due to lack of formal support for Zeek on Windows. We got it working with [our own Zeek port](https://github.com/brimsec/zeek/tree/master/brim/windows), but the best we could do in our first take uses 32-bit [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
 * We don't yet have the necessary Windows certifications in place to provide a warning-free install experience. Your anti-virus software is likely to jump in with "Are you sure you want to run this?" warnings and scans for viruses. Rest assured that we've not put viruses in our code, but we understand if you're concerned about installing under such conditions. You may want to install on a scratch Windows VM if that feels safer, or you can wait until we've secured the certifications in an upcoming release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+## v0.5.2
+
+This is the same as v0.5.1, but addresses a CI issue that stopped the creation of the Windows installer executable. 
+
+#### Windows Limitations (beta notice)
+
+Brim on Windows can currently be considered beta quality. There's two
+significant known limitations:
+
+* On Windows, generation of Zeek logs from pcaps is slower than we'd like it to be. This is due to lack of formal support for Zeek on Windows. We got it working with our own Zeek port, but the best we could do in our first take uses 32-bit [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
+* We don't yet have the necessary Windows certifications in place to provide a warning-free install experience. Your anti-virus software is likely to jump in with "Are you sure you want to run this?" warnings and scans for viruses. Rest assured that we've not put viruses in our code, but we understand if you're concerned about installing under such conditions. You may want to install on a scratch Windows VM if that feels safer, or you can wait until we've secured the certifications in an upcoming release.
+
+## v0.5.1
+
+* Initial Windows release creation and support. Windows releases are currently unsigned (unlike our Mac releases), but will be soon.
+* Warn on close if there are still active pcap ingests.
+* Fix some issues saving search history.
+
+#### Windows Limitations (beta notice)
+
+Brim on Windows can currently be considered beta quality. There's two
+significant known limitations:
+
+* On Windows, generation of Zeek logs from pcaps is slower than we'd like it to be. This is due to lack of formal support for Zeek on Windows. We got it working with our own Zeek port, but the best we could do in our first take uses 32-bit [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
+* We don't yet have the necessary Windows certifications in place to provide a warning-free install experience. Your anti-virus software is likely to jump in with "Are you sure you want to run this?" warnings and scans for viruses. Rest assured that we've not put viruses in our code, but we understand if you're concerned about installing under such conditions. You may want to install on a scratch Windows VM if that feels safer, or you can wait until we've secured the certifications in an upcoming release.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,8 @@
 
 This is the same as v0.5.1, but addresses a CI issue that stopped the creation of the Windows installer executable. 
 
-#### Windows Limitations (beta notice)
-
-Brim on Windows can currently be considered beta quality. There's two
-significant known limitations:
-
-* On Windows, generation of Zeek logs from pcaps is slower than we'd like it to be. This is due to lack of formal support for Zeek on Windows. We got it working with [our own Zeek port](https://github.com/brimsec/zeek/tree/master/brim/windows), but the best we could do in our first take uses 32-bit [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
-* We don't yet have the necessary Windows certifications in place to provide a warning-free install experience. Your anti-virus software is likely to jump in with "Are you sure you want to run this?" warnings and scans for viruses. Rest assured that we've not put viruses in our code, but we understand if you're concerned about installing under such conditions. You may want to install on a scratch Windows VM if that feels safer, or you can wait until we've secured the certifications in an upcoming release.
-
 ## v0.5.1
 
-* Initial Windows release creation and support. Windows releases are currently unsigned (unlike our Mac releases), but will be soon.
+* Initial (beta) Windows release creation and support. Windows releases are currently unsigned (unlike our Mac releases). See [README-Windows](README-Windows.md) for details.
 * Warn on close if there are still active pcap ingests.
 * Fix some issues saving search history.
-
-#### Windows Limitations (beta notice)
-
-Brim on Windows can currently be considered beta quality. There's two
-significant known limitations:
-
-* On Windows, generation of Zeek logs from pcaps is slower than we'd like it to be. This is due to lack of formal support for Zeek on Windows. We got it working with [our own Zeek port](https://github.com/brimsec/zeek/tree/master/brim/windows), but the best we could do in our first take uses 32-bit [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
-* We don't yet have the necessary Windows certifications in place to provide a warning-free install experience. Your anti-virus software is likely to jump in with "Are you sure you want to run this?" warnings and scans for viruses. Rest assured that we've not put viruses in our code, but we understand if you're concerned about installing under such conditions. You may want to install on a scratch Windows VM if that feels safer, or you can wait until we've secured the certifications in an upcoming release.
-

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -3,8 +3,8 @@
 Brim support on Windows is currently at beta quality. There's two
 significant known limitations:
 
-1. On Windows, generation of Zeek logs from pcaps is slower than we'd like it
-to be. This is related to the lack of formal support for Zeek on Windows. We got it
+1. Generation of Zeek logs from pcaps is slower than we'd like it to be. This
+is related to the lack of formal support for Zeek on Windows. We got it
 working with [our own Zeek port](https://github.com/brimsec/zeek/tree/master/brim/windows),
 but the best we could do in our first attempt uses 32-bit
 [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
@@ -14,5 +14,5 @@ install experience. Your anti-virus software is likely to jump in with "Are
 you sure you want to run this?" warnings and scans for viruses. Rest assured
 that we've not put viruses in our code, but we understand if you're concerned
 about installing under such conditions. You may want to install on a scratch
-Windows VM if that feels safer, or Watch the repo to be notified when we've
+Windows VM if that feels safer, or watch the repo to be notified when we've
 secured the certifications in an upcoming release.

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -1,0 +1,18 @@
+# Windows Limitations (beta notice)
+
+Brim support on Windows is currently at beta quality. There's two
+significant known limitations:
+
+1. On Windows, generation of Zeek logs from pcaps is slower than we'd like it
+to be. This is related to the lack of formal support for Zeek on Windows. We got it
+working with [our own Zeek port](https://github.com/brimsec/zeek/tree/master/brim/windows),
+but the best we could do in our first attempt uses 32-bit
+[Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
+2. We don't yet have the necessary Windows certifications in place to "sign"
+the release (like we do for macOS) and hence provide a warning-free
+install experience. Your anti-virus software is likely to jump in with "Are
+you sure you want to run this?" warnings and scans for viruses. Rest assured
+that we've not put viruses in our code, but we understand if you're concerned
+about installing under such conditions. You may want to install on a scratch
+Windows VM if that feels safer, or Watch the repo to be notified when we've
+secured the certifications in an upcoming release.


### PR DESCRIPTION
From a supportability perspective, it's great we have our Windows release, but I want to make sure we've written down that its "beta quality" limitations are known. In a discussion with @alfred-landrum we agreed on an approach like we've done for `zq` where we'll have a `CHANGELOG.md` that we'll update and commit with each release, then copy those same notes into the GitHub Releases tab alongside the artifacts.

Here I've backfilled the notes from our first public Releases into a new `CHANEGLOG.md`, along with my draft proposal for describing the Windows limitations. Once the wording is approved and this PR is merged, I'll backfill those Windows limitations into the notes for those two existing releases.