### PR TITLE
test fix: increase default retryUntil to 60s

### DIFF
--- a/itest/lib/control.js
+++ b/itest/lib/control.js
@@ -27,7 +27,7 @@ export function retry(
 export const retryUntil = (
   f: PromiseFunc,
   cond_f: (*) => boolean,
-  attempts: number = 5,
+  attempts: number = 60,
   delay: number = 1000
 ) =>
   // Retry f until a condition is met. cond_f receives the value from f after


### PR DESCRIPTION
The tests still have a 5m timeout, which so far is enough padding.