### PR TITLE
Ingest Auto Refresh

### DIFF
--- a/src/css/_info-notice.scss
+++ b/src/css/_info-notice.scss
@@ -24,8 +24,7 @@
   align-items: center;
   @include label-normal;
   bottom: 48px;
-  animation: popup 5s infinite;
-
+  animation: popup 2s;
   button {
     margin: 0 6px;
   }

--- a/src/css/_info-notice.scss
+++ b/src/css/_info-notice.scss
@@ -56,12 +56,10 @@
   box-shadow: inset 0 0 0 0.5px darken($color, 10%),
     inset 0 1px 0 0 rgba(255, 255, 255, 0.5), 0 0.5px 1px 0 rgba(0, 0, 0, 0.15);
 
-  outline: none;
   letter-spacing: 0.5px;
   &:active {
     background: darken($color, 8%);
     box-shadow: none;
-    outline: none;
   }
 }
 

--- a/src/css/_info-notice.scss
+++ b/src/css/_info-notice.scss
@@ -11,7 +11,6 @@
 .info-notice {
   white-space: nowrap;
   user-select: none;
-  background: white;
   background: $gray-5;
   color: white;
   border-radius: 8px;

--- a/src/css/_info-notice.scss
+++ b/src/css/_info-notice.scss
@@ -1,0 +1,71 @@
+.info-notice-wrapper {
+  display: flex;
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  justify-content: center;
+  height: 100px;
+}
+
+.info-notice {
+  white-space: nowrap;
+  user-select: none;
+  background: white;
+  background: $gray-5;
+  color: white;
+  border-radius: 8px;
+  height: 32px;
+  padding: 0px 4px;
+  padding-left: 24px;
+  box-shadow: 0 2px 3px 0px rgba(0, 0, 0, 0.4),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  @include label-normal;
+  bottom: 48px;
+  animation: popup 5s infinite;
+
+  button {
+    margin: 0 6px;
+  }
+  .x-button {
+    margin-left: 12px;
+  }
+}
+
+@keyframes popup {
+  from {
+    transform: translateY(100px);
+  }
+
+  20% {
+    transform: translateY(0px);
+  }
+
+  to {
+    transform: translateY(0px);
+  }
+}
+
+@mixin bevel-button($color, $text-color: white) {
+  color: $text-color;
+  @include label-normal;
+  background: linear-gradient($color, darken($color, 4%));
+  border: none;
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 0.5px darken($color, 10%),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.5), 0 0.5px 1px 0 rgba(0, 0, 0, 0.15);
+
+  outline: none;
+  letter-spacing: 0.5px;
+  &:active {
+    background: darken($color, 8%);
+    box-shadow: none;
+    outline: none;
+  }
+}
+
+.bevel-button {
+  @include bevel-button($blue);
+}

