### PR TITLE
Windows installer signing

### DIFF
--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -25,7 +25,19 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
     - run: npm install --no-audit
     - run: npm run build
-    - run: node .\scripts\release --win32
+    - name: Build Signed Release
+      shell: bash
+      run: |
+        f=$(mktemp)
+        echo -ne "${WIN32_SIGNING_PFX_BASE64}" > "${f}"
+        CERT=$(mktemp)
+        # We just need the name; certutil complains if the dest exists.
+        rm -f "${CERT}"
+        certutil -decode "${f}" "${CERT}"
+        node ./scripts/release --win32 --win32CertificateFile "${CERT}" --win32CertificatePassword "${WIN32_SIGNING_PASSPHRASE}"
+      env:
+        WIN32_SIGNING_PASSPHRASE: ${{ secrets.WIN32_SIGNING_PASSPHRASE }}
+        WIN32_SIGNING_PFX_BASE64: ${{ secrets.WIN32_SIGNING_PFX_BASE64 }}
     - name: upload release assets
       uses: svenstaro/upload-release-action@1.1.0
       with:

--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -1,9 +1,6 @@
 name: Brim Windows release
 
-on:
-  push:
-    tags:
-      - v*
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -1,6 +1,9 @@
 name: Brim Windows release
 
-on: [push]
+on:
+  push:
+    tags:
+      - v*
 
 jobs:
   build:

--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -26,15 +26,15 @@ jobs:
       shell: bash
       run: |
         f=$(mktemp)
-        echo -ne "${WIN32_SIGNING_PFX_BASE64}" > "${f}"
+        echo -ne "${WINDOWS_SIGNING_PFX_BASE64}" > "${f}"
         CERT=$(mktemp)
         # We just need the name; certutil complains if the dest exists.
         rm -f "${CERT}"
         certutil -decode "${f}" "${CERT}"
-        node ./scripts/release --win32 --win32CertificateFile "${CERT}" --win32CertificatePassword "${WIN32_SIGNING_PASSPHRASE}"
+        node ./scripts/release --win32 --windowsCertificateFile "${CERT}" --windowsCertificatePassword "${WINDOWS_SIGNING_PASSPHRASE}"
       env:
