### PR TITLE
Do not render RightPane with no space

### DIFF
--- a/src/js/components/RightPane.js
+++ b/src/js/components/RightPane.js
@@ -56,9 +56,8 @@ export default class RightPane extends React.Component<Props, S> {
 
   render() {
     const {prevExists, nextExists, isOpen, width, currentLog} = this.props
-
+    if (!this.props.space) return null
     if (!isOpen) return <XRightPaneExpander />
-
     return (
       <Pane
         isOpen={isOpen}

--- a/src/js/components/RightPane.test.js
+++ b/src/js/components/RightPane.test.js
@@ -1,0 +1,19 @@
+/* @flow */
+import React from "react"
+
+import {XRightPane} from "./RightPane"
+import Layout from "../state/Layout"
+import LogDetails from "../state/LogDetails"
+import Search from "../state/Search"
+import loginTo from "../test/helpers/loginTo"
+import provide from "../test/helpers/provide"
+
+test("no errors if space does not exist", async () => {
+  let {store} = await loginTo("cluster1", "space1")
+
+  store.dispatch(Layout.showRightSidebar())
+  store.dispatch(Search.setSpace(""))
+  store.dispatch(LogDetails.push([]))
+  let el = provide(store, <XRightPane />)
+  expect(el.html()).toBe("")
+})


### PR DESCRIPTION
If there was no space, but the right pane was open, it would crash the app. Check for a space and bail early. A regression test has been added as well.

fixes: #652 

Video of Fix: https://recordit.co/6G8XkThihN