### PR TITLE
avoid Path vs PATH errors on windows

### DIFF
--- a/src/js/zqd/zqd.js
+++ b/src/js/zqd/zqd.js
@@ -81,18 +81,14 @@ export class ZQD {
   start() {
     mkdirSync(this.root, {recursive: true, mode: 0o755})
 
-    // PATH must include both the zqd and zeek bin directories, as zqd depends
-    // on having zeek available in its environment PATH.
+    // We saw errors on command.com vs powershell when we tried to clone
+    // process.env and then determine whether to use "PATH" or "Path".
+    // Directly altering process.env is safe and less error prone.
     const sep = process.platform == "win32" ? ";" : ":"
-    const pathKey = process.platform == "win32" ? "Path" : "PATH"
-    const zqdEnvironment = _merge({}, process.env)
-    zqdEnvironment[pathKey] = [zqdPath, zqdZeekPath, process.env[pathKey]].join(
-      sep
-    )
+    process.env["PATH"] = [zqdPath, zqdZeekPath, process.env["PATH"]].join(sep)
 
     const opts = {
-      stdio: "inherit",
-      env: zqdEnvironment
+      stdio: "inherit"
     }
 
     const confFile = writeZqdConfigFile()

--- a/src/js/zqd/zqd.js
+++ b/src/js/zqd/zqd.js
@@ -81,9 +81,11 @@ export class ZQD {
   start() {
     mkdirSync(this.root, {recursive: true, mode: 0o755})
 
-    // We saw errors on command.com vs powershell when we tried to clone
+    // We saw errors on cmd.com vs powershell when we tried to clone
     // process.env and then determine whether to use "PATH" or "Path".
-    // Directly altering process.env is safe and less error prone.
+    // Windows environment variables are case-insensitive; see the
+    // process.env docs. Directly altering process.env is safe and
+    // less error prone.
     const sep = process.platform == "win32" ? ";" : ":"
     process.env["PATH"] = [zqdPath, zqdZeekPath, process.env["PATH"]].join(sep)
 


### PR DESCRIPTION
There is apparently a difference on trying to use "Path" vs "PATH" depending on whether you use cmd.com or powershell. Avoid needing to clone process.env and worry about that difference, and just modify it directly. Without this change, I would see occasional failures if I ran the integration tests locally in powershell, cmd.com, or git bash. With this change, I don't see any errors.

Fixes #556 .

(same as https://github.com/brimsec/brim/pull/632 , which I accidentally merged to a non-master branch).
