### PR TITLE
Brim wiki article about supported platforms

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -4,6 +4,7 @@ Welcome to the Brim wiki. These pages provide additional information for your
 effective use of the Brim desktop application and related tools.
 
 ## Support Resources
+* [[Supported Platforms]]
 * [[Troubleshooting]]
 * [[Microsoft Windows beta limitations]]
 * [[Zeek JSON Import]]

--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -23,8 +23,6 @@ all) for some platform versions.
 
 # Per-Platform Details
 
-The following details are current as of Brim `v0.9.0`.
-
 ## Windows
 
 Our Windows test automation runs on Windows Server 2019, and therefore this is

--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -19,7 +19,7 @@ continuously as well as occasional ad hoc testing. We welcome you to
 [open an issue](Troubleshooting.md#opening-an-issue) on any problem you
 experience with Brim regardless of platform version, but please understand
 that we may be limited in our ability to provide quick fixes (or any fix at
-all) for certain platforms, subject to availability.
+all) for some platform versions.
 
 # Per-Platform Details
 

--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -1,0 +1,82 @@
+# Supported Platforms
+
+- [Summary](#summary)
+- [Per-Platform Details](#per-platform-details)
+  * [Windows](#windows)
+  * [macOS](#macos)
+  * [Linux](#linux)
+
+# Summary
+
+[Downloadable packages](https://www.brimsecurity.com/download/) for Brim are
+available that run on Windows, macOS, and Linux. The specific
+versions/distributions of these platforms for which we can set expectations of
+quality are affected by end-of-life cycles and their availability in our
+automated test infrastructure.
+
+The sections below describe the details regarding the versions we test with
+continuously as well as occasional ad hoc testing. We welcome you to
+[open an issue](Troubleshooting.md#opening-an-issue) on any problem you
+experience with Brim regardless of platform verison, but please understand
+that we may be limited in our ability to provide quick fixes (or any fix at
+all) for certain platforms, subject to availability.
+
+# Per-Platform Details
+
+The following details are current as of Brim `v0.9.0`.
+
+## Windows
+
+Our Windows test automation runs on Windows Server 2019, and therefore this is
+the platform on which we are best able to ensure quality and prevent
+regressions. Several Brim developers also run Windows 10 on their desktops
+and regularly perform ad hoc testing with it and attempt to reproduce issues on
+Windows 10.
+
+Brim is written using tools that have their own platform limitations. Per the
+supported platform guidance for [Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms)
+and [Go](https://golang.org/doc/install#requirements), Windows versions
+_older_ _than_ Windows 7 or Windows Sevrer 2008R2 are not expected to work at
+all.
+
+We've been informed anecdotally that users are running Brim successfully on
+Windows 7. However, as [Windows 7 is end-of-life](https://support.microsoft.com/en-us/help/4057281/windows-7-support-ended-on-january-14-2020),
+we have no access to this platform to reproduce reported issues or test fixes.
+We will make all attempts to provide  "best effort" support on reported Windows
+7 issues, but please understand that if we're unable to reproduce them on
+Windows Server 2019 or Windows 10, we may not be able to address them.
+
+## macOS
+
+Our macOS test automation runs on Catalina 10.15, and therefore this is
+the platform on which we are best able to ensure quality and prevent
+regressions.
+
+Brim is written using tools that have their own platform limitations. Per the
+supported platform guidance for [Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms) 
+and [Go](https://golang.org/doc/install#requirements), macOS versions _older_
+_than_ 10.11 are not expected to work at all.
+
+We've been informed anecdotally that users are running Brim successfully on
+some of these macOS releases older than 10.15. However, we do not have the
+ability to easily "spin up" test environments with arbitrary macOS versions to
+reproduce reported issues or test fixes. We will make all attempts to provide
+"best effort" support on macOS releases other than 10.15, but please understand
+that if we're unable to reproduce them on Catalina 10.15, we may not be able
+to address them.
+
+## Linux
+
+Our Linux test automation runs on Ubuntu 18.04, and therefore this is
+the platform on which we are best able to ensure quality and prevent
+regressions.
+
+As we publish both `.deb` and `.rpm` installers, we do perform occasional ad
+hoc testing on Fedora to ensure the package installs and runs correctly on
+this RedHat-derived variant.
+
+Brim is written using tools that have their own platform limitations. Per the
+supported platform guidance for [Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms)
+and [Go](https://golang.org/doc/install#requirements), Linux distributions
+_older_ _than_ Ubuntu 12.04, Fedora 21, or Debian 8 are not expected to work
+at all.

--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -73,7 +73,7 @@ regressions.
 
 As we publish both `.deb` and `.rpm` installers, we do perform occasional ad
 hoc testing on Fedora to ensure the package installs and runs correctly on
-this RedHat-derived variant.
+this Red Hat-derived variant.
 
 Brim is written using tools that have their own platform limitations. Per the
 supported platform guidance for [Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms)

--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -17,7 +17,7 @@ automated test infrastructure.
 The sections below describe the details regarding the versions we test with
 continuously as well as occasional ad hoc testing. We welcome you to
 [open an issue](Troubleshooting.md#opening-an-issue) on any problem you
-experience with Brim regardless of platform verison, but please understand
+experience with Brim regardless of platform version, but please understand
 that we may be limited in our ability to provide quick fixes (or any fix at
 all) for certain platforms, subject to availability.
 
@@ -36,7 +36,7 @@ Windows 10.
 Brim is written using tools that have their own platform limitations. Per the
 supported platform guidance for [Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms)
 and [Go](https://golang.org/doc/install#requirements), Windows versions
-_older_ _than_ Windows 7 or Windows Sevrer 2008R2 are not expected to work at
+_older_ _than_ Windows 7 or Windows Server 2008R2 are not expected to work at
 all.
 
 We've been informed anecdotally that users are running Brim successfully on

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,4 +1,5 @@
 **Support Resources**
+* [[Supported Platforms]]
 * [[Troubleshooting]]
 * [[Microsoft Windows beta limitations]]
 * [[Zeek JSON Import]]


### PR DESCRIPTION
This article provides details on the platforms on which we expect to deliver consistent quality (since we run on them in CI) vs. "best effort".

I could definitely use close review on the sections where I call out to the Electron and Go docs. I figure it's worth going to that level of detail since some in the open source community may be able to make use of this information. Since Brim depends on both Electron and Go, I basically took the approach of saying that anything _older_ _than_ the the earliest platform supported by _both_ should _not_ be expected to work. For instance, this is why I set expectations that anything older than macOS 10.11 would not work, since that was the oldest one in in Go's platform statement, though Electron claims to be ok to 10.10.

Closes #642 