### PR TITLE
test feat: integration tests with macOS dmg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
     - run: npm install --no-audit
     - run: npm run build
+    - name: Build and Install MacOS DMG
+      if: runner.os == 'macOS'
+      run: |
+        set -x
+        node scripts/release --darwin
+        hdiutil attach dist/installers/Brim.dmg
+        cp -R /Volumes/Brim/Brim.app /Applications
+        hdiutil detach /Volumes/Brim
     - name: Integration Tests
       uses: GabrielBB/xvfb-action@v1.0
       with:

--- a/itest/lib/env.js
+++ b/itest/lib/env.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+import path from "path"
+
+export const isCI = (): boolean => process.env.GITHUB_ACTIONS === "true"
+
+export const repoDir = (): string =>
+  path.resolve(path.join(__dirname, "..", ".."))


### PR DESCRIPTION
Build the dmg using our tools, simulate installation, and point Spectron to the installed application path.