### PR TITLE
Add Actions workflow for publishing docs to wiki

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,19 @@
+name: Publish documentation to GitHub Wiki
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Upload Documentation to Wiki
+        uses: brimsec/github-wiki-publish-action@v1
+        with:
+          path: "docs"
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This is the first step in putting the Brim docs on a GitHub Wiki.

Our goal is to update the docs as part of Pull Requests on the main repo, potentially at the same time other code is being updated. To facilitate this, an Action is used that checks for changes to the `docs/` directory whenever there's pushes to `master`. Any adds/moves/deletions in that `docs/` directory are committed to the equivalent spot in the adjacent GitHub WIki repo.

As a prerequisite, I went looking for an existing Action that would do this for me. I couldn't find one that worked quite the way I wanted out-of-the-box, so I have our own fork at https://github.com/brimsec/github-wiki-publish-action and merged https://github.com/brimsec/github-wiki-publish-action/pull/1 with my minimal changes.

_This_ PR just gets that workflow in place so I can start using it in subsequent PRs. A preview of what comes next after it's approved/merged:

1. I'll put up a PR that populates the  `docs/` directory with the contents of the articles that we'd initially move to the wiki. I've been testing this out in a personal repo, so you can see the example `docs/` directory at https://github.com/philrz/scratchwiki/tree/master/docs and the corresponding GitHub Wiki created by the Action at https://github.com/philrz/scratchwiki/wiki.

2. Once that PR is approved and ready for merge, I'll enable the GitHub Setting for the Brim repo to enable the wiki, which initializes the wiki repo and starts it out empty. I'll then immediately merge the PR from step #1 so the Action will populate the wiki, and confirm the wiki looks correct (inline images intact, no broken links, etc.)

3. I'll put up PRs to update links to the Troubleshooting doc and Windows beta article in the CHANGELOG/README so they point to the new location in the wiki. I'll also update the link in the bullets on the Releases page and in release postings on our public Slack.

4. Once all links are updated, I'll put up a final PR to remove the redundant Troubleshooting & Windows beta articles from their original homes in the repo.
