### PR TITLE
keep brim folders inside app data

### DIFF
--- a/src/js/brim/ingest/getParams.js
+++ b/src/js/brim/ingest/getParams.js
@@ -5,6 +5,7 @@ import path from "path"
 import type {IngestFileType} from "./detectFileType"
 import fileList, {type FileListData} from "./fileList"
 import time from "../time"
+import lib from "../../lib"
 
 export type IngestParams = {
   dataDir: string,
@@ -18,8 +19,8 @@ export type IngestParamsError = {
 
 export default function getParams(
   data: FileListData,
-  home?: string = os.homedir(),
-  now?: Date = new Date()
+  home: string = os.homedir(),
+  now: Date = new Date()
 ): IngestParams | IngestParamsError {
   let files = fileList(data)
 
@@ -30,15 +31,22 @@ export default function getParams(
   }
 
   function getDataDir() {
-    if (files.oneFile()) return path.normalize(files.first().path)
+    // TODO: use user preferences when they exist https://github.com/brimsec/brim/issues/676
+    return ""
+  }
 
-    let dirName = files.inSameDir() ? files.dirName() : generateDirName(now)
+  function getSpaceName() {
+    let name
+    if (files.oneFile()) name = lib.file(files.first().path).fileName()
+    else if (files.inSameDir()) name = files.dirName()
+    else name = generateDirName(now)
 
-    return path.join(home, ".brim", dirName)
+    return name + ".brim"
   }
 
   return {
-    dataDir: getDataDir() + ".brim",
+    name: getSpaceName(),
+    dataDir: getDataDir(),
     endpoint: files.first().type,
     paths: files.paths()
   }

--- a/src/js/brim/ingest/getParams.js
+++ b/src/js/brim/ingest/getParams.js
@@ -1,7 +1,4 @@
 /* @flow */
-import os from "os"
-import path from "path"
-
 import type {IngestFileType} from "./detectFileType"
 import fileList, {type FileListData} from "./fileList"
 import time from "../time"
@@ -19,7 +16,6 @@ export type IngestParamsError = {
 
 export default function getParams(
   data: FileListData,
-  home: string = os.homedir(),
   now: Date = new Date()
 ): IngestParams | IngestParamsError {
   let files = fileList(data)

--- a/src/js/brim/ingest/test.js
+++ b/src/js/brim/ingest/test.js
@@ -1,56 +1,54 @@
 /* @flow */
-import path from "path"
-
 import ingest from "./"
 
-test("one pcap", () => {
+test("one pcap default", () => {
   let data = ingest.getParams([{type: "pcap", path: "/work/my.pcap"}])
 
   expect(data).toEqual({
-    dataDir: path.join("/work", "my.pcap.brim"),
+    dataDir: "",
+    name: "my.pcap.brim",
     endpoint: "pcap",
     paths: ["/work/my.pcap"]
   })
 })
 
-test("one zeek log", () => {
+test("one zeek log default", () => {
   let data = ingest.getParams([{type: "log", path: "/work/zeek.log"}])
 
   expect(data).toEqual({
-    dataDir: path.join("/work", "zeek.log.brim"),
+    name: "zeek.log.brim",
+    dataDir: "",
     endpoint: "log",
     paths: ["/work/zeek.log"]
   })
 })
 
-test("two zeek logs in same dir", () => {
-  let data = ingest.getParams(
-    [
-      {type: "log", path: "/work/zeek-1.log"},
-      {type: "log", path: "/work/zeek-2.log"}
-    ],
-    "/home"
-  )
+test("two zeek logs in same dir default", () => {
+  let data = ingest.getParams([
+    {type: "log", path: "/work/zeek-1.log"},
+    {type: "log", path: "/work/zeek-2.log"}
+  ])
 
   expect(data).toEqual({
-    dataDir: path.join("/home", ".brim", "work.brim"),
+    name: "work.brim",
+    dataDir: "",
     endpoint: "log",
     paths: ["/work/zeek-1.log", "/work/zeek-2.log"]
   })
 })
 
-test("two zeek logs in different dir", () => {
+test("two zeek logs in different dir default", () => {
   let data = ingest.getParams(
     [
       {type: "log", path: "/work/day-1/zeek.log"},
       {type: "log", path: "/work/day-2/zeek.log"}
     ],
-    "/home",
     new Date(0)
   )
 
   expect(data).toEqual({
-    dataDir: path.join("/home", ".brim", "zeek_1969-12-31_16:00:00.brim"),
+    name: "zeek_1969-12-31_16:00:00.brim",
+    dataDir: "",
     endpoint: "log",
     paths: ["/work/day-1/zeek.log", "/work/day-2/zeek.log"]
   })

--- a/src/js/flows/ingestFiles.js
+++ b/src/js/flows/ingestFiles.js
@@ -57,22 +57,29 @@ const validateInput = (paths) => ({
 
 const createDir = () => ({
   async do({dataDir}) {
-    await fsExtra.ensureDir(dataDir)
+    dataDir && (await fsExtra.ensureDir(dataDir))
   },
   async undo({dataDir}) {
-    await fsExtra.remove(dataDir)
+    dataDir && (await fsExtra.remove(dataDir))
   }
 })
 
 const createSpace = (client, dispatch, clusterId) => ({
   async do(params) {
-    let {name} = await client.spaces.create({data_dir: params.dataDir})
+    let createParams
+    if (params.dataDir) {
+      createParams = {data_dir: params.dataDir}
+    } else {
+      createParams = {name: params.name}
+    }
+    let {name} = await client.spaces.create(createParams)
     dispatch(
       Spaces.setDetail(clusterId, {
         name,
         ingest: {progress: 0, snapshot: 0, warnings: []}
       })
     )
+
     return {...params, name}
   },
   async undo({name}) {

--- a/src/js/flows/initSpace.js
+++ b/src/js/flows/initSpace.js
@@ -56,6 +56,7 @@ function getCurrentSpaceName(spaces, desired) {
 function setSpace(dispatch, data, clusterId) {
   globalDispatch(Spaces.setDetail(clusterId, data))
   dispatch(Search.setSpace(data.name))
+  data = brim.interop.spacePayloadToSpace(data)
   return data
 }
 

--- a/src/js/lib/file.js
+++ b/src/js/lib/file.js
@@ -90,6 +90,10 @@ export default function file(p: string) {
 
     dirName(): string {
       return path.basename(path.dirname(p))
+    },
+
+    fileName(): string {
+      return path.basename(p)
     }
   }
 }


### PR DESCRIPTION
fixes #673 

Our spaces are still named `.brim` but the internal folder we use is now stored within the app's data. I tested this in dev and also release.

![movebrimfolder](https://user-images.githubusercontent.com/14865533/80642429-54391a80-8a1b-11ea-9e98-96de8850a123.gif)
