### PR TITLE
Update links to point to wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,6 @@ This is the same as v0.5.1, but addresses a CI issue that stopped the creation o
 
 ## v0.5.1
 
-* Initial (beta) Windows release creation and support. Windows releases are currently unsigned (unlike our Mac releases). See [README-Windows](README-Windows.md) for details.
+* Initial (beta) Windows release creation and support. Windows releases are currently unsigned (unlike our Mac releases). See [Microsoft Windows beta limitations](wiki/Microsoft-Windows-beta-limitations) for details.
 * Warn on close if there are still active pcap ingests.
 * Fix some issues saving search history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,6 @@ This is the same as v0.5.1, but addresses a CI issue that stopped the creation o
 
 ## v0.5.1
 
-* Initial (beta) Windows release creation and support. Windows releases are currently unsigned (unlike our Mac releases). See [Microsoft Windows beta limitations](wiki/Microsoft-Windows-beta-limitations) for details.
+* Initial (beta) Windows release creation and support. Windows releases are currently unsigned (unlike our Mac releases). See [Microsoft Windows beta limitations](https://github.com/brimsec/brim/wiki/Microsoft-Windows-beta-limitations) for details.
 * Warn on close if there are still active pcap ingests.
 * Fix some issues saving search history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 # Brim Development
 
-Thank you for contributing to Brim! Feel free to [open an issue](TROUBLESHOOTING.md#opening-an-issue), fork the repo, or send us a pull request.
+Thank you for contributing to Brim! Feel free to [open an issue](wiki/Troubleshooting#opening-an-issue), fork the repo, or send us a pull request.
 
 Brim is early in its life cycle and will be expanding quickly.  Please star and/or watch the repo so you can follow and track our progress.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 # Brim Development
 
-Thank you for contributing to Brim! Feel free to [open an issue](wiki/Troubleshooting#opening-an-issue), fork the repo, or send us a pull request.
+Thank you for contributing to Brim! Feel free to [open an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue), fork the repo, or send us a pull request.
 
 Brim is early in its life cycle and will be expanding quickly.  Please star and/or watch the repo so you can follow and track our progress.
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ your platform from the latest
 
 ## Having a problem?
 
-Please review the [troubleshooting guide](TROUBLESHOOTING.md) to review
-common problems and helpful tips before [opening an issue](TROUBLESHOOTING.md#opening-an-issue).
+Please browse the [wiki](wiki) to review common problems and helpful tips before [opening an issue](wiki/Troubleshooting#opening-an-issue).
 
 ## Development and contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ your platform from the latest
 
 ## Having a problem?
 
-Please browse the [wiki](wiki) to review common problems and helpful tips before [opening an issue](wiki/Troubleshooting#opening-an-issue).
+Please browse the [wiki](wiki) to review common problems and helpful tips before [opening an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue).
 
 ## Development and contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ your platform from the latest
 
 ## Having a problem?
 
-Please browse the [wiki](wiki) to review common problems and helpful tips before [opening an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue).
+Please browse the [wiki](https://github.com/brimsec/brim/wiki) to review common problems and helpful tips before [opening an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue).
 
 ## Development and contributing
 


### PR DESCRIPTION
Per step #3 of https://github.com/brimsec/brim/pull/659, I've already updated the links in the bullets at https://github.com/brimsec/brim/releases as well as the announcements on the #brim channel in our public Slack to point to the articles in the wiki. This does the link updates in the top-level docs of the repo as well.