### PR TITLE
Do not mutate the window state object

### DIFF
--- a/src/js/flows/saveWindowState.js
+++ b/src/js/flows/saveWindowState.js
@@ -6,13 +6,13 @@ import rpc from "../electron/rpc"
 
 export default (): Thunk => (_, getState) => {
   rpc.log("Saving window state")
-  let state = getState()
+  let state = {...getState()}
   // remove state pieces which we are not interested in persisting
   delete state.errors
   delete state.notice
   delete state.handlers
 
   return ipcRenderer
-    .invoke("windows:saveState", global.windowId, global.getState())
+    .invoke("windows:saveState", global.windowId, getState())
     .then(() => rpc.log("Window state saved"))
 }

--- a/src/js/flows/saveWindowState.test.js
+++ b/src/js/flows/saveWindowState.test.js
@@ -1,0 +1,12 @@
+/* @flow */
+import initTestStore from "../test/initTestStore"
+import saveWindowState from "./saveWindowState"
+
+test("does not mutate state", () => {
+  let store = initTestStore()
+  let prevState = {...store.getState()}
+
+  store.dispatch(saveWindowState())
+
+  expect(store.getState()).toEqual(prevState)
+})


### PR DESCRIPTION
Fixes #600 

This caused a strange bug where `state.handlers` was undefined. Then the app tried to do something with it, and it threw an error. I traced it back to this state mutation.

It's now locked in with a unit test