### PR TITLE
PROD-1706 adjust github action

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -44,11 +44,19 @@ jobs:
         APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
     - name: run gatekeeper assessment on notarized package
       run: spctl --assess --type execute --verbose --ignore-cache --no-cache dist/packages/Brim-darwin-x64/Brim.app
-    - name: upload release assets
+    - name: upload release dmg
       uses: svenstaro/upload-release-action@1.1.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: dist/installers/*
-        file_glob: true
+        file: dist/installers/Brim.dmg
+        asset_name: Brim.dmg
+        overwrite: true
+    - name: upload release zip
+      uses: svenstaro/upload-release-action@1.1.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: dist/installers/Brim-darwin-autoupdater.zip
+        asset_name: Brim-darwin-autoupdater.zip
         overwrite: true

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -49,7 +49,6 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: dist/installers/Brim.dmg
-        asset_name: Brim.dmg
+        file: dist/installers/*
         file_glob: true
         overwrite: true


### PR DESCRIPTION
We are already producing a .zip in the release script, this adds an explicit step to upload it as part of the assets. Name of the zip is further coupled to this workflow now (just like the `Brim.app` already is), but I don't expect these to change much, if ever, anyway.

Signed-off-by: Mason Fish <mason@looky.cloud>