### PR TITLE
test improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,16 +63,20 @@ jobs:
         hdiutil attach dist/installers/Brim.dmg
         cp -R /Volumes/Brim/Brim.app /Applications
         hdiutil detach /Volumes/Brim
-    - name: Integration Tests
-      uses: GabrielBB/xvfb-action@v1.0
-      with:
-        run: npm run itest -- --ci --forceExit
+    - name: Integration Tests (Linux)
+      if: runner.os == 'Linux'
+      run: xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" npm run itest -- --ci --forceExit
       env:
         # WORKSPACE represents a top-level place for test infra code to
         # find and put things. That avoids proliferation of env
         # variables of directories. It's used to dump logs into the
         # correct place so that CI can reliably find them for
         # collection.
+        WORKSPACE: /var/tmp/brimsec
+    - name: Integration Tests (non-Linux)
+      if: runner.os != 'Linux'
+      run: npm run itest -- --ci --forceExit
+      env:
         WORKSPACE: /var/tmp/brimsec
     - uses: actions/upload-artifact@v1
       if: failure()

--- a/itest/tests/externalApis.test.js
+++ b/itest/tests/externalApis.test.js
@@ -3,9 +3,12 @@ import http from "http"
 import https from "https"
 
 import {retry} from "../lib/control"
+import {TestTimeout} from "../lib/jest"
 import ZeekLogDescriptions from "../../src/js/services/zeekLogDescriptions"
 import brim from "../../src/js/brim"
 import virusTotal from "../../src/js/services/virusTotal"
+
+jest.setTimeout(TestTimeout)
 
 test("ping virus total for a success", () => {
   let value = "80.239.217.49"
@@ -40,6 +43,7 @@ describe("doc urls", () => {
     .map(stripSuffix)
     .map(buildUrl)
     .forEach(([path, url]) => {
-      test(`doc url responds 200 for ${path}`, () => request(path, url))
+      test(`doc url responds 200 for ${path}`, () =>
+        retry(() => request(path, url), 5))
     })
 })


### PR DESCRIPTION
- ci: control xvfb where needed
  The screen size provided by xvfb-action isn't adequate for our tests. This sets the screen size for when we need XVFB. The tradeoff is a YAML "fork" depending on OS. It's likely that down the road OS-wise integration tests will vary anyway, so I think some sort of fork is going to happen sooner or later. It is a reasonable tradeoff.
- test fix: deflake external API tests
  - Ensure jest won't time out a test.
  - Use retry() for the zeek.org tests.