### PR TITLE
Ingest Queryability Bug

### DIFF
--- a/src/css/_toolbar-button.scss
+++ b/src/css/_toolbar-button.scss
@@ -22,6 +22,7 @@
 
   .text {
     @include label-small;
+    white-space: nowrap;
     color: $gray-5;
     display: flex;
     line-height: 16px;

--- a/src/js/flows/openPacket.js
+++ b/src/js/flows/openPacket.js
@@ -49,8 +49,13 @@ export default (
       for await (let {type, ...status} of stream) {
         if (type === "PacketPostStatus") {
           setProgress(extractFrom(status))
-          gDispatch(Spaces.setDetail(clusterId, await client.spaces.get(name)))
+          if (status.snapshot_count > 0) {
+            gDispatch(
+              Spaces.setDetail(clusterId, await client.spaces.get(name))
+            )
+          }
         }
+
         if (type === "TaskEnd" && status.error) {
           throw errors.pcapIngest(status.error.error)
         }

--- a/src/js/flows/openPacket.test.js
+++ b/src/js/flows/openPacket.test.js
@@ -22,6 +22,7 @@ let mockClient = {
       yield {type: "TaskStart"}
       yield {
         type: "PacketPostStatus",
+        snapshot_count: 1,
         start_time: {sec: 0, ns: 0},
         update_time: {sec: 1, ns: 1},
         packet_total_size: 100,


### PR DESCRIPTION
fixes #607 

The UI will render the "Search" page when a space is selected and is "queryable". Queryable means that the `space.min_time` and `space.max_time` are both set to something other than zero.

The first time a "Search" page is rendered for a space, it will issue an initial search with the time span set to the min and max of the space.

So to fix the bug, wait until we receive the first PostPacketStatus with a snapshot_count > 0 before setting the min/max time of the space.

Side Fix:
The text was wrapping on some of the toolbar buttons. That is now fixed and they will not wrap.
<img width="183" alt="Screen Shot 2020-04-14 at 10 00 17 AM" src="https://user-images.githubusercontent.com/3460638/79261054-1c8b7980-7e44-11ea-91a7-4b9b004db90a.png">

