### PR TITLE
Dis-ambiguate the regex literal

### DIFF
--- a/src/js/components/TabWelcome.js
+++ b/src/js/components/TabWelcome.js
@@ -29,7 +29,8 @@ export default function TabWelcome() {
   function onChange(_e, files) {
     if (!files.length) return
     dispatch(ingestFiles(files)).catch((e) => {
-      /(Failed to fetch)|(network error)/.test(e.cause.message)
+      let interruptError = /(Failed to fetch)|(network error)/
+      interruptError.test(e.cause.message)
         ? dispatch(Notice.set(errors.importInterrupt()))
         : dispatch(Notice.set(ErrorFactory.create(e.cause)))
 


### PR DESCRIPTION
This is to get master back to green since prettier wants a semi-colon but eslint does not.

The future fix is to have prettier do all the re-formatting rules, while eslint only has qualitative rules.