### PR TITLE
Mention CentOS 8 in Support Platforms wiki article

### DIFF
--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -65,7 +65,7 @@ to address them.
 
 ## Linux
 
-Our Linux test automation run on Ubuntu 18.04 (`.deb` pacakage), and
+Our Linux test automation run on Ubuntu 18.04 (`.deb` package), and
 CentOS 8 (`.rpm` package), and therefore these are the platforms on which
 we are best able to ensure quality and prevent regressions.
 

--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -65,13 +65,9 @@ to address them.
 
 ## Linux
 
-Our Linux test automation runs on Ubuntu 18.04, and therefore this is
-the platform on which we are best able to ensure quality and prevent
-regressions.
-
-As we publish both `.deb` and `.rpm` installers, we do perform occasional ad
-hoc testing on Fedora to ensure the package installs and runs correctly on
-this Red Hat-derived variant.
+Our Linux test automation run on Ubuntu 18.04 (`.deb` pacakage), and
+CentOS 8 (`.rpm` package), and therefore these are the platforms on which
+we are best able to ensure quality and prevent regressions.
 
 Brim is written using tools that have their own platform limitations. Per the
 supported platform guidance for [Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms)

--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -65,7 +65,7 @@ to address them.
 
 ## Linux
 
-Our Linux test automation run on Ubuntu 18.04 (`.deb` package), and
+Our Linux test automation runs on Ubuntu 18.04 (`.deb` package) and
 CentOS 8 (`.rpm` package), and therefore these are the platforms on which
 we are best able to ensure quality and prevent regressions.
 


### PR DESCRIPTION
@mattnibs pointed out that our integration test coverage is the same on CentOS 8 as it is for Ubuntu 18.04. This simplifies the support statement somewhat.