### PR TITLE
test feat: screen shots on failure

### DIFF
--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -1,8 +1,12 @@
 /* @flow */
-import {Application} from "spectron"
+
+import {writeFileSync} from "fs"
+import crypto from "crypto"
 import path from "path"
 
-import {LOG} from "./log"
+import {Application} from "spectron"
+
+import {LOG, LOGDIR} from "./log"
 import {isCI, repoDir} from "../lib/env"
 import {retryUntil} from "./control"
 import {selectors} from "../../src/js/test/integration"
@@ -315,4 +319,18 @@ export const pcapIngestSample = async (app: Application) => {
       (ingesting) => ingesting === false
     )
   )
+}
+
+export const takeScreenshot = async (app: Application) => {
+  try {
+    let image = await app.browserWindow.capturePage()
+    let filePath = path.join(
+      LOGDIR,
+      "failure-" + crypto.randomBytes(4).toString("hex") + ".png"
+    )
+    writeFileSync(filePath, image)
+    LOG.info(`wrote out screen shot to "${filePath}"`)
+  } catch (e) {
+    LOG.error("unable to take screen shot: " + e)
+  }
 }

--- a/itest/lib/jest.js
+++ b/itest/lib/jest.js
@@ -1,13 +1,10 @@
 /* @flow */
 
-import {writeFileSync} from "fs"
-import crypto from "crypto"
-import path from "path"
-
 import {Application} from "spectron"
 
+import {takeScreenshot} from "./app"
 import {selectors} from "../../src/js/test/integration"
-import {LOG, LOGDIR} from "./log"
+import {LOG} from "./log"
 
 export const TestTimeout = 300000
 // https://jestjs.io/docs/en/troubleshooting#unresolved-promises
@@ -19,17 +16,7 @@ export const handleError = async (
   initialError: Error,
   done: *
 ) => {
-  try {
-    let image = await app.browserWindow.capturePage()
-    let filePath = path.join(
-      LOGDIR,
-      "failure-" + crypto.randomBytes(4).toString("hex") + ".png"
-    )
-    writeFileSync(filePath, image)
-    LOG.info(`wrote out screen shot to "${filePath}"`)
-  } catch (e) {
-    LOG.error("unable to take screen shot: " + e)
-  }
+  takeScreenshot(app)
   let realError = undefined
   let notificationError = undefined
   LOG.error(`handleError: Test hit exception: ${initialError.message}`)

--- a/itest/lib/jest.js
+++ b/itest/lib/jest.js
@@ -1,9 +1,13 @@
 /* @flow */
 
+import {writeFileSync} from "fs"
+import crypto from "crypto"
+import path from "path"
+
 import {Application} from "spectron"
 
 import {selectors} from "../../src/js/test/integration"
-import {LOG} from "./log"
+import {LOG, LOGDIR} from "./log"
 
 export const TestTimeout = 300000
 // https://jestjs.io/docs/en/troubleshooting#unresolved-promises
@@ -15,6 +19,17 @@ export const handleError = async (
   initialError: Error,
   done: *
 ) => {
+  try {
+    let image = await app.browserWindow.capturePage()
+    let filePath = path.join(
+      LOGDIR,
+      "failure-" + crypto.randomBytes(4).toString("hex") + ".png"
+    )
+    writeFileSync(filePath, image)
+    LOG.info(`wrote out screen shot to "${filePath}"`)
+  } catch (e) {
+    LOG.error("unable to take screen shot: " + e)
+  }
   let realError = undefined
   let notificationError = undefined
   LOG.error(`handleError: Test hit exception: ${initialError.message}`)

--- a/itest/lib/log.js
+++ b/itest/lib/log.js
@@ -2,7 +2,7 @@
 const path = require("path")
 const {createLogger, format, transports} = require("winston")
 
-const LOGDIR = path.join(process.env.WORKSPACE || "", "logs")
+export const LOGDIR = path.join(process.env.WORKSPACE || "", "logs")
 
 export const workspaceLogfile = (name: string) => path.join(LOGDIR, name)
 


### PR DESCRIPTION
If an integration test fails, the cleanup handler will now dump a screen shot into the same directory that log artifacts are stored.

I peeled off this work while debugging CI failures for a different branch. You can inspect artifacts at https://github.com/brimsec/brim/suites/589149338/artifacts/4195825