### PR TITLE
PROD-1698 Download Errors with Spaces in Spaces

### DIFF
--- a/src/js/services/BoomClient/adapters/download.js
+++ b/src/js/services/BoomClient/adapters/download.js
@@ -25,25 +25,29 @@ export default (
       file.on("error", reject)
       file.on("finish", () => resolve(dest))
       file.on("open", () => {
-        http
-          .request({
-            hostname,
-            port,
-            path,
-            method,
-            auth: `${username}:${password}`
-          })
-          .on("response", async (resp) => {
-            if (resp.statusCode === 200) {
-              resp.pipe(file)
-            } else {
-              reject(await string(resp))
-            }
-          })
-          .on("error", (e) => {
-            reject(e)
-          })
-          .end()
+        try {
+          http
+            .request({
+              hostname,
+              port,
+              path,
+              method,
+              auth: `${username}:${password}`
+            })
+            .on("response", async (resp) => {
+              if (resp.statusCode === 200) {
+                resp.pipe(file)
+              } else {
+                reject(await string(resp))
+              }
+            })
+            .on("error", (e) => {
+              reject(e)
+            })
+            .end()
+        } catch (e) {
+          reject(e)
+        }
       })
     })
   })

--- a/src/js/services/BoomClient/client/Packets.js
+++ b/src/js/services/BoomClient/client/Packets.js
@@ -21,12 +21,13 @@ export default class Packets extends SubClient {
       const dest = `${args.destDir}/packets-${args.ts_sec +
         args.ts_ns / 1e9}.pcap`
       const method = "GET"
-      const path = `/space/${args.space}/packet?${params.toString()}`
+      const path = `/space/${encodeURIComponent(
+        args.space
+      )}/packet?${params.toString()}`
 
       const {host, port, ...rest} = this.base.options
 
       if (!host || !port) throw "Missing host/port"
-
       return download({...rest, host, port, path, method}, dest)
     } catch (e) {
       return Promise.reject(e)


### PR DESCRIPTION
First I caught an exception that was not being handled so that if an error occurs in the same place, it will at least be shown in the UI.


<img width="400" alt="Screen Shot 2020-03-31 at 2 21 05 PM" src="https://user-images.githubusercontent.com/3460638/78076666-b854ba00-735b-11ea-8db2-ebf5c637df2e.png">


Then I fixed the error that was throwing that exception. It turns out that the node http module does not encode the URI components that we pass to it. This must be done ourselves. By contrast, the browser fetch API encodes for us.

![MnXYnNMfYV](https://user-images.githubusercontent.com/3460638/78077010-66606400-735c-11ea-8156-c93840b88152.gif)

**SIDE DISCOVERY**

I also discovered some code on stack overflow that will allow us to use the browser fetch API and stream the response to the node fs module which writes to the file system. When we implement the packet download api call in zealot, I recommend doing this. 

https://stackoverflow.com/a/44695617/3499804