### PR TITLE
Fix typo in Support Platforms wiki section

### DIFF
--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -16,7 +16,7 @@ automated test infrastructure.
 
 The sections below describe the details regarding the versions we test with
 continuously as well as occasional ad hoc testing. We welcome you to
-[open an issue](Troubleshooting.md#opening-an-issue) on any problem you
+[open an issue](Troubleshooting#opening-an-issue) on any problem you
 experience with Brim regardless of platform version, but please understand
 that we may be limited in our ability to provide quick fixes (or any fix at
 all) for some platform versions.


### PR DESCRIPTION
Alas... one of the hazards of this CI-based wiki publishing workflow is that it's not always easy to spot rendering problems that'll show up in the final wiki location. I'd mistakenly been linking to the raw markdown instead of the rendered link inside the page.