### PR TITLE
ci fix: key artifact name on build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,5 +100,5 @@ jobs:
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: artifacts
+        name: artifacts-${{ matrix.os }}-node-${{ matrix.node-version }}
         path: /var/tmp/brimsec/logs


### PR DESCRIPTION
The artifact namespace is per-workflow run, not job run. This means artifacts need to be named with that in mind to avoid a collision should multiple jobs fail. Key on OS and node version, which is our current matrix.
