### PR TITLE
ci: improve npm caching (fixes #589)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       id: set-npm-cache-dir
       run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
     - name: Clear Extraneous Runner Cache
+      # The macos Github runner has 1G of NPM cache that we don't need.
+      # Clear it before we create our own cache to prevent slower build
+      # times. See https://github.com/brimsec/brim/pull/590
       run: |
           cachedir=${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
           rm -rf "${cachedir:?}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,20 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Set NPM Cache Directory
+      id: set-npm-cache-dir
+      run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
+    - name: Clear Extraneous Runner Cache
+      run: |
+          cachedir=${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
+          rm -rf "${cachedir:?}"
+      shell: bash
     - name: Cache node modules
       uses: actions/cache@v1
       env:
-        cache-name: cache-node-modules
+        cache-name: cache-node-modules3
       with:
-        path: ~/.npm
+        path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
@@ -44,12 +52,20 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Set NPM Cache Directory
+      id: set-npm-cache-dir
+      run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
+    - name: Clear Extraneous Runner Cache
+      run: |
+          cachedir=${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
+          rm -rf "${cachedir:?}"
+      shell: bash
     - name: Cache node modules
       uses: actions/cache@v1
       env:
-        cache-name: cache-node-modules
+        cache-name: cache-node-modules3
       with:
-        path: ~/.npm
+        path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -14,12 +14,20 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+    - name: Set NPM Cache Directory
+      id: set-npm-cache-dir
+      run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
+    - name: Clear Extraneous Runner Cache
+      run: |
+          cachedir=${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
+          rm -rf "${cachedir:?}"
+      shell: bash
     - name: Cache node modules
       uses: actions/cache@v1
       env:
-        cache-name: cache-node-modules
+        cache-name: cache-node-modules3
       with:
-        path: ~/.npm
+        path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-

--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -14,12 +14,20 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+    - name: Set NPM Cache Directory
+      id: set-npm-cache-dir
+      run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
+    - name: Clear Extraneous Runner Cache
+      run: |
+          cachedir=${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
+          rm -rf "${cachedir:?}"
+      shell: bash
     - name: Cache node modules
       uses: actions/cache@v1
       env:
-        cache-name: cache-node-modules
+        cache-name: cache-node-modules3
       with:
-        path: ~/.npm
+        path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-


### PR DESCRIPTION
- Use `npm config get cache` to derive the npm cache directory and use it in the cache step. This fixes the cache misses on Windows.
- Clear the 1G of cache that is on the base macOS runner. Note that `npm cache clear --force` was only able to clear about 250M, so the more direct `rm -rf` approach was needed. This reduces the macOS cache  to about 78M, inline with Windows and Linux cache sizes.
- Change the cache name to prevent reuse of bad caches.

`npm install --no-audit` is still slower on macOS than other platforms, but the massive cache store/recall on mac goes away. It's difficult to compare cloud CI build times, but rough timing comparisons suggest this will generally speed up CI from ~30 to ~10 minutes during PDT mornings.

master: https://github.com/brimsec/brim/actions/runs/74573741
branch: https://github.com/brimsec/brim/actions/runs/74665070