### PR TITLE
Throttle key events

### DIFF
--- a/src/js/components/useSearchShortcuts.js
+++ b/src/js/components/useSearchShortcuts.js
@@ -5,21 +5,31 @@ import {useEffect} from "react"
 import Mousetrap from "mousetrap"
 
 import Tabs from "../state/Tabs"
+import throttle from "lodash/throttle"
 import {adjustSelectedLogIndex} from "../flows/adjustSelectedLogIndex"
 
 export default function() {
   let dispatch = useDispatch()
   useEffect(() => {
-    Mousetrap.bind("down", (e) => {
-      e.preventDefault()
-      dispatch(adjustSelectedLogIndex(1))
-    })
-    Mousetrap.bind("up", (e) => {
-      e.preventDefault()
-      dispatch(adjustSelectedLogIndex(-1))
-    })
+    Mousetrap.bind(
+      "down",
+      throttle((e) => {
+        e.preventDefault()
+        dispatch(adjustSelectedLogIndex(1))
+      }, 200)
+    )
+    Mousetrap.bind(
+      "up",
+      throttle((e) => {
+        e.preventDefault()
+        dispatch(adjustSelectedLogIndex(-1))
+      }, 200)
+    )
     Mousetrap.bind("mod+t", () => dispatch(Tabs.new()))
-    Mousetrap.bind("mod+w", () => dispatch(Tabs.closeActive()))
+    Mousetrap.bind("mod+w", (e) => {
+      e.preventDefault()
+      dispatch(Tabs.closeActive())
+    })
     Mousetrap.bind("ctrl+tab", () => dispatch(Tabs.activateNext()))
     Mousetrap.bind("ctrl+shift+tab", () => dispatch(Tabs.activatePrev()))
     for (let i = 0; i < 8; ++i) {


### PR DESCRIPTION
fixes #591 

I also had noticed that `cmd+w` was closing the whole window instead of just the tab, so fixed that too (prevent default)

Signed-off-by: Mason Fish <mason@looky.cloud>