### PR TITLE
Mention zq update to v0.9.0 in changelog for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v0.6.0
 
+* Update zq to v0.9.0 (#551)
 * Add auto-update for MacOS (#515)
 * Fix error message presentation via content-type inspection (#519)
 * Add menu options for **Help > About** and **File > Settings** in Windows (#521)


### PR DESCRIPTION
Since I was updating the `zq` pointer at the same time I was creating the changelog for Brim `v0.6.0`, I'd forgotten to mention it in the changelog. I've already updated it in the ["live" release notes](https://github.com/brimsec/brim/releases/tag/v0.6.0), but circling back to take care of it here as well.