### PR TITLE
ci fix: properly handle windows paths in bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,19 @@ jobs:
       id: set-npm-cache-dir
       run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
     - name: Clear Extraneous Runner Cache
-      # The macos Github runner has 1G of NPM cache that we don't need.
-      # Clear it before we create our own cache to prevent slower build
-      # times. See https://github.com/brimsec/brim/pull/590
-      run: |
-          cachedir=${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-          rm -rf "${cachedir:?}"
+      # Clear on-runner cache before we create our own cache to prevent
+      # slower build times. See https://github.com/brimsec/brim/pull/590
+      # and https://github.com/brimsec/brim/issues/641
+      run: rm -rf "${NPM_CACHE:?}"
+      env:
+        NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
       shell: bash
     - name: Cache node modules
       uses: actions/cache@v1
+      # Change the cache name any time you want to start with a cleared
+      # cache.
       env:
-        cache-name: cache-node-modules3
+        cache-name: cache-node-modules-ci-v4
       with:
         path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
@@ -59,14 +61,14 @@ jobs:
       id: set-npm-cache-dir
       run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
     - name: Clear Extraneous Runner Cache
-      run: |
-          cachedir=${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-          rm -rf "${cachedir:?}"
+      run: rm -rf "${NPM_CACHE:?}"
+      env:
+        NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
       shell: bash
     - name: Cache node modules
       uses: actions/cache@v1
       env:
-        cache-name: cache-node-modules3
+        cache-name: cache-node-modules-ci-v4
       with:
         path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -18,14 +18,19 @@ jobs:
       id: set-npm-cache-dir
       run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
     - name: Clear Extraneous Runner Cache
-      run: |
-          cachedir=${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-          rm -rf "${cachedir:?}"
+      # Clear on-runner cache before we create our own cache to prevent
+      # slower build times. See https://github.com/brimsec/brim/pull/590
+      # and https://github.com/brimsec/brim/issues/641
+      run: rm -rf "${NPM_CACHE:?}"
+      env:
+        NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
       shell: bash
     - name: Cache node modules
       uses: actions/cache@v1
+      # Change the cache name any time you want to start with a cleared
+      # cache.
       env:
-        cache-name: cache-node-modules3
+        cache-name: cache-node-modules-ci-v4
       with:
         path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -18,14 +18,19 @@ jobs:
       id: set-npm-cache-dir
       run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
     - name: Clear Extraneous Runner Cache
-      run: |
-          cachedir=${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-          rm -rf "${cachedir:?}"
+      # Clear on-runner cache before we create our own cache to prevent
+      # slower build times. See https://github.com/brimsec/brim/pull/590
+      # and https://github.com/brimsec/brim/issues/641
+      run: rm -rf "${NPM_CACHE:?}"
+      env:
+        NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
       shell: bash
     - name: Cache node modules
       uses: actions/cache@v1
+      # Change the cache name any time you want to start with a cleared
+      # cache.
       env:
-        cache-name: cache-node-modules3
+        cache-name: cache-node-modules-ci-v4
       with:
         path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Fixes #641 

Adjust how the npm cache directory is expanded. We need to quote it in
bash so that "\\" is not quashed. But it's not possible to directly quote
the Github action expression, because the running shell will attempt to
expand it using normal shell expansion rules. That means this doesn't
work:
```
  - run: rm -rf "${{ foo.bar }}"
```
Also,
```
  - run: rm -rf ${{ foo.bar }}
```
will not work in some cases, like if foo.bar is a Windows path. If
foo.bar is "c:\foo", the shell will turn that into "c:foo".

The fix is to assign an environment variable from the expression
directly, then quote the environment variable in the shell.

To force using a new, smaller cache, change the cache name.