### PR TITLE
Save ingest warnings in space state

### DIFF
--- a/src/js/brim/ingest/detectFileType.js
+++ b/src/js/brim/ingest/detectFileType.js
@@ -22,7 +22,7 @@ export default async function(path: string): Promise<IngestFileType> {
 }
 
 async function isZeekJson(file) {
-  for await (let line of firstLines(file, 4)) {
+  for await (let line of firstLines(file, 1)) {
     if (!isJson(line)) return false
   }
   return true

--- a/src/js/brim/space.test.js
+++ b/src/js/brim/space.test.js
@@ -6,7 +6,8 @@ let space = {
   min_time: {sec: 1425565512, ns: 943615000},
   max_time: {sec: 1428917684, ns: 732650001},
   packet_support: true,
-  ingest_progress: null
+  ingest_progress: null,
+  ingest_warnings: []
 }
 
 test("default time span is 30 mins before max time", () => {

--- a/src/js/flows/rightclick/cellMenu.test.js
+++ b/src/js/flows/rightclick/cellMenu.test.js
@@ -11,15 +11,16 @@ function menuText(menu: MenuItem) {
     .map((item) => item.label)
     .join(", ")
 }
+const space = {
+  name: "default",
+  min_time: {sec: 1425564900, ns: 0},
+  max_time: {sec: 1428917793, ns: 750000000},
+  packet_support: true,
+  ingest_progress: null,
+  ingest_warnings: []
+}
 
 describe("Log Right Click", () => {
-  const space = {
-    name: "default",
-    min_time: {sec: 1425564900, ns: 0},
-    max_time: {sec: 1428917793, ns: 750000000},
-    packet_support: true,
-    ingest_progress: null
-  }
   const program = "*"
 
   test("conn log with pcap support", () => {
@@ -77,13 +78,6 @@ describe("Log Right Click", () => {
 
 describe("Analysis Right Click", () => {
   const program = "* | count() by id.orig_h"
-  const space = {
-    name: "default",
-    min_time: {sec: 1425564900, ns: 0},
-    max_time: {sec: 1428917793, ns: 750000000},
-    packet_support: true,
-    ingest_progress: null
-  }
 
   test("address field", () => {
     const log = conn()

--- a/src/js/state/Spaces/actions.js
+++ b/src/js/state/Spaces/actions.js
@@ -1,6 +1,12 @@
 /* @flow */
 
-import type {SPACES_DETAIL, SPACES_NAMES, SPACES_INGEST_PROGRESS} from "./types"
+import type {
+  SPACES_DETAIL,
+  SPACES_INGEST_PROGRESS,
+  SPACES_INGEST_WARNING_APPEND,
+  SPACES_INGEST_WARNING_CLEAR,
+  SPACES_NAMES
+} from "./types"
 import type {SpaceDetailPayload} from "../../services/zealot/types"
 
 export default {
@@ -25,5 +31,25 @@ export default {
     clusterId,
     space,
     value
+  }),
+
+  appendIngestWarning: (
+    clusterId: string,
+    space: string,
+    warning: string
+  ): SPACES_INGEST_WARNING_APPEND => ({
+    type: "SPACES_INGEST_WARNING_APPEND",
+    clusterId,
+    space,
+    warning
+  }),
+
+  clearIngestWarnings: (
+    clusterId: string,
+    space: string
+  ): SPACES_INGEST_WARNING_CLEAR => ({
+    type: "SPACES_INGEST_WARNING_CLEAR",
+    clusterId,
+    space
   })
 }

--- a/src/js/state/Spaces/reducer.js
+++ b/src/js/state/Spaces/reducer.js
@@ -26,6 +26,25 @@ function spacesReducer(state, action: SpacesAction) {
           ingest_progress: action.value
         }
       }
+    case "SPACES_INGEST_WARNING_APPEND":
+      return {
+        ...state,
+        [action.space]: {
+          ...state[action.space],
+          ingest_warnings: [
+            ...(state[action.space].ingest_warnings || []),
+            action.warning
+          ]
+        }
+      }
+    case "SPACES_INGEST_WARNING_CLEAR":
+      return {
+        ...state,
+        [action.space]: {
+          ...state[action.space],
+          ingest_warnings: []
+        }
+      }
     default:
       return state
   }

--- a/src/js/state/Spaces/selectors.js
+++ b/src/js/state/Spaces/selectors.js
@@ -23,6 +23,11 @@ export default {
     let clus = getCluster(state, clusterId)
     let space = clus[name]
     if (space) return space.ingest_progress
+  },
+  getIngestWarnings: (clusterId: string, name: string) => (state: State) => {
+    let cluster = getCluster(state, clusterId)
+    let space = cluster[name]
+    return space.ingest_warnings || []
   }
 }
 

--- a/src/js/state/Spaces/test.js
+++ b/src/js/state/Spaces/test.js
@@ -84,3 +84,27 @@ test("only cares about spaces actions", () => {
   store.dispatch({type: "NON_SPACE"})
   expect(Spaces.raw(store.getState())).toEqual({})
 })
+
+test("ingest warnings", () => {
+  let state = store.dispatchAll([
+    Spaces.setDetail("cluster1", detail),
+    Spaces.appendIngestWarning("cluster1", detail.name, "Problem 1"),
+    Spaces.appendIngestWarning("cluster1", detail.name, "Problem 2")
+  ])
+
+  expect(Spaces.getIngestWarnings("cluster1", detail.name)(state)).toEqual([
+    "Problem 1",
+    "Problem 2"
+  ])
+})
+
+test("clear warnings", () => {
+  let state = store.dispatchAll([
+    Spaces.setDetail("cluster1", detail),
+    Spaces.appendIngestWarning("cluster1", detail.name, "Problem 1"),
+    Spaces.appendIngestWarning("cluster1", detail.name, "Problem 2"),
+    Spaces.clearIngestWarnings("cluster1", detail.name)
+  ])
+
+  expect(Spaces.getIngestWarnings("cluster1", detail.name)(state)).toEqual([])
+})

--- a/src/js/state/Spaces/types.js
+++ b/src/js/state/Spaces/types.js
@@ -11,14 +11,20 @@ export type SpacesState = {
   }
 }
 
-export type SpacesAction = SPACES_NAMES | SPACES_DETAIL | SPACES_INGEST_PROGRESS
+export type SpacesAction =
+  | SPACES_NAMES
+  | SPACES_DETAIL
+  | SPACES_INGEST_PROGRESS
+  | SPACES_INGEST_WARNING_APPEND
+  | SPACES_INGEST_WARNING_CLEAR
 
 export type Space = {
   name: string,
   min_time: Ts,
   max_time: Ts,
   packet_support: boolean,
-  ingest_progress: number | null
+  ingest_progress: number | null,
+  ingest_warnings: string[]
 }
 
 export type SPACES_NAMES = {
@@ -38,4 +44,17 @@ export type SPACES_INGEST_PROGRESS = {
   clusterId: string,
   space: string,
   value: number | null
+}
+
+export type SPACES_INGEST_WARNING_APPEND = {
+  type: "SPACES_INGEST_WARNING_APPEND",
+  warning: string,
+  space: string,
+  clusterId: string
+}
+
+export type SPACES_INGEST_WARNING_CLEAR = {
+  type: "SPACES_INGEST_WARNING_CLEAR",
+  space: string,
+  clusterId: string
 }


### PR DESCRIPTION
Fixes: #575 

Store the ingest warnings in the redux store under the space. This works fine since a space is only ever allowed to be ingested into once. We may have to refactor where we put these errors in the future.