### PR TITLE
Windows New Window

### DIFF
--- a/src/js/electron/main.js
+++ b/src/js/electron/main.js
@@ -1,6 +1,7 @@
 /* @flow */
-
 import {appPathSetup} from "./appPathSetup"
+import userTasks from "./userTasks"
+
 // app path and log setup should happen before other imports.
 appPathSetup()
 
@@ -27,6 +28,7 @@ import log from "electron-log"
 
 async function main() {
   if (handleSquirrelEvent(app)) return
+  userTasks(app)
   let session = tron.session()
   let winMan = tron.windowManager()
   let sessionState = session.load()
@@ -53,7 +55,11 @@ async function main() {
 
   app.on("ready", () => {
     installExtensions()
-    winMan.init(sessionState)
+    if (app.commandLine.hasSwitch("new-window")) {
+      winMan.openWindow("search")
+    } else {
+      winMan.init(sessionState)
+    }
   })
 
   app.on("before-quit", () => {

--- a/src/js/electron/tron/windowManager.js
+++ b/src/js/electron/tron/windowManager.js
@@ -47,7 +47,14 @@ export default function windowManager() {
     },
 
     getState(): WindowsState {
-      return windows
+      let state = {}
+      for (let id in windows) {
+        let win = windows[id]
+        if (win.name === "search") {
+          state[id] = win
+        }
+      }
+      return state
     },
 
     getWindows(): WindowState[] {

--- a/src/js/electron/userTasks.js
+++ b/src/js/electron/userTasks.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+export default function(app: *) {
+  app.setUserTasks([
+    {
+      program: process.execPath,
+      arguments: "--new-window",
+      iconPath: process.execPath,
+      iconIndex: 0,
+      title: "New Window",
+      description: "Create a new window"
+    }
+  ])
+}

--- a/src/js/electron/userTasks.js
+++ b/src/js/electron/userTasks.js
@@ -1,14 +1,26 @@
 /* @flow */
 
+import electronIsDev from "./isDev"
+import path from "path"
+
 export default function(app: *) {
   app.setUserTasks([
     {
       program: process.execPath,
-      arguments: "--new-window",
+      arguments: getArguments(),
       iconPath: process.execPath,
       iconIndex: 0,
       title: "New Window",
       description: "Create a new window"
     }
   ])
+}
+
+function getArguments() {
+  if (electronIsDev) {
+    let appRoot = path.join(__dirname, "..", "..", "..")
+    return [appRoot, "--new-window"].join(" ")
+  } else {
+    return "--new-window"
+  }
 }

--- a/src/js/electron/userTasks.js
+++ b/src/js/electron/userTasks.js
@@ -4,16 +4,18 @@ import electronIsDev from "./isDev"
 import path from "path"
 
 export default function(app: *) {
-  app.setUserTasks([
-    {
-      program: process.execPath,
-      arguments: getArguments(),
-      iconPath: process.execPath,
-      iconIndex: 0,
-      title: "New Window",
-      description: "Create a new window"
-    }
-  ])
+  if (app.setUserTasks) {
+    app.setUserTasks([
+      {
+        program: process.execPath,
+        arguments: getArguments(),
+        iconPath: process.execPath,
+        iconIndex: 0,
+        title: "New Window",
+        description: "Create a new window"
+      }
+    ])
+  }
 }
 
 function getArguments() {


### PR DESCRIPTION
When the about page is the only window that is opened when quitting the app, the app would be in a state where a new search page was impossible to create on windows.

We fix this in two ways:
* Only re-open the previous session's "search" windows. If none exist, then open a new one.
* Provide a menu option in the taskbar on windows to create a new window.

<img width="490" alt="image" src="https://user-images.githubusercontent.com/3460638/81015541-b88d1d00-8e13-11ea-89cc-baa54daa4b71.png">

fixes: #645 