### PR TITLE
PROD-1538 use arrow keys to select logs

### DIFF
--- a/src/js/components/useSearchShortcuts.js
+++ b/src/js/components/useSearchShortcuts.js
@@ -5,10 +5,13 @@ import {useEffect} from "react"
 import Mousetrap from "mousetrap"
 
 import Tabs from "../state/Tabs"
+import {adjustSelectedLogIndex} from "../flows/adjustSelectedLogIndex"
 
 export default function() {
   let dispatch = useDispatch()
   useEffect(() => {
+    Mousetrap.bind("down", () => dispatch(adjustSelectedLogIndex(1)))
+    Mousetrap.bind("up", () => dispatch(adjustSelectedLogIndex(-1)))
     Mousetrap.bind("mod+t", () => dispatch(Tabs.new()))
     Mousetrap.bind("mod+w", () => dispatch(Tabs.closeActive()))
     Mousetrap.bind("ctrl+tab", () => dispatch(Tabs.activateNext()))

--- a/src/js/components/useSearchShortcuts.js
+++ b/src/js/components/useSearchShortcuts.js
@@ -10,8 +10,14 @@ import {adjustSelectedLogIndex} from "../flows/adjustSelectedLogIndex"
 export default function() {
   let dispatch = useDispatch()
   useEffect(() => {
-    Mousetrap.bind("down", () => dispatch(adjustSelectedLogIndex(1)))
-    Mousetrap.bind("up", () => dispatch(adjustSelectedLogIndex(-1)))
+    Mousetrap.bind("down", (e) => {
+      e.preventDefault()
+      dispatch(adjustSelectedLogIndex(1))
+    })
+    Mousetrap.bind("up", (e) => {
+      e.preventDefault()
+      dispatch(adjustSelectedLogIndex(-1))
+    })
     Mousetrap.bind("mod+t", () => dispatch(Tabs.new()))
     Mousetrap.bind("mod+w", () => dispatch(Tabs.closeActive()))
     Mousetrap.bind("ctrl+tab", () => dispatch(Tabs.activateNext()))

--- a/src/js/flows/adjustSelectedLogIndex.js
+++ b/src/js/flows/adjustSelectedLogIndex.js
@@ -1,0 +1,27 @@
+/* @flow */
+import type {Thunk} from "../state/types"
+import Log from "../models/Log"
+import LogDetails from "../state/LogDetails"
+import Viewer from "../state/Viewer"
+import {viewLogDetail} from "./viewLogDetail"
+
+export const adjustSelectedLogIndex = (indexDelta: number): Thunk => (
+  dispatch,
+  getState
+) => {
+  const state = getState()
+
+  const currentLog = LogDetails.build(state)
+  if (!currentLog) return null
+
+  const viewerLogs = Viewer.getLogs(state)
+  const currentLogNdx = viewerLogs.findIndex((viewerLog) =>
+    Log.isSame(viewerLog, currentLog)
+  )
+  if (currentLogNdx === -1) return null
+
+  const newNdx = currentLogNdx + indexDelta
+  if (newNdx < 0 || newNdx > viewerLogs.length - 1) return null
+
+  dispatch(viewLogDetail(viewerLogs[newNdx]))
+}


### PR DESCRIPTION
Can use arrow keys to select logs from viewer if one has already been selected (and is currently in the search results).

**Note**: While playing around with this I discovered that the existing arrow behavior for scrolling has a bug where it will begin to scroll but then breaks, so this feature also acts as a bit of a bandaid for that since will now preventDafault() on either event. Ideally, IMO, we should track if the currently selected log is not only among the current search results, but is also within the current results view, and if it is not then we will adjust the scroll view to be in sight of it. Then if no result is selected then the up/down arrows will scroll the viewer properly (this is the part that is broken atm), though it looks like there is also some existing functionality in the search input box where that will go through search history (similar to the behavior of some terminals).

![updownselect](https://user-images.githubusercontent.com/14865533/78403501-4ecde900-75b1-11ea-8fb4-69ab5ec2eac7.gif)
