### PR TITLE
Use zqd waterfall logger

### DIFF
--- a/src/js/zqd/zqd.js
+++ b/src/js/zqd/zqd.js
@@ -33,14 +33,15 @@ function writeZqdConfigFile(): string {
   const accessLogFile = join(logDir, "zqd-access.log")
 
   const data = `
-loggers:
-  - name: zqd
-    level: info
-    path: ${zqdLogFile}
-    mode: rotate
+logger:
+  type: waterfall
+  children:
   - name: http.access
     level: info
     path: ${accessLogFile}
+    mode: rotate
+  - level: info
+    path: ${zqdLogFile}
     mode: rotate
 `
 


### PR DESCRIPTION
Change logging config to use the waterfall logger added to zqd in
brimsec/zq#492. Logs named http.access will be logged in zqd-access.log,
every other log will go to zqd-core.log.