### PR TITLE
PROD-1687 Surface download errors in the app

### DIFF
--- a/src/js/services/BoomClient/adapters/download.js
+++ b/src/js/services/BoomClient/adapters/download.js
@@ -33,11 +33,11 @@ export default (
             method,
             auth: `${username}:${password}`
           })
-          .on("response", (resp) => {
+          .on("response", async (resp) => {
             if (resp.statusCode === 200) {
               resp.pipe(file)
             } else {
-              reject(resp.statusMessage)
+              reject(await string(resp))
             }
           })
           .on("error", (e) => {
@@ -47,3 +47,12 @@ export default (
       })
     })
   })
+
+async function string(stream) {
+  stream.setEncoding("utf-8")
+  let data = ""
+  for await (let chunk of stream) {
+    data += chunk
+  }
+  return data
+}

--- a/src/js/services/BoomClient/client/Packets.js
+++ b/src/js/services/BoomClient/client/Packets.js
@@ -6,26 +6,30 @@ import download from "../adapters/download"
 
 export default class Packets extends SubClient {
   get(args: PacketArgs) {
-    const params = new URLSearchParams()
-    params.set("ts_sec", args.ts_sec.toString())
-    params.set("ts_ns", args.ts_ns.toString())
-    params.set("duration_sec", args.duration_sec.toString())
-    params.set("duration_ns", args.duration_ns.toString())
-    params.set("proto", args.proto)
-    params.set("src_host", args.src_host)
-    params.set("src_port", args.src_port)
-    params.set("dst_host", args.dst_host)
-    params.set("dst_port", args.dst_port)
+    try {
+      const params = new URLSearchParams()
+      params.set("ts_sec", args.ts_sec.toString())
+      params.set("ts_ns", args.ts_ns.toString())
+      params.set("duration_sec", args.duration_sec.toString())
+      params.set("duration_ns", args.duration_ns.toString())
+      params.set("proto", args.proto)
+      params.set("src_host", args.src_host)
+      params.set("src_port", args.src_port)
+      params.set("dst_host", args.dst_host)
+      params.set("dst_port", args.dst_port)
 
-    const dest = `${args.destDir}/packets-${args.ts_sec +
-      args.ts_ns / 1e9}.pcap`
-    const method = "GET"
-    const path = `/space/${args.space}/packet?${params.toString()}`
+      const dest = `${args.destDir}/packets-${args.ts_sec +
+        args.ts_ns / 1e9}.pcap`
+      const method = "GET"
+      const path = `/space/${args.space}/packet?${params.toString()}`
 
-    const {host, port, ...rest} = this.base.options
+      const {host, port, ...rest} = this.base.options
 
-    if (!host || !port) throw "Missing host/port"
+      if (!host || !port) throw "Missing host/port"
 
-    return download({...rest, host, port, path, method}, dest)
+      return download({...rest, host, port, path, method}, dest)
+    } catch (e) {
+      return Promise.reject(e)
+    }
   }
 }

--- a/src/js/state/Packets/flows.js
+++ b/src/js/state/Packets/flows.js
@@ -18,8 +18,6 @@ export default {
     const state = getState()
     const space = Tab.spaceName(state)
     const destDir = downloadsDir()
-
-    console.log("DEBUG: ", space, destDir, log.getFields())
     return boom.packets
       .get({
         ts_sec: log.getSec("ts"),

--- a/src/js/state/Packets/flows.js
+++ b/src/js/state/Packets/flows.js
@@ -38,6 +38,7 @@ export default {
       })
       .catch((error) => {
         dispatch(Packets.error(log.getString("uid"), error))
+        throw error
       })
       .finally(() => {
         setTimeout(() => dispatch(View.hideDownloads()), 5000)

--- a/src/js/state/Packets/flows.js
+++ b/src/js/state/Packets/flows.js
@@ -18,6 +18,8 @@ export default {
     const state = getState()
     const space = Tab.spaceName(state)
     const destDir = downloadsDir()
+
+    console.log("DEBUG: ", space, destDir, log.getFields())
     return boom.packets
       .get({
         ts_sec: log.getSec("ts"),


### PR DESCRIPTION
Instead of reading the response from the server, we were just returning the StatusMessage. 

The pr reads the response and rejects the promise if its an error.

The reason for throwing the error again is so that we don't try to open anything when the promise resolves.


UPDATE:

Wrapped packets.get in a try catch and return a rejected promise if theres an error. This way we always see the error string in the app rather than the console.

The example below is the result of me hard coding a "null" value for the duration field.

<img width="773" alt="image" src="https://user-images.githubusercontent.com/3460638/77705869-047bb500-6f7e-11ea-9060-c2c71b4caa1d.png">

Added some debug info: (space, destDir, log)

<img width="445" alt="Screen Shot 2020-03-26 at 4 20 18 PM" src="https://user-images.githubusercontent.com/3460638/77705884-12313a80-6f7e-11ea-8fdd-7021aa6077ac.png">
