### PR TITLE
Fix results assumptions

### DIFF
--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -316,14 +316,14 @@ export const pcapIngestSample = async (app: Application) => {
     app.client.chooseFile(selectors.pcaps.fileInput, pcapFile)
   )
 
-  await waitForResults(app)
-
   await appStep("wait for ingest to finish", () =>
     retryUntil(
       () => app.client.isExisting(selectors.status.ingestProgress),
       (ingesting) => ingesting === false
     )
   )
+
+  await waitForResults(app)
 }
 
 export const takeScreenshot = async (app: Application) => {

--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -300,6 +300,11 @@ export const toggleOptimizations = async (app: Application) => {
   await app.client.click(selectors.settings.button)
 }
 
+export const waitForResults = (app: Application) =>
+  appStep("wait for results viewer to appear", () =>
+    app.client.waitForVisible(selectors.viewer.results_base)
+  )
+
 export const pcapIngestSample = async (app: Application) => {
   // Ingest a PCAP and wait until we see derived records.
   const pcapFile = path.normalize(path.join(__dirname, "..", "sample.pcap"))
@@ -310,9 +315,9 @@ export const pcapIngestSample = async (app: Application) => {
   await appStep("choose file", () =>
     app.client.chooseFile(selectors.pcaps.fileInput, pcapFile)
   )
-  await appStep("wait for viewer to appear", () =>
-    app.client.waitForVisible(selectors.viewer.results_base)
-  )
+
+  await waitForResults(app)
+
   await appStep("wait for ingest to finish", () =>
     retryUntil(
       () => app.client.isExisting(selectors.status.ingestProgress),

--- a/itest/lib/data.js
+++ b/itest/lib/data.js
@@ -7,7 +7,6 @@ export const dataSets = {
   // last 30 minutes to last hour, some of these numbers may become invalid.
   sample: {
     histogram: {
-      defaultDistinctPaths: 8,
       defaultRectsPerClass: 11,
       defaultTotalRectCount: 8 * 11,
       rectAttrMin: 0,

--- a/itest/lib/data.js
+++ b/itest/lib/data.js
@@ -7,7 +7,6 @@ export const dataSets = {
   // last 30 minutes to last hour, some of these numbers may become invalid.
   sample: {
     histogram: {
-      defaultTotalRectCount: 8 * 11,
       rectAttrMin: 0,
       rectAttrMax: 1000,
       wholeSpaceDistinctPaths: 8,

--- a/itest/lib/data.js
+++ b/itest/lib/data.js
@@ -7,11 +7,11 @@ export const dataSets = {
   // last 30 minutes to last hour, some of these numbers may become invalid.
   sample: {
     histogram: {
-      defaultRectsPerClass: 11,
       defaultTotalRectCount: 8 * 11,
       rectAttrMin: 0,
       rectAttrMax: 1000,
-      wholeSpaceDistinctPaths: 8
+      wholeSpaceDistinctPaths: 8,
+      wholeSpaceRectsPerClass: 11
     },
     spaceName: "sample.pcap.brim"
   }

--- a/itest/tests/histogram.test.js
+++ b/itest/tests/histogram.test.js
@@ -66,7 +66,9 @@ describe("Histogram tests", () => {
     LOG.debug("Pre-login")
     pcapIngestSample(app)
       .then(async () => {
-        LOG.debug("Checking number of histogram rect elements")
+        LOG.debug("Checking a histogram appears")
+        // Verify that a histogram of at least *partial data* is
+        // present.
         await retryUntil(
           () => app.client.$$(selectors.histogram.rectElem),
           (rectElements) => rectElements.length > 0

--- a/itest/tests/histogram.test.js
+++ b/itest/tests/histogram.test.js
@@ -68,13 +68,9 @@ describe("Histogram tests", () => {
         LOG.debug("Checking number of histogram rect elements")
         await retryUntil(
           () => app.client.$$(selectors.histogram.rectElem),
-          (rectElements) =>
-            rectElements.length ===
-            dataSets.sample.histogram.defaultTotalRectCount
+          (rectElements) => rectElements.length > 0
         ).catch(() => {
-          throw new Error(
-            "Histogram did not render the expected number of rect elements"
-          )
+          throw new Error("Initial histogram did not render any rect elements")
         })
         LOG.debug("Got number of histogram rect elements")
         // Assuming we properly loaded data into a default space, we

--- a/itest/tests/histogram.test.js
+++ b/itest/tests/histogram.test.js
@@ -117,7 +117,7 @@ describe("Histogram tests", () => {
           expect(pathClass.length).toBe(4)
           pathClass.forEach((attr) => {
             expect(attr.length).toBe(
-              dataSets.sample.histogram.defaultRectsPerClass
+              dataSets.sample.histogram.wholeSpaceRectsPerClass
             )
           })
         })

--- a/itest/tests/histogram.test.js
+++ b/itest/tests/histogram.test.js
@@ -66,7 +66,7 @@ describe("Histogram tests", () => {
     pcapIngestSample(app)
       .then(async () => {
         LOG.debug("Checking number of histogram rect elements")
-        let result = await retryUntil(
+        await retryUntil(
           () => app.client.$$(selectors.histogram.rectElem),
           (rectElements) =>
             rectElements.length ===
@@ -77,9 +77,6 @@ describe("Histogram tests", () => {
           )
         })
         LOG.debug("Got number of histogram rect elements")
-        return result
-      })
-      .then(async () => {
         // Assuming we properly loaded data into a default space, we
         // we must wait until the components of the histogram are rendered. This
         // means we must wait for a number of g elements and rect elements. Those

--- a/itest/tests/histogram.test.js
+++ b/itest/tests/histogram.test.js
@@ -77,12 +77,15 @@ describe("Histogram tests", () => {
         // we must wait until the components of the histogram are rendered. This
         // means we must wait for a number of g elements and rect elements. Those
         // elements depend on both the dataset itself and the product's behavior.
-        LOG.debug("Getting number of distinct _paths")
+        // Set to "Whole Space" to make sure this entire histogram is redrawn.
+        await setSpan(app, "Whole Space")
+        // Just count a higher number of _paths, not all ~1500 rect elements.
+        LOG.debug("Checking rect elements in Whole Space")
         let pathClasses = await retryUntil(
           () => app.client.getAttribute(selectors.histogram.gElem, "class"),
           (pathClasses) =>
             pathClasses.length ===
-            dataSets.sample.histogram.defaultDistinctPaths
+            dataSets.sample.histogram.wholeSpaceDistinctPaths
         )
         LOG.debug("Got number of distinct _paths")
         expect(pathClasses.sort()).toMatchSnapshot()
@@ -102,7 +105,7 @@ describe("Histogram tests", () => {
           // Whereas we just counted g elements before, this breaks down rect
           // elements within their g parent, ensuring rect elements are of the
           // proper _path.
-          dataSets.sample.histogram.defaultDistinctPaths
+          dataSets.sample.histogram.wholeSpaceDistinctPaths
         )
         LOG.debug("Ensuring all rect elements' attributes are sane")
         allRectValues.forEach((pathClass) => {
@@ -115,16 +118,6 @@ describe("Histogram tests", () => {
           })
         })
         LOG.debug("Ensured all rect elements' attributes are sane")
-        // Now set to "Whole Space" to make sure this histogram is redrawn.
-        await setSpan(app, "Whole Space")
-        // Just count a higher number of _paths, not all ~1500 rect elements.
-        LOG.debug("Checking rect elements in Whole Space")
-        await retryUntil(
-          () => app.client.getAttribute(selectors.histogram.gElem, "class"),
-          (pathClasses) =>
-            pathClasses.length ===
-            dataSets.sample.histogram.wholeSpaceDistinctPaths
-        )
         done()
       })
       .catch((err) => {

--- a/itest/tests/histogram.test.js
+++ b/itest/tests/histogram.test.js
@@ -6,7 +6,8 @@ import {
   newAppInstance,
   pcapIngestSample,
   startApp,
-  setSpan
+  setSpan,
+  waitForResults
 } from "../lib/app.js"
 import {retryUntil} from "../lib/control.js"
 import {handleError, stdTest} from "../lib/jest.js"
@@ -79,6 +80,7 @@ describe("Histogram tests", () => {
         // elements depend on both the dataset itself and the product's behavior.
         // Set to "Whole Space" to make sure this entire histogram is redrawn.
         await setSpan(app, "Whole Space")
+        await waitForResults(app)
         // Just count a higher number of _paths, not all ~1500 rect elements.
         LOG.debug("Checking rect elements in Whole Space")
         let pathClasses = await retryUntil(


### PR DESCRIPTION
Ensure all tests do no deep verification until either refreshing the page or running a query. The only test that needed to be change is the histogram deep inspection test.

The initial histogram check will just ensure something is visible. Subsequent deep inspection counting is done after a page refresh, initiated by an explicit span setting of "Whole Space".

Fixes #609.