### PR TITLE
integration test for rpm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,63 @@ jobs:
     - run: npm run lint
     - run: npm run flow
     - run: npm test -- --maxWorkers=2 --ci
+    - name: Build Linux Packages
+      if: runner.os == 'Linux'
+      run: |
+        set -x
+        node scripts/release --linux
+    - name: Persist rpm package
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v1
+      with:
+        name: linux-release
+        path: ./dist/installers
+
+  integration_test_centos:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        node-version: [12.x]
+    container:
+      image: centos:8
+      env:
+        # This environment variable causes chrome to run with no sandbox- needed
+        # whenever chrome is run as root.
+        APPVEYOR: true
+    needs: build
+    steps:
+    - run: dnf install -y xorg-x11-server-Xvfb git nss-tools pulseaudio
+    - run: git config --global core.autocrlf false
+    - uses: actions/checkout@v2
+    - name: setup node version ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Set NPM Cache Directory
+      id: set-npm-cache-dir
+      run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
+    - name: Clear Extraneous Runner Cache
+      run: rm -rf "${NPM_CACHE:?}"
+      env:
+        NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
+    - name: Cache node modules
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-node-modules-ci-v4
+      with:
+        path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+    - run: npm install --no-audit
+    - name: Download rpm package
+      uses: actions/download-artifact@v1
+      with:
+        name: linux-release
+    - name: Integration Tests (Centos 8)
+      run: |
+        dnf install -y ./linux-release/brim_x86_64.rpm
+        xvfb-run -d -s "-screen 0 1280x1024x24" npm run itest -- --ci --forceExit
 
   integration_test:
     runs-on: ${{ matrix.os }}
@@ -87,16 +144,16 @@ jobs:
         hdiutil attach dist/installers/Brim.dmg
         cp -R /Volumes/Brim/Brim.app /Applications
         retry_until_success 60 1 hdiutil detach /Volumes/Brim
-      shell: bash
-    - name: Build and Install Debian Pkg
+    - name: Download deb package
+      if: runner.os == 'Linux'
+      uses: actions/download-artifact@v1
+      with:
+        name: linux-release
+    - name: Integration Tests (Debian Linux)
       if: runner.os == 'Linux'
       run: |
-        set -x
-        node scripts/release --linux
-        sudo dpkg --force-depends -i ./dist/installers/brim_amd64.deb
-    - name: Integration Tests (Linux)
-      if: runner.os == 'Linux'
-      run: xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" npm run itest -- --ci --forceExit
+        sudo apt install -y ./linux-release/brim_amd64.deb
+        xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" npm run itest -- --ci --forceExit
       env:
         # WORKSPACE represents a top-level place for test infra code to
         # find and put things. That avoids proliferation of env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         set -x
         node scripts/release --linux
-    - name: Persist rpm package
+    - name: Persist Linux packages
       if: runner.os == 'Linux'
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         hdiutil attach dist/installers/Brim.dmg
         cp -R /Volumes/Brim/Brim.app /Applications
         retry_until_success 60 1 hdiutil detach /Volumes/Brim
-    - name: Download deb package
+    - name: Download Linux packages
       if: runner.os == 'Linux'
       uses: actions/download-artifact@v1
       with:

--- a/scripts/release/install.js
+++ b/scripts/release/install.js
@@ -17,6 +17,7 @@ const defaultLinuxOpts = {
     return path.join(dest, "<%= name %>_<%= arch %>.<%= ext %>")
   },
   options: {
+    name: "brim",
     homepage: "https://www.brimsecurity.com",
     icon: "./dist/static/AppIcon.png",
     maintainer: "Brim Security, Inc. <support@brimsecurity.com>"


### PR DESCRIPTION
Add the build ci phase to build the linux release artifacts (.deb and
at the .rpm) at the end of the job then upload artifacts.

Add integration_test_centos which downloads the created rpm package
and runs the standard suite of integration tests against it.

Also:
- Have ubuntu integration tests download and run against the uploaded
deb package.

closes #618 