### PR TITLE
Use troubleshooting URL in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-Please make sure you've reviewed the [troubleshooting guide](/TROUBLESHOOTING.md)
-before opening a new issue. Thanks!
+Before opening a new issue, please make sure you've reviewed the troubleshooting guide:
+https://github.com/brimsec/brim/blob/master/TROUBLESHOOTING.md
 
 **Describe the bug**
 [A description of what the bug is]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-Please make sure you've reviewed the [troubleshooting guide](/TROUBLESHOOTING.md) 
-before opening a new issue. Thanks!
+Before opening a new issue, please make sure you've reviewed the troubleshooting guide:
+https://github.com/brimsec/brim/blob/master/TROUBLESHOOTING.md
 
 **Is your feature request related to a problem? Please describe.**
 [For example: "I'm always frustrated when..."]


### PR DESCRIPTION
After seeing how the templates actually looked when opening a new issue, I realized it was a mistake to use markdown notation to point at the troubleshooting doc. The user first sees the template as raw text, not rendered markdown. Therefore it seems more user-friendly to offer them a full URL they could easily cut & paste into a browser window.