### PR TITLE
Use a better error messages for ingest interrupt

### DIFF
--- a/src/js/components/TabWelcome.js
+++ b/src/js/components/TabWelcome.js
@@ -11,6 +11,7 @@ import Notice from "../state/Notice"
 import SavedSpacesList from "./SavedSpacesList"
 import Spaces from "../state/Spaces"
 import Tab from "../state/Tab"
+import errors from "../errors"
 import ingestFiles from "../flows/ingestFiles"
 import initNewTab from "../flows/initNewTab"
 import refreshSpaceNames from "../flows/refreshSpaceNames"
@@ -28,9 +29,12 @@ export default function TabWelcome() {
   function onChange(_e, files) {
     if (!files.length) return
     dispatch(ingestFiles(files)).catch((e) => {
-      console.error(e)
-      dispatch(Notice.set(ErrorFactory.create(e.cause)))
+      /(Failed to fetch)|(network error)/.test(e.cause.message)
+        ? dispatch(Notice.set(errors.importInterrupt()))
+        : dispatch(Notice.set(ErrorFactory.create(e.cause)))
+
       dispatch(refreshSpaceNames())
+      console.error(e.message)
     })
   }
 

--- a/src/js/errors/index.js
+++ b/src/js/errors/index.js
@@ -8,5 +8,10 @@ export default {
   spaceDeleted: (name: string) => ({
     type: "SpaceDeletedError",
     message: `The space "${name}" previously on this tab has been deleted.`
+  }),
+  importInterrupt: () => ({
+    type: "ImportInterruptError",
+    message: "The import was interrupted.",
+    details: ["To prevent this, keep your computer awake during the import."]
   })
 }


### PR DESCRIPTION

<img width="646" alt="Screen Shot 2020-05-04 at 5 19 11 PM" src="https://user-images.githubusercontent.com/3460638/81025544-d6ff1280-8e2b-11ea-8855-a78cc5100a6b.png">


This would happen during ingest if someone closes their laptop
then re-opens it, or if the computer falls asleep.

If the computer sleeps before the first IngestStatus is returned,
the error message is "Failed to fetch". If it happens after the
first status is returned, the error message is "network error".

We now look for both of these and present the importInterupt error
message.

<img width="660" alt="Screen Shot 2020-05-04 at 5 19 53 PM" src="https://user-images.githubusercontent.com/3460638/81025557-dfefe400-8e2b-11ea-975d-c6792af4f6a1.png">
<img width="400" alt="Screen Shot 2020-05-04 at 5 19 25 PM" src="https://user-images.githubusercontent.com/3460638/81025559-e0887a80-8e2b-11ea-81d3-41d1faee7de4.png">

fixes #533 