### PR TITLE
test fix: remove explicit remote-debugging-port

### DIFF
--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -26,9 +26,6 @@ export const newAppInstance = (name: string, idx: number): Application => {
 
   // https://github.com/electron-userland/spectron#new-applicationoptions
   let appArgs = {
-    // Some version of Spectron choose a random debugging port in the 9000-9999
-    // range. Since zqd uses 9867, set this to 9999.
-    chromeDriverArgs: ["remote-debugging-port=9999"],
     startTimeout: 60000,
     waitTimeout: 60000,
     chromeDriverLogPath: workspaceLogfile(


### PR DESCRIPTION
This was originally employed to work around Spectron choosing a random port colliding with our back end. Spectron's choosing a random port was in turn used as an Electron workaround.

The workarounds haven't been needed since Electron 5. We moved past Electron 4 at https://github.com/brimsec/brim/pull/381 .

This effectively reverts https://github.com/brimsec/brim/pull/319

Other refs:
https://github.com/electron-userland/spectron/pull/361
https://github.com/electron-userland/spectron/pull/364

I temporarily enabled collection of artifacts upon success here: https://github.com/brimsec/brim/actions/runs/80214904

```sh
$ find {macos,ubuntu}/*chromedriver.log -exec grep -m1 devtoolsFrontendUrl {} \;
   "devtoolsFrontendUrl": "/devtools/inspector.html?ws=localhost:49530/devtools/page/46363801C6153D7D02C3C5B8E364EFB5",
   "devtoolsFrontendUrl": "/devtools/inspector.html?ws=localhost:49913/devtools/page/9C7B12F86B908DB8DB62CAF07E777A5E",
   "devtoolsFrontendUrl": "/devtools/inspector.html?ws=localhost:49926/devtools/page/92166780DF0E7743DE2C321C196C0431",
   "devtoolsFrontendUrl": "/devtools/inspector.html?ws=localhost:42833/devtools/page/D56C6ACC0BA245796591A3D6C81FF3CA",
   "devtoolsFrontendUrl": "/devtools/inspector.html?ws=localhost:41821/devtools/page/664EE001E08EACAFF8369E4AB09875D6",
   "devtoolsFrontendUrl": "/devtools/inspector.html?ws=localhost:36223/devtools/page/B32E7436441F33210DFA2E9AA262DDF4",
```