### PR TITLE
encode space name

### DIFF
--- a/src/js/services/BoomClient/client/Descriptors.js
+++ b/src/js/services/BoomClient/client/Descriptors.js
@@ -6,14 +6,14 @@ export default class Descriptors extends SubClient {
   list(spaceName: string) {
     return this.base.send({
       method: "GET",
-      path: `/space/${spaceName}/descriptor`
+      path: `/space/${encodeURIComponent(spaceName)}/descriptor`
     })
   }
 
   get(spaceName: string, td: number | string) {
     return this.base.send({
       method: "GET",
-      path: `/space/${spaceName}/descriptor/${td}`
+      path: `/space/${encodeURIComponent(spaceName)}/descriptor/${td}`
     })
   }
 }

--- a/src/js/services/BoomClient/client/Spaces.js
+++ b/src/js/services/BoomClient/client/Spaces.js
@@ -14,7 +14,7 @@ export default class Spaces extends SubClient {
   get(name: string) {
     return this.base.send({
       method: "GET",
-      path: `/space/${name}`
+      path: `/space/${encodeURIComponent(name)}`
     })
   }
 
@@ -29,7 +29,7 @@ export default class Spaces extends SubClient {
   delete(name: string) {
     return this.base.send({
       method: "DELETE",
-      path: `/space/${name}`
+      path: `/space/${encodeURIComponent(name)}`
     })
   }
 }

--- a/src/js/services/zealot/logsApi.js
+++ b/src/js/services/zealot/logsApi.js
@@ -14,7 +14,7 @@ export default {
   post({space, paths, types}: LogsPostArgs) {
     return {
       method: "POST",
-      path: `/space/${space}/log`,
+      path: `/space/${encodeURIComponent(space)}/log`,
       body: getBody(paths, types)
     }
   }

--- a/src/js/services/zealot/pcapsApi.js
+++ b/src/js/services/zealot/pcapsApi.js
@@ -7,13 +7,13 @@ export default {
   get({space}: PcapsGetArgs) {
     return {
       method: "GET",
-      path: `/space/${space}/packet`
+      path: `/space/${encodeURIComponent(space)}/packet`
     }
   },
   post({space, path}: PcapsPostArgs) {
     return {
       method: "POST",
-      path: `/space/${space}/packet`,
+      path: `/space/${encodeURIComponent(space)}/packet`,
       body: JSON.stringify({path})
     }
   }

--- a/src/js/services/zealot/spacesApi.js
+++ b/src/js/services/zealot/spacesApi.js
@@ -10,7 +10,7 @@ export default {
   },
   get(name: string) {
     return {
-      path: `/space/${name}`,
+      path: `/space/${encodeURIComponent(name)}`,
       method: "GET"
     }
   },
@@ -23,7 +23,7 @@ export default {
   },
   delete(name: string) {
     return {
-      path: `/space/${name}`,
+      path: `/space/${encodeURIComponent(name)}`,
       method: "DELETE"
     }
   }


### PR DESCRIPTION
fixes #650 

uri encodes `space` when used as a uri path

![use#](https://user-images.githubusercontent.com/14865533/80833647-d81e0e80-8ba3-11ea-901e-094e5fb13290.gif)

Signed-off-by: Mason Fish <mason@looky.cloud>