### PR TITLE
fix invalid filter

### DIFF
--- a/src/js/brim/field.js
+++ b/src/js/brim/field.js
@@ -14,6 +14,8 @@ export const PATH_PAD = 12
 const WHITE_SPACE = /\s+/
 const COMMA = /,/
 const STRING_TYPE = /^b?string$/
+const DOUBLE_QUOTE = /"/g
+const ESCAPED_DOUBLE_QUOTE = '\\"'
 
 function field({name, type, value}: FieldData): $Field {
   return {
@@ -32,7 +34,8 @@ function field({name, type, value}: FieldData): $Field {
       if (this.type === "bool") return this.value === "T" ? "true" : "false"
       let quote = [WHITE_SPACE, COMMA].some((reg) => reg.test(this.value))
       if (STRING_TYPE.test(this.type)) quote = true
-      return quote ? `"${this.value}"` : this.value
+      const str = this.value.replace(DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE)
+      return quote ? `"${str}"` : str
     },
     stringValue(): string {
       if (value === null) return "null"

--- a/src/js/brim/field.test.js
+++ b/src/js/brim/field.test.js
@@ -16,7 +16,7 @@ test("string does quote", () => {
 test("string escapes double quotes", () => {
   let f = brim.field({name: "service", type: "string", value: '"test"'})
 
-  // '"test"', as a string, should return "\"test\"" to escape the inner double quotes
+  // "test", as a value of type 'string', should return "\"test\"" to escape the inner double quotes
   expect(f.queryableValue()).toEqual('"\\"test\\""')
 })
 

--- a/src/js/brim/field.test.js
+++ b/src/js/brim/field.test.js
@@ -13,6 +13,13 @@ test("string does quote", () => {
   expect(f.queryableValue()).toEqual('"d,n,s"')
 })
 
+test("string escapes double quotes", () => {
+  let f = brim.field({name: "service", type: "string", value: '"test"'})
+
+  // '"test"', as a string, should return "\"test\"" to escape the inner double quotes
+  expect(f.queryableValue()).toEqual('"\\"test\\""')
+})
+
 describe("#queryableValue", () => {
   const fn = (data: any) => brim.field(data).queryableValue()
 


### PR DESCRIPTION
#626 

In the repro steps for this issue, the log's contents have double quotes as part of the values which need to be escaped when we use that value as a search argument 

![escapeDoubleQuotesFilter](https://user-images.githubusercontent.com/14865533/80261298-e7023f80-863e-11ea-964d-18e13282b9fd.gif)
