### PR TITLE
Install zq hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
     - run: dnf install -y xorg-x11-server-Xvfb git nss-tools pulseaudio
     - run: git config --global core.autocrlf false
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
     - name: setup node version ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -112,6 +115,9 @@ jobs:
     steps:
     - run: git config --global core.autocrlf false
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
     - name: setup node version ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -12,6 +12,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: install rpm
       run: sudo apt-get install -y rpm
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
     - name: setup node
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
     - name: setup node
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
     - name: setup node
       uses: actions/setup-node@v1
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16844,8 +16844,8 @@
       }
     },
     "zq": {
-      "version": "github:brimsec/zq#649d9a61a09658fb269d1d8bf56dfe1198e6ee4c",
-      "from": "github:brimsec/zq#v0.12.0"
+      "version": "git+https://github.com/brimsec/zq.git#335d284bfb0a5a4ced3e9cc3070c9270050f2376",
+      "from": "git+https://github.com/brimsec/zq.git#335d284bfb0a5a4ced3e9cc3070c9270050f2376"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.16",
     "valid-url": "^1.0.9",
-    "zq": "brimsec/zq#v0.12.0"
+    "zq": "git+https://github.com/brimsec/zq.git#335d284bfb0a5a4ced3e9cc3070c9270050f2376"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",


### PR DESCRIPTION
It's possible to npm install zq from an arbitrary Github hash as long as you choose a zq hash that supports it. While npm's syntax for doing this is flexible, the only one that seems to use HTTPS is of this form:
`npm install https://github.com/brimsec/zq#086719e76d53ace254cc495b4cc21d2efe069e73`. The shorthand like `github:brimsec/zq#hash` use the `git://` URI scheme.

See https://github.com/brimsec/zq/pull/712 for the companion PR. It does the heavy lifting. Here, we need only copy into zdeps where needed and set up Go.

Fixes #699 #702 