### PR TITLE
PROD-1638 Never activate a tab that does not exist

### DIFF
--- a/src/js/state/Tabs/reducer.js
+++ b/src/js/state/Tabs/reducer.js
@@ -19,9 +19,13 @@ export default function reducer(state: TabsState = init, action: TabActions) {
 
   switch (action.type) {
     case "TABS_ACTIVATE":
-      return {
-        ...state,
-        active: action.id
+      if (state.data.map((t) => t.id).includes(action.id))
+        return {
+          ...state,
+          active: action.id
+        }
+      else {
+        return state
       }
     case "TABS_REMOVE":
       if (state.data.length === 1) return state

--- a/src/js/state/Tabs/selectors.js
+++ b/src/js/state/Tabs/selectors.js
@@ -13,7 +13,7 @@ const getActiveTab = createSelector<State, void, TabState, TabsState>(
   (state) => state.tabs,
   (tabs) => {
     let tab = tabs.data.find((t) => t.id === tabs.active)
-    if (!tab) throw "Can't find active tab"
+    if (!tab) throw new Error("Can't find active tab")
     return tab
   }
 )

--- a/src/js/state/Tabs/test.js
+++ b/src/js/state/Tabs/test.js
@@ -26,6 +26,16 @@ test("add tab with data and activate", () => {
   expect(tab.search.spanArgs).toEqual(["now", "now-1m"])
 })
 
+test("cannot activate tab that does not exist in data", () => {
+  let state = store.dispatchAll([
+    Tabs.add("1"),
+    Tabs.activate("1"),
+    Tabs.activate("does-not-exist")
+  ])
+  let tab = Tabs.getActiveTab(state)
+  expect(tab.id).toBe("1")
+})
+
 test("remove tab", () => {
   let state = store.dispatchAll([Tabs.add("1"), Tabs.remove("1")])
   expect(Tabs.getCount(state)).toBe(1)


### PR DESCRIPTION
The first fix is to throw a `new Error()` rather than a `"string"` so that the error page gets populated.

<img width="1112" alt="Screen Shot 2020-03-31 at 4 22 04 PM" src="https://user-images.githubusercontent.com/3460638/78084199-68caba00-736c-11ea-8788-11321b7756be.png">

The second fix is to make sure that you can never activate a tab that has been deleted. I added some console logs to debug this and found that every now and then, the timing of the dispatch calls led to "DELETE tab x" followed by an "ACTIVATE tab x".

You can now bang away at activating and removing tabs and you'll never hit this error.