--- a/src/css/_x-button.scss
+++ b/src/css/_x-button.scss
@@ -1,0 +1,34 @@
+.x-button {
+  background: none;
+  border: none;
+  width: 23px;
+  height: 23px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 17px;
+  padding: 0;
+  position: relative;
+  user-select: none;
+  border-radius: 2px;
+  outline: none;
+  svg {
+    width: 9px;
+    height: 9px;
+    fill: darken(white, 30%);
+  }
+
+  &:hover {
+    svg {
+      fill: white;
+    }
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  &:active {
+    svg {
+      fill: darken(white, 30%);
+    }
+    background: rgba(255, 255, 255, 0.1);
+  }
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -121,6 +121,7 @@
 @import "load-files-input";
 @import "ingest-warnings-modal";
 @import "log-detail-window";
-
 /* Common */
 @import "history-buttons";
+@import "info-notice";
+@import "x-button";

--- a/src/js/brim/space.js
+++ b/src/js/brim/space.js
@@ -37,10 +37,10 @@ export default function space(info: Space) {
       return [from, to]
     },
     ingesting() {
-      return isNumber(info.ingest_progress)
+      return isNumber(info.ingest.progress)
     },
     ingestProgress() {
-      return isNumber(info.ingest_progress) ? info.ingest_progress : 0
+      return isNumber(info.ingest.progress) ? info.ingest.progress : 0
     },
     queryable() {
       return !(this.ingesting() && this.empty())

--- a/src/js/brim/space.test.js
+++ b/src/js/brim/space.test.js
@@ -1,20 +1,20 @@
 /* @flow */
 import brim from "./"
+import fixtures from "../test/fixtures"
 
-let space = {
-  name: "myspace",
-  min_time: {sec: 1425565512, ns: 943615000},
-  max_time: {sec: 1428917684, ns: 732650001},
-  packet_support: true,
-  ingest_progress: null,
-  ingest_warnings: []
-}
+let space = fixtures("space1")
 
 test("default time span is 30 mins before max time", () => {
   let span = brim.space(space).defaultSpanArgs()
   expect(span).toEqual([
-    {sec: 1428915885, ns: 0},
-    {sec: 1428917685, ns: 0}
+    {
+      sec: 1428915994,
+      ns: 0
+    },
+    {
+      sec: 1428917794,
+      ns: 0
+    }
   ])
 })
 

--- a/src/js/components/App.js
+++ b/src/js/components/App.js
@@ -1,8 +1,7 @@
 /* @flow */
 
 import {useDispatch, useSelector} from "react-redux"
-import React, {useEffect, useState} from "react"
-import classNames from "classnames"
+import React, {useEffect} from "react"
 
 import {ipcRenderer} from "electron"
 
@@ -14,15 +13,10 @@ import SettingsModal from "./SettingsModal"
 import View from "../state/View"
 import brim from "../brim"
 import refreshSpaceNames from "../flows/refreshSpaceNames"
-import useListener from "./hooks/useListener"
 
 export default function App() {
   brim.time.setZone(useSelector(View.getTimeZone))
-  let [mouse, setMouse] = useState(true)
   let dispatch = useDispatch()
-
-  useListener(document, "mousedown", () => setMouse(true))
-  useListener(document, "keydown", () => setMouse(false))
 
   useEffect(() => {
     dispatch(refreshSpaceNames())
@@ -30,12 +24,7 @@ export default function App() {
   }, [])
 
   return (
-    <div
-      className={classNames("app-wrapper", {
-        "using-mouse": mouse,
-        "using-keyboard": !mouse
-      })}
-    >
+    <div className="app-wrapper">
       <div className="title-bar-drag-area" />
       <XLatestError />
       <ClusterGate />

--- a/src/js/components/InfoNotice.js
+++ b/src/js/components/InfoNotice.js
@@ -5,13 +5,17 @@ import ReactDOM from "react-dom"
 import XButton from "./XButton"
 import lib from "../lib"
 
-export default function InfoNotice() {
+type Props = {|onClick: (number) => void|}
+
+export default function InfoNotice({onClick}: Props) {
   return ReactDOM.createPortal(
     <div className="info-notice-wrapper">
       <div className="info-notice">
         More data is now available.
-        <button className="bevel-button">Refresh</button>
-        <XButton />
+        <button className="bevel-button" onClick={() => onClick(0)}>
+          Refresh
+        </button>
+        <XButton onClick={() => onClick(1)} />
       </div>
     </div>,
     lib.doc.id("tooltip-root")

--- a/src/js/components/InfoNotice.js
+++ b/src/js/components/InfoNotice.js
@@ -1,0 +1,19 @@
+/* @flow */
+import React from "react"
+import ReactDOM from "react-dom"
+
+import XButton from "./XButton"
+import lib from "../lib"
+
+export default function InfoNotice() {
+  return ReactDOM.createPortal(
+    <div className="info-notice-wrapper">
+      <div className="info-notice">
+        More data is now available.
+        <button className="bevel-button">Refresh</button>
+        <XButton />
+      </div>
+    </div>,
+    lib.doc.id("tooltip-root")
+  )
+}

--- a/src/js/components/IngestRefresh.js
+++ b/src/js/components/IngestRefresh.js
@@ -1,34 +1,82 @@
 /* @flow */
+
+/* INGEST AUTO REFRESH
+
+If the tab history is empty, this component submits the current search. This
+happens the first time this tab is rendered after a file is dragged in.
+
+As the files are ingested the backend incrememnts a snapshot_counter to
+indicate that more data is available to search.
+
+Everytime space.ingest.snapshot is incremented, this component will effectively
+hit the "Enter" key for the user if all these conditions are met:
+
+* There is only 1 entry in the tab history
+* The search bar inputs are in the same state as that first entry
+* The current snapshot has not yet been acknowledged
+
+If anyone of those is not true, then the component renders a message box to
+allow the user to manually refresh if they want. This box appears when
+
+* Any of the above conditions are not met
+* The current snapshot has not yet been acknowledged
+
+The snapshot is acknowledged when any of these events happen:
+* A search is submitted
+* The user presses the "x" button on the message box.
+*/
+
+import {isEqual} from "lodash"
 import {useDispatch, useSelector} from "react-redux"
 import React, {useEffect, useState} from "react"
 
+import History from "../state/History"
 import InfoNotice from "./InfoNotice"
 import Search from "../state/Search"
 import Tab from "../state/Tab"
 import brim from "../brim"
 import submitSearch from "../flows/submitSearch"
+import useThrottle from "./hooks/useThrottle"
 
 export default function IngestRefresh() {
   let dispatch = useDispatch()
-  let firstVisit = !useSelector(Tab.currentEntry)
+  let historyCount = useSelector(History.count)
+  let firstSearch = useSelector(History.first)
+  let nextSearch = useSelector(Search.getCurrentRecord)
   let space = useSelector(Tab.space)
-  let [ack, setAck] = useState(space.ingest.snapshot)
+  let snapshot = useThrottle(space.ingest.snapshot, 3000)
+  let [snapshotAck, setSnapshotAck] = useState(snapshot)
+  let ack = () => setSnapshotAck(snapshot)
+  let autoRefresh =
+    historyCount === 1 &&
+    isEqual(firstSearch, nextSearch) &&
+    snapshot !== snapshotAck
 
   useEffect(() => {
-    if (firstVisit) {
+    ack()
+    if (historyCount === 0) {
       dispatch(Search.setSpanArgs(brim.space(space).everythingSpan()))
       dispatch(submitSearch())
     }
-  }, [firstVisit])
+  }, [historyCount])
 
-  function onClick(index) {
-    setAck(space.ingest.snapshot)
-    if (index === 0) dispatch(submitSearch())
-  }
+  useEffect(() => {
+    if (autoRefresh) {
+      ack()
+      dispatch(submitSearch(false))
+    }
+  }, [autoRefresh])
 
-  if (ack === space.ingest.snapshot) {
-    return null
+  if (!autoRefresh && snapshot !== snapshotAck) {
+    return (
+      <InfoNotice
+        onClick={(buttonIndex) => {
+          ack()
+          if (buttonIndex === 0) dispatch(submitSearch(false))
+        }}
+      />
+    )
   } else {
-    return <InfoNotice onClick={onClick} />
+    return null
   }
 }

--- a/src/js/components/IngestRefresh.js
+++ b/src/js/components/IngestRefresh.js
@@ -1,0 +1,34 @@
+/* @flow */
+import {useDispatch, useSelector} from "react-redux"
+import React, {useEffect, useState} from "react"
+
+import InfoNotice from "./InfoNotice"
+import Search from "../state/Search"
+import Tab from "../state/Tab"
+import brim from "../brim"
+import submitSearch from "../flows/submitSearch"
+
+export default function IngestRefresh() {
+  let dispatch = useDispatch()
+  let firstVisit = !useSelector(Tab.currentEntry)
+  let space = useSelector(Tab.space)
+  let [ack, setAck] = useState(space.ingest.snapshot)
+
+  useEffect(() => {
+    if (firstVisit) {
+      dispatch(Search.setSpanArgs(brim.space(space).everythingSpan()))
+      dispatch(submitSearch())
+    }
+  }, [firstVisit])
+
+  function onClick(index) {
+    setAck(space.ingest.snapshot)
+    if (index === 0) dispatch(submitSearch())
+  }
+
+  if (ack === space.ingest.snapshot) {
+    return null
+  } else {
+    return <InfoNotice onClick={onClick} />
+  }
+}

--- a/src/js/components/TabSearch.js
+++ b/src/js/components/TabSearch.js
@@ -1,34 +1,19 @@
 /* @flow */
-import {useDispatch, useSelector} from "react-redux"
-import React, {useEffect} from "react"
+import React from "react"
 
 import {DebugModal} from "./DebugModal"
 import {XDownloadProgress} from "./DownloadProgress"
 import ControlBar from "./ControlBar"
 import CurlModal from "./CurlModal"
 import EmptySpaceModal from "./EmptySpaceModal"
+import IngestRefresh from "./IngestRefresh"
 import IngestWarningsModal from "./IngestWarningsModal"
-import Search from "../state/Search"
 import SearchHeaderChart from "./SearchHeaderChart"
 import SearchResults from "./SearchResults/SearchResults"
-import Tab from "../state/Tab"
 import WhoisModal from "./WhoisModal"
 import ZQModal from "./ZQModal"
-import brim from "../brim"
-import submitSearch from "../flows/submitSearch"
 
 export default function TabSearch() {
-  let dispatch = useDispatch()
-  let firstVisit = !useSelector(Tab.currentEntry)
-  let space = useSelector(Tab.space)
-
-  useEffect(() => {
-    if (firstVisit) {
-      dispatch(Search.setSpanArgs(brim.space(space).everythingSpan()))
-      dispatch(submitSearch())
-    }
-  }, [firstVisit])
-
   return (
     <>
       <div className="search-page-header">
@@ -43,6 +28,7 @@ export default function TabSearch() {
       <ZQModal />
       <XDownloadProgress />
       <IngestWarningsModal />
+      <IngestRefresh />
     </>
   )
 }

--- a/src/js/components/TabWelcome.js
+++ b/src/js/components/TabWelcome.js
@@ -1,9 +1,11 @@
 /* @flow */
 import {useDispatch, useSelector} from "react-redux"
 import React, {useEffect} from "react"
+
 import remote from "electron"
 
 import BrimTextLogo from "./BrimTextLogo"
+import History from "../state/History"
 import LoadFilesInput from "./LoadFilesInput"
 import SavedSpacesList from "./SavedSpacesList"
 import SpaceDeletedNotice from "./SpaceDeletedNotice"
@@ -20,6 +22,7 @@ export default function TabWelcome() {
 
   useEffect(() => {
     dispatch(refreshSpaceNames())
+    dispatch(History.clear())
   }, [])
 
   function onChange(_e, files) {

--- a/src/js/components/XButton.js
+++ b/src/js/components/XButton.js
@@ -1,0 +1,12 @@
+/* @flow */
+import React from "react"
+
+import X from "./icons/x-md.svg"
+
+export default function XButton(rest: *) {
+  return (
+    <button {...rest} className="x-button">
+      <X />
+    </button>
+  )
+}

--- a/src/js/components/hooks/useThrottle.js
+++ b/src/js/components/hooks/useThrottle.js
@@ -1,0 +1,32 @@
+/* @flow */
+import {useEffect, useRef, useState} from "react"
+
+export default function(value: *, wait: number) {
+  let [state, setState] = useState(value)
+  let timeout = useRef(null)
+  let pending = useRef(false)
+  let nextValue = useRef(null)
+
+  useEffect(() => {
+    if (!timeout.current) {
+      setState(value)
+
+      let callback = () => {
+        if (pending.current) {
+          pending.current = false
+          setState(nextValue.current)
+          timeout.current = setTimeout(callback, wait)
+        } else {
+          timeout.current = undefined
+        }
+      }
+
+      timeout.current = setTimeout(callback, wait)
+    } else {
+      pending.current = true
+      nextValue.current = value
+    }
+  }, [value])
+
+  return state
+}

--- a/src/js/flows/ingestFiles.js
+++ b/src/js/flows/ingestFiles.js
@@ -61,7 +61,12 @@ const createDir = () => ({
 const createSpace = (client, dispatch, clusterId) => ({
   async do(params) {
     let {name} = await client.spaces.create({data_dir: params.dataDir})
-    dispatch(Spaces.setDetail(clusterId, {name}))
+    dispatch(
+      Spaces.setDetail(clusterId, {
+        name,
+        ingest: {progress: 0, snapshot: 0, warnings: []}
+      })
+    )
     return {...params, name}
   },
   async undo({name}) {

--- a/src/js/flows/ingestFiles.js
+++ b/src/js/flows/ingestFiles.js
@@ -29,7 +29,7 @@ export default (
     await lib.transaction([
       validateInput(paths),
       createDir(),
-      createSpace(client),
+      createSpace(client, gDispatch, clusterId),
       registerHandler(dispatch, requestId),
       postFiles(client),
       setSpace(dispatch, tabId),
@@ -58,13 +58,15 @@ const createDir = () => ({
   }
 })
 
-const createSpace = (client) => ({
+const createSpace = (client, dispatch, clusterId) => ({
   async do(params) {
     let {name} = await client.spaces.create({data_dir: params.dataDir})
+    dispatch(Spaces.setDetail(clusterId, {name}))
     return {...params, name}
   },
   async undo({name}) {
     await client.spaces.delete(name)
+    dispatch(Spaces.remove(clusterId, name))
   }
 })
 

--- a/src/js/flows/ingestFiles.test.js
+++ b/src/js/flows/ingestFiles.test.js
@@ -2,6 +2,7 @@
 import fsExtra from "fs-extra"
 
 import Notice from "../state/Notice"
+import Spaces from "../state/Spaces"
 import Tab from "../state/Tab"
 import ingestFiles from "./ingestFiles"
 import initTestStore from "../test/initTestStore"
@@ -11,6 +12,7 @@ let mockClient = {
   spaces: {
     create: () => Promise.resolve({name: "dataSpace"}),
     list: () => Promise.resolve(["dataSpace"]),
+    delete: () => Promise.resolve(),
     get: () =>
       Promise.resolve({
         name: "dataSpace",
@@ -50,8 +52,10 @@ test("opening a packet", async () => {
     min_time: {ns: 0, sec: 0},
     max_time: {ns: 1, sec: 1},
     packet_support: true,
-    ingest_progress: null,
-    ingest_warnings: []
+    ingest: {
+      progress: null,
+      warnings: []
+    }
   })
 
   return fsExtra.remove("tmp")
@@ -69,6 +73,8 @@ test("when there is an error", async () => {
   )
 
   let state = store.getState()
+  let cluster = Tab.clusterId(state)
+  expect(Spaces.getSpaces(cluster)(state)).toEqual([])
   expect(Tab.spaceName(state)).toEqual("")
   expect(Notice.getError(state)).toEqual({
     details: ["Detail: Boom"],

--- a/src/js/flows/ingestFiles.test.js
+++ b/src/js/flows/ingestFiles.test.js
@@ -54,7 +54,8 @@ test("opening a packet", async () => {
     packet_support: true,
     ingest: {
       progress: null,
-      warnings: []
+      warnings: [],
+      snapshot: 1
     }
   })
 

--- a/src/js/flows/rightclick/cellMenu.test.js
+++ b/src/js/flows/rightclick/cellMenu.test.js
@@ -3,6 +3,7 @@
 import type {MenuItem} from "electron"
 
 import {conn, dns} from "../../test/mockLogs"
+import fixtures from "../../test/fixtures"
 import menu from "../../electron/menu"
 
 function menuText(menu: MenuItem) {
@@ -11,14 +12,7 @@ function menuText(menu: MenuItem) {
     .map((item) => item.label)
     .join(", ")
 }
-const space = {
-  name: "default",
-  min_time: {sec: 1425564900, ns: 0},
-  max_time: {sec: 1428917793, ns: 750000000},
-  packet_support: true,
-  ingest_progress: null,
-  ingest_warnings: []
-}
+const space = fixtures("space1")
 
 describe("Log Right Click", () => {
   const program = "*"

--- a/src/js/initializers/initDetail.js
+++ b/src/js/initializers/initDetail.js
@@ -2,20 +2,21 @@
 
 import {ipcRenderer} from "electron"
 
+import {viewLogDetail} from "../flows/viewLogDetail"
+import LogDetails from "../state/LogDetails"
+import Search from "../state/Search/actions"
+import Tab from "../state/Tab"
+import brim from "../brim"
 import closeWindow from "../flows/closeWindow"
 import initBoom from "./initBoom"
+import initDOM from "./initDOM"
+import initMenuActionListeners from "./initMenuActionListeners"
 import initQueryParams, {getQueryParams} from "./initQueryParams"
 import initStore from "./initStore"
+import initUserInputClasses from "./initUserInputClasses"
 import invoke from "../electron/ipc/invoke"
 import ipc from "../electron/ipc"
 import refreshWindow from "../flows/refreshWindow"
-import initDOM from "./initDOM"
-import {viewLogDetail} from "../flows/viewLogDetail"
-import LogDetails from "../state/LogDetails"
-import initMenuActionListeners from "./initMenuActionListeners"
-import Tab from "../state/Tab"
-import brim from "../brim"
-import Search from "../state/Search/actions"
 
 let {id} = getQueryParams()
 
@@ -30,6 +31,7 @@ export default () => {
     let dispatch = store.dispatch
 
     initDOM("detail-root")
+    initUserInputClasses()
     initQueryParams(store)
     initMenuActionListeners(dispatch)
 

--- a/src/js/initializers/initPersistance.js
+++ b/src/js/initializers/initPersistance.js
@@ -5,7 +5,7 @@ import throttle from "lodash/throttle"
 
 import type {State} from "../state/types"
 
-export const VERSION = "6"
+export const VERSION = "7"
 
 export function isCurrentVersion(state: *) {
   return state && state.version === VERSION

--- a/src/js/initializers/initSearch.js
+++ b/src/js/initializers/initSearch.js
@@ -8,13 +8,14 @@ import initBoom from "./initBoom"
 import initDOM from "./initDOM"
 import initGlobalStore from "./initGlobalStore"
 import initMenuActionListeners from "./initMenuActionListeners"
+import initNewSearchTab from "./initNewSearchTab"
 import initQueryParams, {getQueryParams} from "./initQueryParams"
 import initShortcuts from "./initShortcuts"
 import initStore from "./initStore"
+import initUserInputClasses from "./initUserInputClasses"
 import invoke from "../electron/ipc/invoke"
 import ipc from "../electron/ipc"
 import refreshWindow from "../flows/refreshWindow"
-import initNewSearchTab from "./initNewSearchTab"
 
 let {id} = getQueryParams()
 
@@ -32,6 +33,7 @@ export default () => {
     let dispatch = store.dispatch
 
     initDOM("app-root")
+    initUserInputClasses()
     initShortcuts(store)
     initMenuActionListeners(dispatch)
     initQueryParams(store)

--- a/src/js/initializers/initUserInputClasses.js
+++ b/src/js/initializers/initUserInputClasses.js
@@ -1,0 +1,15 @@
+/* @flow */
+export default function() {
+  document.addEventListener("mousedown", () => {
+    let el = document.body
+    if (!el) return
+    el.classList.add("using-mouse")
+    el.classList.remove("using-keyboard")
+  })
+  document.addEventListener("keydown", () => {
+    let el = document.body
+    if (!el) return
+    el.classList.add("using-keyboard")
+    el.classList.remove("using-mouse")
+  })
+}

--- a/src/js/state/History/selectors.js
+++ b/src/js/state/History/selectors.js
@@ -1,11 +1,14 @@
 /* @flow */
 
 import type {TabState} from "../Tab/types"
+import activeTabSelect from "../Tab/activeTabSelect"
 import brim from "../../brim"
 
 export default {
   prev: (state: TabState) => state.history.entries[state.history.position - 1],
   current: (state: TabState) => state.history.entries[state.history.position],
   canGoBack: (state: TabState) => brim.entries(state.history).canGoBack(),
-  canGoForward: (state: TabState) => brim.entries(state.history).canGoForward()
+  canGoForward: (state: TabState) => brim.entries(state.history).canGoForward(),
+  first: activeTabSelect((state: TabState) => state.history.entries[0]),
+  count: activeTabSelect((state: TabState) => state.history.entries.length)
 }

--- a/src/js/state/Search/selectors.js
+++ b/src/js/state/Search/selectors.js
@@ -19,6 +19,15 @@ export default {
     }
   },
 
+  getCurrentRecord: (state: State): SearchRecord => {
+    return {
+      program: SearchBar.getSearchBar(state).current,
+      pins: SearchBar.getSearchBar(state).pinned,
+      spanArgs: Tab.getSpanArgs(state),
+      space: Tab.spaceName(state)
+    }
+  },
+
   getArgs: (state: State): SearchArgs => {
     let program = SearchBar.getSearchProgram(state)
     let span = Tab.getSpanAsDates(state)

--- a/src/js/state/Spaces/actions.js
+++ b/src/js/state/Spaces/actions.js
@@ -6,6 +6,7 @@ import type {
   SPACES_INGEST_WARNING_APPEND,
   SPACES_INGEST_WARNING_CLEAR,
   SPACES_NAMES,
+  SPACES_REMOVE,
   Space
 } from "./types"
 
@@ -30,32 +31,32 @@ export default {
 
   setIngestProgress: (
     clusterId: string,
-    space: string,
+    name: string,
     value: number | null
   ): SPACES_INGEST_PROGRESS => ({
     type: "SPACES_INGEST_PROGRESS",
     clusterId,
-    space,
+    name,
     value
   }),
 
   appendIngestWarning: (
     clusterId: string,
-    space: string,
+    name: string,
     warning: string
   ): SPACES_INGEST_WARNING_APPEND => ({
     type: "SPACES_INGEST_WARNING_APPEND",
     clusterId,
-    space,
+    name,
     warning
   }),
 
   clearIngestWarnings: (
     clusterId: string,
-    space: string
+    name: string
   ): SPACES_INGEST_WARNING_CLEAR => ({
     type: "SPACES_INGEST_WARNING_CLEAR",
     clusterId,
-    space
+    name
   })
 }

--- a/src/js/state/Spaces/actions.js
+++ b/src/js/state/Spaces/actions.js
@@ -9,6 +9,7 @@ import type {
   SPACES_REMOVE,
   Space
 } from "./types"
+import type {SpaceDetailPayload} from "../../services/zealot/types"
 
 export default {
   setNames: (clusterId: string, names: string[]): SPACES_NAMES => ({
@@ -17,7 +18,10 @@ export default {
     names: names || []
   }),
 
-  setDetail: (clusterId: string, space: $Shape<Space>): SPACES_DETAIL => ({
+  setDetail: (
+    clusterId: string,
+    space: $Shape<Space> | SpaceDetailPayload
+  ): SPACES_DETAIL => ({
     type: "SPACES_DETAIL",
     clusterId,
     space

--- a/src/js/state/Spaces/actions.js
+++ b/src/js/state/Spaces/actions.js
@@ -5,9 +5,9 @@ import type {
   SPACES_INGEST_PROGRESS,
   SPACES_INGEST_WARNING_APPEND,
   SPACES_INGEST_WARNING_CLEAR,
-  SPACES_NAMES
+  SPACES_NAMES,
+  Space
 } from "./types"
-import type {SpaceDetailPayload} from "../../services/zealot/types"
 
 export default {
   setNames: (clusterId: string, names: string[]): SPACES_NAMES => ({
@@ -16,10 +16,16 @@ export default {
     names: names || []
   }),
 
-  setDetail: (clusterId: string, space: SpaceDetailPayload): SPACES_DETAIL => ({
+  setDetail: (clusterId: string, space: $Shape<Space>): SPACES_DETAIL => ({
     type: "SPACES_DETAIL",
     clusterId,
     space
+  }),
+
+  remove: (clusterId: string, name: string): SPACES_REMOVE => ({
+    type: "SPACES_REMOVE",
+    clusterId,
+    name
   }),
 
   setIngestProgress: (

--- a/src/js/state/Spaces/actionsFor.js
+++ b/src/js/state/Spaces/actionsFor.js
@@ -1,0 +1,37 @@
+/* @flow */
+import type {
+  SPACES_DETAIL,
+  SPACES_INGEST_SNAPSHOT,
+  SPACES_REMOVE
+} from "./types"
+import actions from "./actions"
+
+export default function actionsFor(clusterId: string, name: string) {
+  return {
+    setIngestProgress: (value: number) => {
+      return actions.setIngestProgress(clusterId, name, value)
+    },
+    appendIngestWarning: (warning: string) => {
+      return actions.appendIngestWarning(clusterId, name, warning)
+    },
+    clearIngestWarnings: () => {
+      return actions.clearIngestWarnings(clusterId, name)
+    },
+    setIngestSnapshot: (count: number): SPACES_INGEST_SNAPSHOT => ({
+      type: "SPACES_INGEST_SNAPSHOT",
+      clusterId,
+      name,
+      count
+    }),
+    remove: (): SPACES_REMOVE => ({
+      type: "SPACES_REMOVE",
+      clusterId,
+      name
+    }),
+    create: (): SPACES_DETAIL => ({
+      type: "SPACES_DETAIL",
+      clusterId,
+      space: {name}
+    })
+  }
+}

--- a/src/js/state/Spaces/actionsFor.js
+++ b/src/js/state/Spaces/actionsFor.js
@@ -8,7 +8,7 @@ import actions from "./actions"
 
 export default function actionsFor(clusterId: string, name: string) {
   return {
-    setIngestProgress: (value: number) => {
+    setIngestProgress: (value: number | null) => {
       return actions.setIngestProgress(clusterId, name, value)
     },
     appendIngestWarning: (warning: string) => {

--- a/src/js/state/Spaces/index.js
+++ b/src/js/state/Spaces/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import actionsFor from "./actionsFor"
 import actions from "./actions"
 import reducer from "./reducer"
 import selectors from "./selectors"
@@ -7,5 +8,6 @@ import selectors from "./selectors"
 export default {
   ...actions,
   ...selectors,
+  actionsFor,
   reducer
 }

--- a/src/js/state/Spaces/reducer.js
+++ b/src/js/state/Spaces/reducer.js
@@ -3,7 +3,7 @@
 import produce from "immer"
 
 import brim from "../../brim"
-import type {SpacesAction, SpacesState} from "./types"
+import type {Space, SpacesAction, SpacesState} from "./types"
 
 const init: SpacesState = {}
 
@@ -25,15 +25,19 @@ const spacesReducer = produce((draft, action: SpacesAction) => {
       break
 
     case "SPACES_INGEST_PROGRESS":
-      getSpace(draft, action.space).ingest.progress = action.value
+      getSpace(draft, action.name).ingest.progress = action.value
       break
 
     case "SPACES_INGEST_WARNING_APPEND":
-      getSpace(draft, action.space).ingest.warnings.push(action.warning)
+      getSpace(draft, action.name).ingest.warnings.push(action.warning)
       break
 
     case "SPACES_INGEST_WARNING_CLEAR":
-      getSpace(draft, action.space).ingest.warnings = []
+      getSpace(draft, action.name).ingest.warnings = []
+      break
+
+    case "SPACES_INGEST_SNAPSHOT":
+      getSpace(draft, action.name).ingest.snapshot = action.count
       break
 
     case "SPACES_REMOVE":
@@ -56,7 +60,7 @@ export default function reducer(
   }
 }
 
-function defaults(name, data = {}) {
+function defaults(name, data: $Shape<Space> = {}): Space {
   let defaults = {
     name,
     min_time: {ns: 0, sec: 0},
@@ -65,6 +69,7 @@ function defaults(name, data = {}) {
     ingest: {
       progress: null,
       warnings: [],
+      snapshot: null,
       ...data.ingest
     }
   }

--- a/src/js/state/Spaces/selectors.js
+++ b/src/js/state/Spaces/selectors.js
@@ -30,6 +30,11 @@ export default {
     let space = cluster[name]
     if (space) return space.ingest.warnings
     else return []
+  },
+  getIngestSnapshot: (clusterId: string, name: string) => (state: State) => {
+    let cluster = getCluster(state, clusterId)
+    let space = cluster[name]
+    if (space) return space.ingest.snapshot
   }
 }
 

--- a/src/js/state/Spaces/selectors.js
+++ b/src/js/state/Spaces/selectors.js
@@ -20,14 +20,15 @@ export default {
     })
   },
   getIngestProgress: (clusterId: string, name: string) => (state: State) => {
-    let clus = getCluster(state, clusterId)
-    let space = clus[name]
-    if (space) return space.ingest_progress
+    let cluster = getCluster(state, clusterId)
+    let space = cluster[name]
+    if (space) return space.ingest.progress
+    else return null
   },
   getIngestWarnings: (clusterId: string, name: string) => (state: State) => {
     let cluster = getCluster(state, clusterId)
     let space = cluster[name]
-    if (space) return space.ingest_warnings || []
+    if (space) return space.ingest.warnings
     else return []
   }
 }

--- a/src/js/state/Spaces/test.js
+++ b/src/js/state/Spaces/test.js
@@ -62,10 +62,8 @@ test("setting the ingest progress throws error if no space yet", () => {
 })
 
 test("setting the ingest progress", () => {
-  store.dispatchAll([
-    Spaces.setDetail("cluster1", detail),
-    Spaces.setIngestProgress("cluster1", detail.name, 0.5)
-  ])
+  let actions = Spaces.actionsFor("cluster1", detail.name)
+  store.dispatchAll([actions.create(), actions.setIngestProgress(0.5)])
 
   let value = Spaces.getIngestProgress(
     "cluster1",
@@ -106,10 +104,11 @@ test("only cares about spaces actions", () => {
 })
 
 test("ingest warnings", () => {
+  let actions = Spaces.actionsFor("cluster1", detail.name)
   let state = store.dispatchAll([
-    Spaces.setDetail("cluster1", detail),
-    Spaces.appendIngestWarning("cluster1", detail.name, "Problem 1"),
-    Spaces.appendIngestWarning("cluster1", detail.name, "Problem 2")
+    actions.create(),
+    actions.appendIngestWarning("Problem 1"),
+    actions.appendIngestWarning("Problem 2")
   ])
 
   expect(Spaces.getIngestWarnings("cluster1", detail.name)(state)).toEqual([
@@ -119,21 +118,32 @@ test("ingest warnings", () => {
 })
 
 test("clear warnings", () => {
+  let actions = Spaces.actionsFor("cluster1", detail.name)
   let state = store.dispatchAll([
-    Spaces.setDetail("cluster1", detail),
-    Spaces.appendIngestWarning("cluster1", detail.name, "Problem 1"),
-    Spaces.appendIngestWarning("cluster1", detail.name, "Problem 2"),
-    Spaces.clearIngestWarnings("cluster1", detail.name)
+    actions.create(),
+    actions.appendIngestWarning("Problem 1"),
+    actions.appendIngestWarning("Problem 2"),
+    actions.clearIngestWarnings()
   ])
 
   expect(Spaces.getIngestWarnings("cluster1", detail.name)(state)).toEqual([])
 })
 
 test("remove space", () => {
-  let state = store.dispatchAll([
-    Spaces.setDetail("cluster1", detail),
-    Spaces.remove("cluster1", detail.name)
-  ])
+  let actions = Spaces.actionsFor("cluster1", detail.name)
+
+  let state = store.dispatchAll([actions.create(), actions.remove()])
 
   expect(Spaces.getSpaces("cluster1")(state)).toEqual([])
+})
+
+test("setting the spanshot counter", () => {
+  let actions = Spaces.actionsFor("cluster1", detail.name)
+
+  let state = store.dispatchAll([
+    actions.create(),
+    actions.setIngestSnapshot(1)
+  ])
+
+  expect(Spaces.getIngestSnapshot("cluster1", detail.name)(state)).toBe(1)
 })

--- a/src/js/state/Spaces/test.js
+++ b/src/js/state/Spaces/test.js
@@ -50,7 +50,8 @@ test("setting the space detail adds the defaults", () => {
     max_time: {sec: 1428917793, ns: 750000000},
     ingest: {
       progress: null,
-      warnings: []
+      warnings: [],
+      snapshot: null
     }
   })
 })
@@ -86,14 +87,14 @@ test("getting the spaces with details, others not", () => {
       max_time: {ns: 750000000, sec: 1428917793},
       min_time: {ns: 0, sec: 1425564900},
       packet_support: true,
-      ingest: {warnings: [], progress: null}
+      ingest: {warnings: [], progress: null, snapshot: null}
     },
     {
       name: "space-b",
       max_time: {ns: 0, sec: 0},
       min_time: {ns: 0, sec: 0},
       packet_support: false,
-      ingest: {warnings: [], progress: null}
+      ingest: {warnings: [], progress: null, snapshot: null}
     }
   ])
 })

--- a/src/js/state/Spaces/test.js
+++ b/src/js/state/Spaces/test.js
@@ -40,11 +40,6 @@ test("setting the space detail adds the defaults", () => {
 
   expect(Spaces.get("cluster1", "default")(state)).toEqual({
     name: "default",
-    // <<<<<<< HEAD
-    //     max_time: {ns: 750000000, sec: 1428917793},
-    //     min_time: {ns: 0, sec: 1425564900},
-    //     packet_support: true
-    // =======
     packet_support: true,
     min_time: {sec: 1425564900, ns: 0},
     max_time: {sec: 1428917793, ns: 750000000},

--- a/src/js/state/Spaces/types.js
+++ b/src/js/state/Spaces/types.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import type {SpaceDetailPayload} from "../../services/zealot/types"
 import type {Ts} from "../../brim"
 
 export type SpacesState = {
@@ -42,7 +43,7 @@ export type SPACES_NAMES = {
 export type SPACES_DETAIL = {
   type: "SPACES_DETAIL",
   clusterId: string,
-  space: $Shape<Space>
+  space: $Shape<Space> | SpaceDetailPayload
 }
 
 export type SPACES_INGEST_PROGRESS = {

--- a/src/js/state/Spaces/types.js
+++ b/src/js/state/Spaces/types.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import type {SpaceDetailPayload} from "../../services/zealot/types"
 import type {Ts} from "../../brim"
 
 export type SpacesState = {
@@ -17,14 +16,19 @@ export type SpacesAction =
   | SPACES_INGEST_PROGRESS
   | SPACES_INGEST_WARNING_APPEND
   | SPACES_INGEST_WARNING_CLEAR
+  | SPACES_REMOVE
 
 export type Space = {
   name: string,
   min_time: Ts,
   max_time: Ts,
   packet_support: boolean,
-  ingest_progress: number | null,
-  ingest_warnings: string[]
+  ingest: SpaceIngest
+}
+
+type SpaceIngest = {
+  warnings: string[],
+  progress: number | null
 }
 
 export type SPACES_NAMES = {
@@ -36,7 +40,7 @@ export type SPACES_NAMES = {
 export type SPACES_DETAIL = {
   type: "SPACES_DETAIL",
   clusterId: string,
-  space: SpaceDetailPayload
+  space: $Shape<Space>
 }
 
 export type SPACES_INGEST_PROGRESS = {
@@ -57,4 +61,10 @@ export type SPACES_INGEST_WARNING_CLEAR = {
   type: "SPACES_INGEST_WARNING_CLEAR",
   space: string,
   clusterId: string
+}
+
+export type SPACES_REMOVE = {
+  type: "SPACES_REMOVE",
+  clusterId: string,
+  name: string
 }

--- a/src/js/state/Spaces/types.js
+++ b/src/js/state/Spaces/types.js
@@ -17,6 +17,7 @@ export type SpacesAction =
   | SPACES_INGEST_WARNING_APPEND
   | SPACES_INGEST_WARNING_CLEAR
   | SPACES_REMOVE
+  | SPACES_INGEST_SNAPSHOT
 
 export type Space = {
   name: string,
@@ -28,7 +29,8 @@ export type Space = {
 
 type SpaceIngest = {
   warnings: string[],
-  progress: number | null
+  progress: number | null,
+  snapshot: number | null
 }
 
 export type SPACES_NAMES = {
@@ -46,20 +48,20 @@ export type SPACES_DETAIL = {
 export type SPACES_INGEST_PROGRESS = {
   type: "SPACES_INGEST_PROGRESS",
   clusterId: string,
-  space: string,
+  name: string,
   value: number | null
 }
 
 export type SPACES_INGEST_WARNING_APPEND = {
   type: "SPACES_INGEST_WARNING_APPEND",
   warning: string,
-  space: string,
+  name: string,
   clusterId: string
 }
 
 export type SPACES_INGEST_WARNING_CLEAR = {
   type: "SPACES_INGEST_WARNING_CLEAR",
-  space: string,
+  name: string,
   clusterId: string
 }
 
@@ -67,4 +69,10 @@ export type SPACES_REMOVE = {
   type: "SPACES_REMOVE",
   clusterId: string,
   name: string
+}
+export type SPACES_INGEST_SNAPSHOT = {
+  type: "SPACES_INGEST_SNAPSHOT",
+  clusterId: string,
+  name: string,
+  count: number
 }

--- a/src/js/test/fixtures/index.js
+++ b/src/js/test/fixtures/index.js
@@ -9,12 +9,6 @@ let fixtures = {
   },
   space1: {
     name: "default",
-    compression: "none",
-    flush_timeout: 500,
-    close_timeout: 5000,
-    slab_threshold: 131072,
-    slab_fanout: 8,
-    max_writers: 150,
     min_time: {
       sec: 1425564900,
       ns: 0
@@ -23,8 +17,8 @@ let fixtures = {
       sec: 1428917793,
       ns: 750000000
     },
-    size: 4580591172,
-    packet_support: true
+    packet_support: true,
+    ingest: {progress: null, warnings: []}
   }
 }
 


### PR DESCRIPTION

![aDVBrfBfti](https://user-images.githubusercontent.com/3460638/80637669-3c11cd00-8a14-11ea-841a-3464a404cbf5.gif)




fixes #616 

If the tab history is empty, this component submits the current search. This
happens the first time this tab is rendered after a file is dragged in.

As the files are ingested the backend incrememnts a snapshot_counter to
indicate that more data is available to search.

Everytime space.ingest.snapshot is incremented, this component will effectively
hit the "Enter" key for the user if all these conditions are met:

* There is only 1 entry in the tab history
* The search bar inputs are in the same state as that first entry
* The current snapshot has not yet been acknowledged

If anyone of those is not true, then the component renders a message box to
allow the user to manually refresh if they want. This box appears when

* Any of the above conditions are not met
* The current snapshot has not yet been acknowledged

The snapshot is acknowledged when any of these events happen:
* A search is submitted
* The user presses the "x" button on the message box.