### PR TITLE
Redhat release artifact

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
+    - name: install rpm
+      run: sudo apt-get install -y rpm
     - name: setup node
       uses: actions/setup-node@v1
       with:
@@ -41,6 +43,6 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: dist/installers/brim_amd64.deb
-        asset_name: brim_amd64.deb
+        file: dist/installers/*
+        file_glob: true
         overwrite: true

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -35,9 +35,8 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
     - run: npm install --no-audit
     - run: npm run build
-    - name: build package
-      run: |
-        node ./scripts/release --linux
+    - name: build packages
+      run: node ./scripts/release --linux
     - name: upload release artifact
       uses: svenstaro/upload-release-action@1.1.0
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5215,6 +5215,208 @@
         }
       }
     },
+    "electron-installer-redhat": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-3.0.0.tgz",
+      "integrity": "sha512-BtYh174AOIGq0iDges4/fihqJYw8WsWXRKuRpKvUlkqrwfeGMWqln28+kKV5IW6GPfHjRFeCO5dcMUioUDBo1A==",
+      "optional": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.10.0",
+        "fs-extra": "^8.1.0",
+        "lodash": "^4.17.15",
+        "word-wrap": "^1.2.3",
+        "yargs": "^15.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "optional": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "optional": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "optional": true
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "optional": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "optional": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "optional": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "optional": true
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "optional": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "optional": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "optional": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "optional": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "optional": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "optional": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "optional": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "electron-installer-run": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/electron-installer-run/-/electron-installer-run-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "zq": "brimsec/zq#v0.11.1"
   },
   "optionalDependencies": {
-    "electron-installer-debian": "^3.0.0"
+    "electron-installer-debian": "^3.0.0",
+    "electron-installer-redhat": "^3.0.0"
   }
 }

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -42,6 +42,7 @@ program
           certificatePassword: cmd.windowsCertificatePassword
         })
       )
-    if (cmd.linux) pack.linux().then(install.debian)
+    if (cmd.linux)
+      pack.linux().then(() => Promise.all([install.debian(), install.redhat()]))
   })
   .parse(process.argv)

--- a/scripts/release/install.js
+++ b/scripts/release/install.js
@@ -1,14 +1,27 @@
 /* @noflow */
 const fs = require("fs")
 const os = require("os")
-const installer = require("electron-winstaller")
-const debInstaller = require("electron-installer-debian")
+const installerWin = require("electron-winstaller")
+const installerDebian = require("electron-installer-debian")
+const installerRedhat = require("electron-installer-redhat")
 const createDMG = require("electron-installer-dmg")
 const createZip = require("electron-installer-zip")
 const path = require("path")
 
 const out = "./dist/installers"
 const appPath = "dist/packages/Brim-darwin-x64/Brim.app"
+const defaultLinuxOpts = {
+  src: "./dist/packages/Brim-linux-x64",
+  dest: out,
+  rename: (dest) => {
+    return path.join(dest, "<%= name %>_<%= arch %>.<%= ext %>")
+  },
+  options: {
+    homepage: "https://www.brimsecurity.com",
+    icon: "./dist/static/AppIcon.png",
+    maintainer: "Brim Security, Inc. <support@brimsecurity.com>"
+  }
+}
 
 module.exports = {
   darwin: async function() {
@@ -45,7 +58,7 @@ module.exports = {
   win32: function(opts) {
     console.log("Building installer for win32")
     fixWindowsInstallerDeps()
-    return installer
+    return installerWin
       .createWindowsInstaller({
         ...opts,
         appDirectory: "./dist/packages/Brim-Win32-x64",
@@ -67,18 +80,19 @@ module.exports = {
 
   debian: function() {
     console.log("Building deb package installer")
-    return debInstaller({
-      src: "./dist/packages/Brim-linux-x64",
-      dest: out,
-      arch: "amd64",
-      rename: (dest) => {
-        return path.join(dest, "<%= name %>_<%= arch %>.deb")
-      },
-      options: {
-        homepage: "https://www.brimsecurity.com",
-        icon: "./dist/static/AppIcon.png",
-        maintainer: "Brim Security, Inc. <support@brimsecurity.com>"
-      }
+    return installerDebian({
+      ...defaultLinuxOpts,
+      ext: "deb",
+      arch: "amd64"
+    })
+  },
+
+  redhat: function() {
+    console.log("Building installer for redhat")
+    return installerRedhat({
+      ...defaultLinuxOpts,
+      ext: "rpm",
+      arch: "x86_64"
     })
   }
 }

--- a/scripts/release/install.js
+++ b/scripts/release/install.js
@@ -88,7 +88,7 @@ module.exports = {
   },
 
   redhat: function() {
-    console.log("Building installer for redhat")
+    console.log("Building rpm package installer")
     return installerRedhat({
       ...defaultLinuxOpts,
       ext: "rpm",


### PR DESCRIPTION
Augment ./scripts/release --linux command to produce redhat release
package.

Update linux release github action to upload .rpm artifact.

Working on Fedora 30:
![image](https://user-images.githubusercontent.com/2147549/79618890-28836f80-80c0-11ea-869b-bde1970f3cec.png)

Icon works as well (gnome 3):
![image](https://user-images.githubusercontent.com/2147549/79618836-012ca280-80c0-11ea-98df-151c28196fe8.png)

part of #618 