### PR TITLE
dont remove the run directory on npm clean

### DIFF
--- a/scripts/clean/index.js
+++ b/scripts/clean/index.js
@@ -2,4 +2,3 @@
 const fs = require("fs-extra")
 
 fs.removeSync("dist")
-fs.removeSync("run")


### PR DESCRIPTION
Since `npm run start` runs `clean`, without this change, it's hard to locally test loading the same space between runs.
