### PR TITLE
Add error message for importing a directory

### DIFF
--- a/src/js/flows/ingestFiles.js
+++ b/src/js/flows/ingestFiles.js
@@ -40,7 +40,16 @@ export default (
 
 const validateInput = (paths) => ({
   async do() {
-    let params = await ingest.detectFileTypes(paths).then(ingest.getParams)
+    let params = await ingest
+      .detectFileTypes(paths)
+      .then(ingest.getParams)
+      .catch((e) => {
+        if (e.message.startsWith("EISDIR"))
+          throw new Error(
+            "Importing directories is not yet supported. Select multiple files."
+          )
+        else throw e
+      })
     if (params.error) throw new Error(params.error)
     return params
   }


### PR DESCRIPTION
If the user clicks the "Choose files..." button, the will not be able to select a directory. However, they can drop a directory on the dropzone. If this happens, we present them with a better error message.

fixes: #725 

<img width="865" alt="Screen Shot 2020-05-01 at 3 36 02 PM" src="https://user-images.githubusercontent.com/3460638/80846616-ae73e000-8bc1-11ea-8d58-bac8c8915f70.png">