-        WIN32_SIGNING_PASSPHRASE: ${{ secrets.WIN32_SIGNING_PASSPHRASE }}
-        WIN32_SIGNING_PFX_BASE64: ${{ secrets.WIN32_SIGNING_PFX_BASE64 }}
+        WINDOWS_SIGNING_PASSPHRASE: ${{ secrets.WINDOWS_SIGNING_PASSPHRASE }}
+        WINDOWS_SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_SIGNING_PFX_BASE64 }}
     - name: upload release assets
       uses: svenstaro/upload-release-action@1.1.0
       with:

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -10,14 +10,13 @@ but the best we could do in our first attempt uses 32-bit
 [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
 
 2. We sign the Windows installer we create with every new Brim release;
-   however, you may still see a Microsoft Defender SmartScreen popup when you
-run the installer. This is because Brim, and the signing certificate we use,
-are both new, and Defender considers number of application installs and
-certificate uses when determining whether or not to display the SmartScreen
-popup. Once we have enough Brim Windows installations, Defender should stop
-doing this.  We do recommend that you click on the "More Info" link in the
-SmartScreen popup and verify that the installer is signed by `Brim Security,
-Inc.`.
+however, you may still see a Microsoft Defender SmartScreen popup when you run
+the installer. This is because Brim, and the signing certificate we use, are
+both new, and Defender considers number of application installs and certificate
+uses when determining whether or not to display the SmartScreen popup. Once we
+have enough Brim Windows installations, Defender should stop doing this.  We do
+recommend that you click on the "More Info" link in the SmartScreen popup and
+verify that the installer is signed by `Brim Security, Inc.`.
 
 We recommend this blog post if you'd like more info on Windows code signing:
 https://www.digicert.com/blog/ms-smartscreen-application-reputation/

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -8,11 +8,16 @@ is related to the lack of formal support for Zeek on Windows. We got it
 working with [our own Zeek port](https://github.com/brimsec/zeek/tree/master/brim/windows),
 but the best we could do in our first attempt uses 32-bit
 [Cygwin](https://www.cygwin.com/). We'll be working to improve this over time.
-2. We don't yet have the necessary Windows certifications in place to "sign"
-the release (like we do for macOS) and hence provide a warning-free
-install experience. Your anti-virus software is likely to jump in with "Are
-you sure you want to run this?" warnings and scans for viruses. Rest assured
-that we've not put viruses in our code, but we understand if you're concerned
-about installing under such conditions. You may want to install on a scratch
-Windows VM if that feels safer, or watch the repo to be notified when we've
-secured the certifications in an upcoming release.
+
+2. We sign the Windows installer we create with every new Brim release;
+   however, you may still see a Microsoft Defender SmartScreen popup when you
+run the installer. This is because Brim, and the signing certificate we use,
+are both new, and Defender considers number of application installs and
+certificate uses when determining whether or not to display the SmartScreen
+popup. Once we have enough Brim Windows installations, Defender should stop
+doing this.  We do recommend that you click on the "More Info" link in the
+SmartScreen popup and verify that the installer is signed by `Brim Security,
+Inc.`.
+
+We recommend this blog post if you'd like more info on Windows code signing:
+https://www.digicert.com/blog/ms-smartscreen-application-reputation/

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -10,8 +10,8 @@ program
   .option("--darwin", "Release for macOS")
   .option("--sign", "Sign package (macOS only)", false)
   .option("--notarize", "Notarize package (macOS only)", false)
-  .option("--win32CertificateFile <win32CertificateFile>", "PFX signing cert (win32 only)", false)
-  .option("--win32CertificatePassword <win32CertificatePassword>", "PFX password (win32 only)", false)
+  .option("--windowsCertificateFile <windowsCertificateFile>", "PFX signing cert (win32 only)", false)
+  .option("--windowsCertificatePassword <windowsCertificatePassword>", "PFX password (win32 only)", false)
   .action(function(cmd) {
       if (cmd.darwin) {
           let p = pack.darwin(cmd.sign || cmd.notarize)
@@ -25,8 +25,8 @@ program
       }
     if (cmd.win32) pack.win32().then(
         () => install.win32({
-            certificateFile: cmd.win32CertificateFile,
-            certificatePassword: cmd.win32CertificatePassword
+            certificateFile: cmd.windowsCertificateFile,
+            certificatePassword: cmd.windowsCertificatePassword
         }))
   })
   .parse(process.argv)

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -10,6 +10,8 @@ program
   .option("--darwin", "Release for macOS")
   .option("--sign", "Sign package (macOS only)", false)
   .option("--notarize", "Notarize package (macOS only)", false)
+  .option("--win32CertificateFile <win32CertificateFile>", "PFX signing cert (win32 only)", false)
+  .option("--win32CertificatePassword <win32CertificatePassword>", "PFX password (win32 only)", false)
   .action(function(cmd) {
       if (cmd.darwin) {
           let p = pack.darwin(cmd.sign || cmd.notarize)
@@ -21,6 +23,10 @@ program
           }))
           p.then(() => install.darwin())
       }
-    if (cmd.win32) pack.win32().then(() => install.win32())
+    if (cmd.win32) pack.win32().then(
+        () => install.win32({
+            certificateFile: cmd.win32CertificateFile,
+            certificatePassword: cmd.win32CertificatePassword
+        }))
   })
   .parse(process.argv)

--- a/scripts/release/install.js
+++ b/scripts/release/install.js
@@ -41,11 +41,12 @@ module.exports = {
     )
   },
 
-  win32: function() {
+  win32: function(opts) {
     console.log("Building installer for win32")
     fixWindowsInstallerDeps()
     return installer
       .createWindowsInstaller({
+        ...opts,
         appDirectory: "./dist/packages/Brim-Win32-x64",
         outputDirectory: out,
         authors: "Brim Security, Inc.",
@@ -56,8 +57,10 @@ module.exports = {
       .then(() => {
         console.log("Built installer for win32 in " + out)
       })
-      .catch((e) => {
-        console.log("Error building win32 installer: " + e.message)
+      .catch(() => {
+        // Exception caught above is not printed below, as a bubbling
+        // up exception may contain a passphrase.
+        console.log("Error building win32 installer")
       })
   }
 }


### PR DESCRIPTION
Assuming a PFX base64-encoded password-protected certificate secret pair, sign a Windows installer release asset.

Usage is: `node scripts/release --win32 [--windowsCertificateFile <file> --windowsCertificatePassword <password>]`

The stack for signing is as follows, and you can read more about the stack at the links provided.

- `scripts/release`
  -  [electron/windows-installer](https://github.com/electron/windows-installer)
     - [Squirrel](https://github.com/Squirrel/Squirrel.Windows)
        - [signtool](https://docs.microsoft.com/en-us/windows/win32/seccrypto/signtool)

The basic electron-winstaller method of signing requires file and password parameters. I've taken care to ensure the password is not printed upon either success or failure.

The release CI will produced a signed executable. Interested parties may view certificate details when examining the signed executable's properties.

![image](https://user-images.githubusercontent.com/16110130/78398893-c1869680-75a8-11ea-8765-e4c84c0c84e7.png)