### PR TITLE
use zeekrunner scripts and zqd cli option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,11 @@ When developing features that need a non-released zqd instance, you can:
 
 ### zeek
 
-Brim uses [Zeek](https://www.zeek.org) to convert packet captures into Zeek logs. These logs are then combined and stored in [ZNG](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md) format. As an npm postinstall step, a [zeek artifact](https://github.com/brimsec/zeek/releases) (an archive with a zeek binary and other configuration files) is downloaded and stored in the `./zdeps` directory.
+Brim, via zqd, uses [Zeek](https://www.zeek.org) to convert packet captures into Zeek logs. These logs are then combined and stored in [ZNG](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md) format.
 
-zqd runs zeek as needed to ingest packet capture data. zqd expects that a `zeek` command is available in its PATH; Brim ensures this is true for the zeek artifact under `./zdeps`.
+As an npm postinstall step, a [zeek artifact](https://github.com/brimsec/zeek/releases) is downloaded and expanded into the `./zdeps/zeek` directory. This artifact contains a zeek binary and associated scripts, and a "zeek runner" script or command that is called by zqd. zqd is passed the full path to the zeek runner via the `-zeekrunner` command line option. When a pcap file is ingested, zqd runs the zeek runner with no arguments and its working directory set to an output directory for the zeek TSV logs, and then feeds the pcap data to the zeek runner via stdin. zqd then internally converts the zeek TSV logs into ZNG format.
+
+An alternate Zeek setup may be used by overriding the zeek runner location. This may be done either by launching Brim with the `BRIM_ZEEK_RUNNER` environment variable set to the absolute path of a zeek runner script or commmand, or by setting a preference in the Brim UI (pending [brimsec/brim#741](https://github.com/brimsec/brim/issues/741)).
 
 ## Tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2258,7 +2258,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -3223,7 +3223,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -3380,7 +3380,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3650,7 +3650,7 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
@@ -4025,7 +4025,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -4649,7 +4649,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -6471,7 +6471,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -11503,7 +11503,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -11590,7 +11590,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -12061,7 +12061,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -12084,7 +12084,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -12805,7 +12805,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -12994,7 +12994,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -13462,7 +13462,7 @@
     },
     "pretty-bytes": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
       "dev": true,
       "requires": {
@@ -13857,7 +13857,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -14025,7 +14025,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -14312,7 +14312,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -14419,7 +14419,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
@@ -14523,7 +14523,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -15188,7 +15188,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -15213,7 +15213,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -15538,13 +15538,13 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
       "dev": true,
       "requires": {
@@ -15554,7 +15554,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -15566,7 +15566,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -16477,7 +16477,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -16885,8 +16885,8 @@
       }
     },
     "zq": {
-      "version": "git+https://github.com/brimsec/zq.git#3de3c96be7a4efda0ab81486231c733c67f86448",
-      "from": "git+https://github.com/brimsec/zq.git#3de3c96be7a4efda0ab81486231c733c67f86448"
+      "version": "git+https://github.com/brimsec/zq.git#590a0faf1f7dc52b364ebd41c2abba7172437618",
+      "from": "git+https://github.com/brimsec/zq.git#590a0faf1f7dc52b364ebd41c2abba7172437618"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2258,7 +2258,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -3223,7 +3223,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -3380,7 +3380,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3650,7 +3650,7 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
@@ -4025,7 +4025,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -4649,7 +4649,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -6471,7 +6471,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -11503,7 +11503,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -11590,7 +11590,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -12061,7 +12061,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -12084,7 +12084,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -12805,7 +12805,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -12994,7 +12994,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -13462,7 +13462,7 @@
     },
     "pretty-bytes": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
       "dev": true,
       "requires": {
@@ -13857,7 +13857,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -14025,7 +14025,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -14312,7 +14312,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -14419,7 +14419,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
@@ -14523,7 +14523,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -15188,7 +15188,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -15213,7 +15213,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -15538,13 +15538,13 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "0.2.3",
-      "resolved": "http://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
       "dev": true,
       "requires": {
@@ -15554,7 +15554,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -15566,7 +15566,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -16477,7 +16477,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16885,8 +16885,8 @@
       }
     },
     "zq": {
-      "version": "git+https://github.com/brimsec/zq.git#96b45829a35c0ba9f95d307e86e8bf8193e8efea",
-      "from": "git+https://github.com/brimsec/zq.git#96b45829a35c0ba9f95d307e86e8bf8193e8efea"
+      "version": "git+https://github.com/brimsec/zq.git#ef06a626f53c8e132590c6247521163f551d0a1c",
+      "from": "git+https://github.com/brimsec/zq.git#ef06a626f53c8e132590c6247521163f551d0a1c"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16885,8 +16885,8 @@
       }
     },
     "zq": {
-      "version": "git+https://github.com/brimsec/zq.git#ef06a626f53c8e132590c6247521163f551d0a1c",
-      "from": "git+https://github.com/brimsec/zq.git#ef06a626f53c8e132590c6247521163f551d0a1c"
+      "version": "git+https://github.com/brimsec/zq.git#5f91910a566a833f1591911144bad0538c77ccdf",
+      "from": "git+https://github.com/brimsec/zq.git#5f91910a566a833f1591911144bad0538c77ccdf"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16885,8 +16885,8 @@
       }
     },
     "zq": {
-      "version": "git+https://github.com/brimsec/zq.git#590a0faf1f7dc52b364ebd41c2abba7172437618",
-      "from": "git+https://github.com/brimsec/zq.git#590a0faf1f7dc52b364ebd41c2abba7172437618"
+      "version": "git+https://github.com/brimsec/zq.git#96b45829a35c0ba9f95d307e86e8bf8193e8efea",
+      "from": "git+https://github.com/brimsec/zq.git#96b45829a35c0ba9f95d307e86e8bf8193e8efea"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.16",
     "valid-url": "^1.0.9",
-    "zq": "git+https://github.com/brimsec/zq.git#590a0faf1f7dc52b364ebd41c2abba7172437618"
+    "zq": "git+https://github.com/brimsec/zq.git#96b45829a35c0ba9f95d307e86e8bf8193e8efea"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.16",
     "valid-url": "^1.0.9",
-    "zq": "git+https://github.com/brimsec/zq.git#96b45829a35c0ba9f95d307e86e8bf8193e8efea"
+    "zq": "git+https://github.com/brimsec/zq.git#ef06a626f53c8e132590c6247521163f551d0a1c"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.16",
     "valid-url": "^1.0.9",
-    "zq": "git+https://github.com/brimsec/zq.git#3de3c96be7a4efda0ab81486231c733c67f86448"
+    "zq": "git+https://github.com/brimsec/zq.git#590a0faf1f7dc52b364ebd41c2abba7172437618"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.16",
     "valid-url": "^1.0.9",
-    "zq": "git+https://github.com/brimsec/zq.git#ef06a626f53c8e132590c6247521163f551d0a1c"
+    "zq": "git+https://github.com/brimsec/zq.git#5f91910a566a833f1591911144bad0538c77ccdf"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",

--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -112,7 +112,7 @@ async function zeekDownload(version, zdepsPath) {
     // like linux/mac.
     artifactFile = "zeek.zip"
     artifactUrl =
-      "https://storage.googleapis.com/brimsec/zeek-windows/zeek-20200403.zip"
+      "https://storage.cloud.google.com/brimsec/scratch/zeek-dev-zeek-runner.zip"
   } else {
     artifactFile = `zeek-${version}.${plat.osarch}.zip`
     artifactUrl = `https://github.com/brimsec/zeek/releases/download/${version}/${artifactFile}`
@@ -157,7 +157,7 @@ async function main() {
   try {
     // We encode the zeek version here for now to avoid the unncessary
     // git clone if it were in package.json.
-    const zeekVersion = "v3.0.2-brim2"
+    const zeekVersion = "dev-zeek-runner"
     await zeekDownload(zeekVersion, zdepsPath)
 
     // The zq dependency should be a git tag or commit. Any tag that

--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -112,7 +112,7 @@ async function zeekDownload(version, zdepsPath) {
     // like linux/mac.
     artifactFile = "zeek-dev-zeek-runner.zip"
     artifactUrl =
-      "https://storage.cloud.google.com/brimsec/scratch/zeek-dev-zeek-runner.zip"
+      "https://storage.googleapis.com/brimsec/scratch/zeek-dev-zeek-runner.zip"
   } else {
     artifactFile = `zeek-${version}.${plat.osarch}.zip`
     artifactUrl = `https://github.com/brimsec/zeek/releases/download/${version}/${artifactFile}`

--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -110,7 +110,7 @@ async function zeekDownload(version, zdepsPath) {
   if (process.platform == "win32") {
     // Special casing for zeek on windows as it's not yet created automatically
     // like linux/mac.
-    artifactFile = "zeek.zip"
+    artifactFile = "zeek-dev-zeek-runner.zip"
     artifactUrl =
       "https://storage.cloud.google.com/brimsec/scratch/zeek-dev-zeek-runner.zip"
   } else {

--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -105,18 +105,8 @@ async function zeekDownload(version, zdepsPath) {
   const plat = platformDefs[process.platform]
   const zeekPath = path.join(zdepsPath, "zeek")
 
-  let artifactFile, artifactUrl
-
-  if (process.platform == "win32") {
-    // Special casing for zeek on windows as it's not yet created automatically
-    // like linux/mac.
-    artifactFile = "zeek-dev-zeek-runner.zip"
-    artifactUrl =
-      "https://storage.googleapis.com/brimsec/scratch/zeek-dev-zeek-runner.zip"
-  } else {
-    artifactFile = `zeek-${version}.${plat.osarch}.zip`
-    artifactUrl = `https://github.com/brimsec/zeek/releases/download/${version}/${artifactFile}`
-  }
+  const artifactFile = `zeek-${version}.${plat.osarch}.zip`
+  const artifactUrl = `https://github.com/brimsec/zeek/releases/download/${version}/${artifactFile}`
 
   const tmpdir = tmp.dirSync({unsafeCleanup: true})
   try {
@@ -132,11 +122,7 @@ async function zeekDownload(version, zdepsPath) {
     tmpdir.removeCallback()
   }
 
-  if (process.platform == "win32") {
-    console.log("zeek windows artifact downloaded to " + zeekPath)
-  } else {
-    console.log("zeek " + version + " downloaded to " + zeekPath)
-  }
+  console.log("zeek " + version + " downloaded to " + zeekPath)
 }
 
 // Build the zqd binary inside the node_modules/zq directory via "make build".
@@ -157,7 +143,7 @@ async function main() {
   try {
     // We encode the zeek version here for now to avoid the unncessary
     // git clone if it were in package.json.
-    const zeekVersion = "dev-zeek-runner"
+    const zeekVersion = "v3.0.2-brim3"
     await zeekDownload(zeekVersion, zdepsPath)
 
     // The zq dependency should be a git tag or commit. Any tag that

--- a/src/js/zqd/zqd.js
+++ b/src/js/zqd/zqd.js
@@ -16,15 +16,15 @@ const zdepsDirectory = join(app.getAppPath(), "zdeps")
 const platformDefs = {
   darwin: {
     zqdBin: "zqd",
-    zeekBin: "zeek"
+    zeekRunnerBin: "zeekrunner"
   },
   linux: {
     zqdBin: "zqd",
-    zeekBin: "zeek"
+    zeekRunnerBin: "zeekrunner"
   },
   win32: {
     zqdBin: "zqd.exe",
-    zeekBin: "zeek.exe"
+    zeekRunnerBin: "zeekrunner.exe"
   }
 }
 
@@ -86,7 +86,7 @@ function zeekRunnerCommand(): string {
 
   let zeekRunner = process.env.BRIM_ZEEK_RUNNER
   if (!zeekRunner) {
-    zeekRunner = resolve(join(zdepsDirectory, "zeek", plat.zeekBin))
+    zeekRunner = resolve(join(zdepsDirectory, "zeek", plat.zeekRunnerBin))
   }
 
   if (!pathExistsSync(zeekRunner)) {

--- a/src/js/zqd/zqd.js
+++ b/src/js/zqd/zqd.js
@@ -86,6 +86,9 @@ function zeekRunnerCommand(): string {
 
   let zeekRunner = process.env.BRIM_ZEEK_RUNNER
   if (!zeekRunner) {
+    // TODO: https://github.com/brimsec/brim/issues/741
+    // If the environment varible isn't set, allow the user to set
+    // a preferred zeekrunner location via preferences.
     zeekRunner = resolve(join(zdepsDirectory, "zeek", plat.zeekRunnerBin))
   }
 


### PR DESCRIPTION
This is part of the brimsec/brim repo side work for brimsec/brim#731. 

Use the `-zeekrunner` cli option to zqd ( https://github.com/brimsec/zq/pull/718 ), defaulting to the value of environment variable `BRIM_ZEEK_RUNNER`, else to the zeekrunner included from the zdeps zeek artifact ( https://github.com/brimsec/zeek/pull/23 ).



