### PR TITLE
test fix: test download pcaps (fixes #543)

### DIFF
--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -275,6 +275,9 @@ export const waitUntilDownloadFinished = async (app: Application) =>
     )
   })
 
+export const pcapsDir = async (app: Application) =>
+  await app.electron.remote.app.getPath("temp")
+
 export const toggleOptimizations = async (app: Application) => {
   // Stateless toggle of optimizations. If you use this twice after reset
   // state, both will be back to their original state. This is only used to
@@ -334,4 +337,26 @@ export const takeScreenshot = async (app: Application) => {
   } catch (e) {
     LOG.error("unable to take screen shot: " + e)
   }
+}
+
+const waitForClickableButtonAndClick = async (
+  app: Application,
+  selector: string
+) => {
+  await appStep(`wait for button ${selector} to be visible`, () =>
+    app.client.waitForVisible(selector)
+  )
+
+  await appStep(`wait for button ${selector} to be enabled`, () =>
+    retryUntil(
+      () => app.client.getAttribute(selectors.pcaps.button, "disabled"),
+      (isDisabled) => !isDisabled
+    )
+  )
+
+  await click(app, selector)
+}
+
+export const clickPcapButton = async (app: Application) => {
+  await waitForClickableButtonAndClick(app, selectors.pcaps.button)
 }

--- a/itest/tests/pcaps.test.js
+++ b/itest/tests/pcaps.test.js
@@ -1,0 +1,102 @@
+/* @noflow */
+
+import {readFileSync, readdirSync, unlinkSync} from "fs"
+import md5 from "md5"
+import path from "path"
+
+import {LOG} from "../lib/log"
+import {
+  click,
+  clickPcapButton,
+  newAppInstance,
+  pcapIngestSample,
+  pcapsDir,
+  searchDisplay,
+  startApp,
+  startSearch,
+  waitForSearch,
+  waitUntilDownloadFinished,
+  writeSearch
+} from "../lib/app"
+import {selectors} from "../../src/js/test/integration"
+import {handleError, stdTest} from "../lib/jest"
+
+const clearPcaps = async (app) => {
+  let dir = await pcapsDir(app)
+  let files = readdirSync(dir)
+  files.forEach((fileBasename) => {
+    if (fileBasename.match(/^packets-.+\.pcap$/)) {
+      let fileAbspath = path.join(dir, fileBasename)
+      unlinkSync(fileAbspath)
+      LOG.debug(`Unlinked file ${fileAbspath}`)
+    }
+  })
+}
+
+describe("Test PCAPs", () => {
+  let app
+  let testIdx = 0
+
+  beforeEach(async () => {
+    app = newAppInstance(path.basename(__filename), ++testIdx)
+    await startApp(app)
+    await clearPcaps(app)
+    return pcapIngestSample(app)
+  })
+
+  afterEach(() => {
+    if (app && app.isRunning()) {
+      return app.stop()
+    }
+  })
+
+  stdTest(
+    "pcap button downloads deterministically-formed pcap file",
+    (done) => {
+      writeSearch(
+        app,
+        "_path=ssl id.orig_h=192.168.1.110 id.resp_h=209.216.230.240 id.resp_p=443"
+      )
+        .then(async () => {
+          await startSearch(app)
+          await waitForSearch(app)
+          await searchDisplay(app)
+          await click(app, selectors.viewer.resultCellContaining("ssl"))
+          await clickPcapButton(app)
+          let downloadText = await waitUntilDownloadFinished(app)
+          expect(downloadText).toBe("Download Complete")
+          const fileBasename = "packets-1582646593.996366.pcap"
+          let pcapAbspath = path.join(await pcapsDir(app), fileBasename)
+          expect(md5(readFileSync(pcapAbspath))).toBe(
+            "888453c81738fd8ade4c7f9888d86f86"
+          )
+          done()
+        })
+        .catch((err) => {
+          handleError(app, err, done)
+        })
+    }
+  )
+
+  stdTest("pcap download works for null duration", (done) => {
+    writeSearch(app, "duration=null id.orig_p=47783")
+      .then(async () => {
+        await startSearch(app)
+        await waitForSearch(app)
+        await searchDisplay(app)
+        await click(app, selectors.viewer.resultCellContaining("conn"))
+        await clickPcapButton(app)
+        let downloadText = await waitUntilDownloadFinished(app)
+        expect(downloadText).toBe("Download Complete")
+        const fileBasename = "packets-1582646589.440467.pcap"
+        let pcapAbspath = path.join(await pcapsDir(app), fileBasename)
+        expect(md5(readFileSync(pcapAbspath))).toBe(
+          "678442857027fdc5ad1e3418614dcdb8"
+        )
+        done()
+      })
+      .catch((err) => {
+        handleError(app, err, done)
+      })
+  })
+})


### PR DESCRIPTION
Add integration tests for downloading packet captures. The tests are
accomplished by uploading data, running zql to find a deterministic
connection (can't use UID), clicking a cell, and downloading the packet
capture. In CI the files are put into a directory, where we can examine
the file's MD5.

In older times, there was a bug where a null-duration connection's pcap
could not be downloaded. That has since been fixed, so that test is
enabled.