### PR TITLE
Long Error Messages

### DIFF
--- a/src/css/_notice-banner.scss
+++ b/src/css/_notice-banner.scss
@@ -1,10 +1,7 @@
 .notice-banner {
   @include error-bg;
-
   padding: $space-s $space-m;
-
   font-size: 14px;
-  white-space: nowrap;
   margin: 0;
 
   p {

--- a/src/js/components/ErrorNotice.js
+++ b/src/js/components/ErrorNotice.js
@@ -48,9 +48,11 @@ function Default({error}: {error: BrimError}) {
       </p>
       {details && details.length > 0 && (
         <div className="error-details">
-          {details.map((string, i) => (
-            <p key={i}>{string}</p>
-          ))}
+          {details
+            .flatMap((s) => s.split("\n"))
+            .map((string, i) => (
+              <p key={i}>{string}</p>
+            ))}
         </div>
       )}
     </>


### PR DESCRIPTION
The fix is allow wrapping and new lines.

The errors will now appear looking like this:

<img width="1203" alt="Screen Shot 2020-05-01 at 3 19 48 PM" src="https://user-images.githubusercontent.com/3460638/80845869-68b61800-8bbf-11ea-98fd-1af6e7d43a58.png">
