### PR TITLE
fix windows ci: dont rely on focus to destroy a window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
-        os: [macos-10.15, ubuntu-18.04]
+        os: [macos-10.15, ubuntu-18.04, windows-2019]
     needs: build
     steps:
     - uses: actions/checkout@v2

--- a/src/js/electron/ipc/windows/mainHandler.js
+++ b/src/js/electron/ipc/windows/mainHandler.js
@@ -35,8 +35,9 @@ export default function(manager: $WindowManager) {
     })
   })
 
-  ipcMain.handle("windows:destroy", () => {
-    manager.destroyWindow()
+  ipcMain.handle("windows:destroy", (e) => {
+    let win = BrowserWindow.fromWebContents(e.sender)
+    manager.destroyWindow(win)
   })
 
   ipcMain.handle("windows:log", (e, {id, args}) => {

--- a/src/js/electron/tron/windowManager.js
+++ b/src/js/electron/tron/windowManager.js
@@ -97,8 +97,7 @@ export default function windowManager() {
       if (win) win.close()
     },
 
-    destroyWindow() {
-      let win = BrowserWindow.getFocusedWindow()
+    destroyWindow(win: BrowserWindow) {
       if (win) win.destroy()
     }
   }


### PR DESCRIPTION
When Spectron launches Electron instances on Windows, empty command prompt windows are spawned along with the Electron instance window. (Spectron internally uses a `.bat` file to run chromedriver, and Windows apparently always shows a command prompt window when you run a batch file). 

These command prompt windows steal focus from the Electron window. So an individual test may succeed or fail, but Spectron can't shutdown the instance, because it can't close its test window, because it's not focused.

I verified this locally by running the integration tests w/o any changes, and verifying that despite test success or failure, the only way the Electron instances would go away is if I put in a brief sleep so that I could manually click on the Electron instances to make them focused.

@jameskerr @mason-fish : this is really beyond my redux knowledge, so I won't be surprised if there's a better way to address this. Also, I see that the 'closeWindow' operation relies on a focused window, and it may make sense to ensure it doesn't rely on focus so we don't hit this again.

Fixes #598 . cc @mikesbrown 

