### PR TITLE
Check the version of the state object

### DIFF
--- a/src/js/initializers/index.js
+++ b/src/js/initializers/index.js
@@ -2,6 +2,7 @@
 
 import {ipcRenderer} from "electron"
 
+import {isCurrentVersion} from "./initPersistance"
 import closeWindow from "../flows/closeWindow"
 import initBoom from "./initBoom"
 import initDOM from "./initDOM"
@@ -20,10 +21,15 @@ export default () => {
   return Promise.all([
     invoke(ipc.windows.initialState(id)),
     initGlobalStore()
-  ]).then(([initialState, globalStore]) => {
+  ]).then(([prevState, globalStore]) => {
+    let windowState = isCurrentVersion(prevState) ? prevState : undefined
+    let globalState = globalStore.getState()
+    let initState = {...windowState, ...globalState}
+
     let boom = initBoom(undefined)
-    let store = initStore({...initialState, ...globalStore.getState()}, boom)
+    let store = initStore(initState, boom)
     let dispatch = store.dispatch
+
     initDOM()
     initShortcuts(store)
     initMenuActionListeners(dispatch)

--- a/src/js/initializers/initPersistance.js
+++ b/src/js/initializers/initPersistance.js
@@ -5,7 +5,12 @@ import throttle from "lodash/throttle"
 
 import type {State} from "../state/types"
 
-export const VERSION = "5"
+export const VERSION = "6"
+
+export function isCurrentVersion(state: *) {
+  return state && state.version === VERSION
+}
+
 const KEY = "BRIM_STATE"
 const PERSIST = [
   "tabs",

--- a/src/js/state/createGlobalStore.js
+++ b/src/js/state/createGlobalStore.js
@@ -1,9 +1,12 @@
 /* @flow */
 import {createStore} from "redux"
 
+import {isCurrentVersion} from "../initializers/initPersistance"
 import globalReducer, {type GlobalState} from "./globalReducer"
 
-export default function(initialState: GlobalState | void) {
+export default function(prevState: GlobalState | void) {
+  let initState = isCurrentVersion(prevState) ? prevState : undefined
+
   // $FlowFixMe
-  return createStore(globalReducer, initialState)
+  return createStore(globalReducer, initState)
 }

--- a/src/js/state/globalReducer.js
+++ b/src/js/state/globalReducer.js
@@ -9,7 +9,8 @@ import Spaces from "./Spaces"
 
 export type GlobalState = {
   investigation: InvestigationState,
-  spaces: SpacesState
+  spaces: SpacesState,
+  version: string
 }
 
 export default combineReducers<*, *>({


### PR DESCRIPTION
Drop the previously saved state if the version is different
This is a crude way to handle state migrations. I'd like to
think this through more, but at least there are no startup
errors when you upgrade versions now.

Going forward, we'll need to increment this VERSION string each time we mess with the shape of the state. 

I think it would be good to write a test that does some of the common operations on the redux store, the saves the resulting state in a snapshot. Then each time we make changes to the state shape, hopefully that test will fail with a message like "update the state version".

Depending on how critical it is for users to save state, like their history and in the future, their saved queries. We may want to write more code to migrate data and what not.

fixes #584 