### PR TITLE
test workaround: do not set span for now

### DIFF
--- a/itest/tests/query.test.js
+++ b/itest/tests/query.test.js
@@ -8,7 +8,6 @@ import {
   newAppInstance,
   pcapIngestSample,
   searchDisplay,
-  setSpan,
   startApp,
   startSearch,
   waitForResults,
@@ -42,7 +41,6 @@ describe("Query tests", () => {
   })
 
   beforeEach(async () => {
-    await setSpan(app, "Whole Space")
     await writeSearch(app, "")
     await waitForResults(app)
   })


### PR DESCRIPTION
As long as Whole Space is the default, we needn't set "Whole Space"
every time. This works around #668 until a better fix can be introduced.