### PR TITLE
PROD-1566 Boom client inspect content-type

### DIFF
--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -108,7 +108,8 @@ async function zeekDownload(version, zdepsPath) {
     // Special casing for zeek on windows as it's not yet created automatically
     // like linux/mac.
     artifactFile = "zeek.zip"
-    artifactUrl = "https://storage.googleapis.com/brimsec/zeek-windows/zeek-20200624.zip"
+    artifactUrl =
+      "https://storage.googleapis.com/brimsec/zeek-windows/zeek-20200624.zip"
   } else {
     artifactFile = `zeek-${version}.${plat.osarch}.zip`
     artifactUrl = `https://github.com/brimsec/zeek/releases/download/${version}/${artifactFile}`

--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -108,8 +108,7 @@ async function zeekDownload(version, zdepsPath) {
     // Special casing for zeek on windows as it's not yet created automatically
     // like linux/mac.
     artifactFile = "zeek.zip"
-    artifactUrl =
-      "https://storage.googleapis.com/brimsec/zeek-windows/zeek-20200624.zip"
+    artifactUrl = "https://storage.googleapis.com/brimsec/zeek-windows/zeek-20200624.zip"
   } else {
     artifactFile = `zeek-${version}.${plat.osarch}.zip`
     artifactUrl = `https://github.com/brimsec/zeek/releases/download/${version}/${artifactFile}`

--- a/src/js/services/BoomClient/adapters/BrowserFetchAdapter.js
+++ b/src/js/services/BoomClient/adapters/BrowserFetchAdapter.js
@@ -35,9 +35,9 @@ export function send(req: BoomRequest) {
         }
         pull()
       } else {
-        parseResponse(resp)
-          .then((data) => req.emitDone(data))
-          .catch((e) => req.emitError(e))
+        parseResponse(resp).then((data) => {
+          typeof data === "string" ? req.emitError(data) : req.emitDone(data)
+        })
       }
     })
     .catch((error) => req.emitError(error))

--- a/src/js/services/BoomClient/adapters/BrowserFetchAdapter.js
+++ b/src/js/services/BoomClient/adapters/BrowserFetchAdapter.js
@@ -2,6 +2,7 @@
 
 import BoomRequest from "../lib/BoomRequest"
 import NdJsonDecoder from "../lib/NdJsonDecoder"
+import {parseResponse} from "../../zealot/fetcher"
 
 export function send(req: BoomRequest) {
   let {url, method, body, headers} = req
@@ -10,10 +11,7 @@ export function send(req: BoomRequest) {
   fetch(url, {method, body, headers, signal: control.signal})
     .then((resp) => {
       if (!resp.ok) {
-        resp
-          .json()
-          .then((j) => req.emitError(j))
-          .catch((e) => req.emitError(e))
+        parseResponse(resp).then((e) => req.emitError(e))
       } else if (req.streaming) {
         const text = new TextDecoder()
         const ndJson = new NdJsonDecoder((payload) => req.emitStream(payload))
@@ -37,8 +35,7 @@ export function send(req: BoomRequest) {
         }
         pull()
       } else {
-        resp
-          .json()
+        parseResponse(resp)
           .then((data) => req.emitDone(data))
           .catch((e) => req.emitError(e))
       }

--- a/src/js/services/BoomClient/lib/BoomRequest.js
+++ b/src/js/services/BoomClient/lib/BoomRequest.js
@@ -45,7 +45,11 @@ export default class BoomRequest {
     this.emit("stream", payload)
   }
 
-  emitError(error: Error) {
+  emitError(error: Error | string) {
+    if (typeof error === "string") {
+      this.emit("error", error)
+    }
+
     this.status = "error"
     if (this.isAbortError(error)) {
       if (this.emitAbort) this.emit("abort", error)

--- a/src/js/services/BoomClient/lib/BoomRequest.js
+++ b/src/js/services/BoomClient/lib/BoomRequest.js
@@ -46,11 +46,12 @@ export default class BoomRequest {
   }
 
   emitError(error: Error | string) {
+    this.status = "error"
     if (typeof error === "string") {
       this.emit("error", error)
+      return
     }
 
-    this.status = "error"
     if (this.isAbortError(error)) {
       if (this.emitAbort) this.emit("abort", error)
     } else {

--- a/src/js/services/zealot/fetcher.js
+++ b/src/js/services/zealot/fetcher.js
@@ -8,7 +8,7 @@ export type FetchGenerator = AsyncGenerator<Object, void, void>
 export type FetchPromise = Promise<Object>
 export type FetchArgs = {method: string, path: string, body?: string}
 
-export function parseResponse(resp) {
+export function parseResponse(resp: Response): Promise<*> {
   switch (resp.headers.get("Content-Type")) {
     case "application/json":
       try {

--- a/src/js/services/zealot/fetcher.js
+++ b/src/js/services/zealot/fetcher.js
@@ -8,7 +8,7 @@ export type FetchGenerator = AsyncGenerator<Object, void, void>
 export type FetchPromise = Promise<Object>
 export type FetchArgs = {method: string, path: string, body?: string}
 
-function parseResponse(resp) {
+export function parseResponse(resp) {
   switch (resp.headers.get("Content-Type")) {
     case "application/json":
       try {


### PR DESCRIPTION
This is meant to be a quick fix reusing the parse function that now exists in the zealot client. When we go through here again to refactor/consolidate the two clients into one then we can cleanup some of the assumptions that the boom client is still making w.r.t. expecting json encoded errors.

![boomParse](https://user-images.githubusercontent.com/14865533/77942598-b06c1b80-7270-11ea-8d49-a3c76f8d45d0.gif)
