### PR TITLE
Render html menus in integration tests

### DIFF
--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -232,7 +232,7 @@ export const click = (app: Application, selector: string) =>
 
 export const rightClick = (app: Application, selector: string) =>
   appStep(`right-click on selector "${selector}"`, async () => {
-    await app.client.waitForClickable(app, selector)
+    await waitForClickable(app, selector)
     try {
       await retryUntil(
         () => app.client.rightClick(selector),

--- a/itest/tests/__snapshots__/contextMenu.test.js.snap
+++ b/itest/tests/__snapshots__/contextMenu.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test search mods via right-clicks count by _path; sort asc 1`] = `
+Array [
+  "_path",
+  "count",
+  "capture_loss",
+  "1",
+  "conn",
+  "19",
+  "dns",
+  "2",
+  "files",
+  "4",
+  "ssl",
+  "1",
+  "stats",
+  "1",
+  "weird",
+  "1",
+  "x509",
+  "1",
+]
+`;

--- a/itest/tests/contextMenu.test.js
+++ b/itest/tests/contextMenu.test.js
@@ -1,0 +1,57 @@
+/* @flow */
+
+import {basename} from "path"
+
+import {
+  click,
+  newAppInstance,
+  pcapIngestSample,
+  rightClick,
+  searchDisplay,
+  setSpan,
+  startApp,
+  startSearch,
+  waitForResults,
+  writeSearch
+} from "../lib/app.js"
+import {handleError, stdTest} from "../lib/jest.js"
+import {selectors} from "../../src/js/test/integration"
+
+describe("Test search mods via right-clicks", () => {
+  let app
+  let testIdx = 0
+
+  beforeAll(async () => {
+    app = newAppInstance(basename(__filename), ++testIdx)
+    await startApp(app)
+    await pcapIngestSample(app)
+    await setSpan(app, "Whole Space")
+  })
+
+  afterAll(async () => {
+    if (app && app.isRunning()) {
+      await app.stop()
+    }
+  })
+
+  beforeEach(async () => {
+    await writeSearch(app, "")
+    await startSearch(app)
+    await waitForResults(app)
+  })
+
+  stdTest("count by _path; sort asc", (done) => {
+    rightClick(app, selectors.viewer.resultCellContaining("capture_loss"))
+      .then(async () => {
+        await click(app, selectors.viewer.contextMenuItem("Count by field"))
+        await rightClick(app, selectors.viewer.resultCellContaining("dns"))
+        await click(app, selectors.viewer.contextMenuItem("Sort A...Z"))
+        let results = await searchDisplay(app)
+        expect(results).toMatchSnapshot()
+        done()
+      })
+      .catch((err) => {
+        handleError(app, err, done)
+      })
+  })
+})

--- a/src/css/_html-context-menu.scss
+++ b/src/css/_html-context-menu.scss
@@ -1,0 +1,36 @@
+.html-context-menu {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 300px;
+  max-height: 100vh;
+  background: white;
+  overflow: auto;
+  box-shadow: 0 0 3px 3px rgba(0, 0, 0, 0.15);
+  user-select: none;
+  animation: fadein 300ms;
+
+  ul {
+    list-style: none;
+    padding: 20px 0;
+    margin: 0;
+    @include label-normal;
+  }
+
+  li {
+    margin: 0;
+    padding: 4px 20px;
+    &:hover {
+      background: darken(white, 2%);
+    }
+  }
+
+  li.disabled {
+    opacity: 0.2;
+    pointer-events: none;
+  }
+
+  hr {
+    border-top: 0;
+  }
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -125,3 +125,4 @@
 @import "history-buttons";
 @import "info-notice";
 @import "x-button";
+@import "html-context-menu";

--- a/src/js/components/App.js
+++ b/src/js/components/App.js
@@ -9,6 +9,7 @@ import {XLatestError} from "./LatestError"
 import AboutModal from "./AboutModal"
 import ClusterGate from "./Login/ClusterGate"
 import ErrorNotice from "./ErrorNotice"
+import HTMLContextMenu from "./HTMLContextMenu"
 import SettingsModal from "./SettingsModal"
 import View from "../state/View"
 import brim from "../brim"
@@ -33,6 +34,7 @@ export default function App() {
       <ErrorNotice />
       <SettingsModal />
       <AboutModal />
+      <HTMLContextMenu />
     </div>
   )
 }

--- a/src/js/components/HTMLContextMenu.js
+++ b/src/js/components/HTMLContextMenu.js
@@ -19,6 +19,8 @@ import {ipcRenderer} from "electron"
 import lib from "../lib"
 import useEventListener from "./hooks/useEventListener"
 
+import {reactElementProps} from "../test/integration"
+
 export default function HTMLContextMenu() {
   let [template, setTemplate] = useState(null)
   const openMenu = (e) => setTemplate(e.detail)
@@ -27,7 +29,7 @@ export default function HTMLContextMenu() {
 
   if (!template) return null
   return ReactDOM.createPortal(
-    <div className="html-context-menu">
+    <div className="html-context-menu" {...reactElementProps("contextMenu")}>
       <ul>
         {template.map((item, i) => (
           <HTMLMenuItem item={item} key={i} />

--- a/src/js/components/HTMLContextMenu.js
+++ b/src/js/components/HTMLContextMenu.js
@@ -1,55 +1,65 @@
-/* @flow */
-import React, {useEffect, useState} from "react"
+/* @flow
+
+  This is a component only used for integration tests. Since spectron cannot
+  interact with the native right click menus, this component creates an
+  html version of the right click menus with the same labels and click handlers
+  that the native menu will recieve.
+
+  Usually, when a native menu is clicked, it sends an event to the originating
+  renderer process. This component simulates that simply by emiting the event
+  here in the renderer. See the stubIpcSend() function below.
+*/
+
+import React, {useState} from "react"
 import ReactDOM from "react-dom"
 import classNames from "classnames"
 
 import {ipcRenderer} from "electron"
 
 import lib from "../lib"
+import useEventListener from "./hooks/useEventListener"
 
 export default function HTMLContextMenu() {
   let [template, setTemplate] = useState(null)
-
-  useEffect(() => {
-    const name = "nativeContextMenu"
-    const handler = (e) => setTemplate(e.detail)
-
-    // $FlowFixMe
-    document.addEventListener(name, handler, false)
-    document.addEventListener("click", () => setTemplate(null), false)
-    // $FlowFixMe
-    return () => document.removeEventListener(name, handler, false)
-  }, [])
+  const openMenu = (e) => setTemplate(e.detail)
+  useEventListener(document, "click", () => setTemplate(null), [])
+  useEventListener(document, "nativeContextMenu", openMenu, [])
 
   if (!template) return null
-
-  function onClick(item) {
-    item.click(item, {
-      webContents: {
-        send: (name, ...args) => {
-          ipcRenderer.emit(name, null, ...args)
-        }
-      }
-    })
-  }
   return ReactDOM.createPortal(
     <div className="html-context-menu">
       <ul>
-        {template.map((item, i) => {
-          if (item.type === "separator") return <hr key={i} />
-          else
-            return (
-              <li
-                key={i}
-                onClick={() => onClick(item)}
-                className={classNames({disabled: !item.enabled})}
-              >
-                {item.label}
-              </li>
-            )
-        })}
+        {template.map((item, i) => (
+          <HTMLMenuItem item={item} key={i} />
+        ))}
       </ul>
     </div>,
     lib.doc.id("tooltip-root")
   )
 }
+
+function HTMLMenuItem({item}) {
+  if (item.type === "separator") {
+    return <hr />
+  } else {
+    return (
+      <li
+        onClick={() => item.click(item, stubbedBrowserWindow)}
+        className={classNames({disabled: !item.enabled})}
+      >
+        {item.label}
+      </li>
+    )
+  }
+}
+
+function stubIpcSend(name, ...args) {
+  /*
+    Since ipcRendere inherits from EventEmitter, we can simply emit this event
+    right here in the renderer to simulate it being sent over from the main
+    processes like it does with the native context menu.
+  */
+  ipcRenderer.emit(name, null /* event */, ...args)
+}
+
+const stubbedBrowserWindow = {webContents: {send: stubIpcSend}}

--- a/src/js/components/HTMLContextMenu.js
+++ b/src/js/components/HTMLContextMenu.js
@@ -1,0 +1,55 @@
+/* @flow */
+import React, {useEffect, useState} from "react"
+import ReactDOM from "react-dom"
+import classNames from "classnames"
+
+import {ipcRenderer} from "electron"
+
+import lib from "../lib"
+
+export default function HTMLContextMenu() {
+  let [template, setTemplate] = useState(null)
+
+  useEffect(() => {
+    const name = "nativeContextMenu"
+    const handler = (e) => setTemplate(e.detail)
+
+    // $FlowFixMe
+    document.addEventListener(name, handler, false)
+    document.addEventListener("click", () => setTemplate(null), false)
+    // $FlowFixMe
+    return () => document.removeEventListener(name, handler, false)
+  }, [])
+
+  if (!template) return null
+
+  function onClick(item) {
+    item.click(item, {
+      webContents: {
+        send: (name, ...args) => {
+          ipcRenderer.emit(name, null, ...args)
+        }
+      }
+    })
+  }
+  return ReactDOM.createPortal(
+    <div className="html-context-menu">
+      <ul>
+        {template.map((item, i) => {
+          if (item.type === "separator") return <hr key={i} />
+          else
+            return (
+              <li
+                key={i}
+                onClick={() => onClick(item)}
+                className={classNames({disabled: !item.enabled})}
+              >
+                {item.label}
+              </li>
+            )
+        })}
+      </ul>
+    </div>,
+    lib.doc.id("tooltip-root")
+  )
+}

--- a/src/js/components/hooks/useEventListener.js
+++ b/src/js/components/hooks/useEventListener.js
@@ -1,0 +1,14 @@
+/* @flow */
+import {useEffect} from "react"
+
+export default function useEventListener(
+  el: Node,
+  name: string,
+  callback: Function,
+  deps: ?(*[])
+) {
+  useEffect(() => {
+    el.addEventListener(name, callback, false)
+    return () => el.removeEventListener(name, callback, false)
+  }, deps)
+}

--- a/src/js/lib/System.js
+++ b/src/js/lib/System.js
@@ -2,10 +2,8 @@
 
 import {remote} from "electron"
 
-let test = true
-
 export function showContextMenu(template: Object) {
-  if (test) {
+  if (process.env.BRIM_ITEST === "true") {
     document.dispatchEvent(
       new CustomEvent("nativeContextMenu", {detail: template})
     )

--- a/src/js/lib/System.js
+++ b/src/js/lib/System.js
@@ -2,6 +2,14 @@
 
 import {remote} from "electron"
 
+let test = true
+
 export function showContextMenu(template: Object) {
-  new remote.Menu.buildFromTemplate(template).popup()
+  if (test) {
+    document.dispatchEvent(
+      new CustomEvent("nativeContextMenu", {detail: template})
+    )
+  } else {
+    new remote.Menu.buildFromTemplate(template).popup()
+  }
 }

--- a/src/js/test/integration.js
+++ b/src/js/test/integration.js
@@ -8,6 +8,7 @@ const dataAttrs = {
   // are interested in. This is done by injecting custom data attributes [1]
   // into the DOM.
   // [1] https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*
+  contextMenu: "contextMenu",
   correlationPanel: "correlationPanel",
   curlCommand: "curlCommand",
   curlModal: "curlModal",
@@ -19,7 +20,6 @@ const dataAttrs = {
   ingestProgress: "ingestProgress",
   killHistogramSearch: "killHistogramSearch",
   killViewerSearch: "killViewerSearch",
-  logCellMenu: "logCellMenu",
   login: "login",
   notification: "notification-header",
   optionsButton: "optionsButton",
@@ -52,16 +52,16 @@ const _histogramSelector = `[${itestLocator}='${dataAttrs.histogram}']`
 const dataAttrSelector = (component: string) =>
   `[${itestLocator}='` + dataAttrs[component] + "']"
 
-// Use this to generate Xpaths to find elemnents containing text, all under a
+// Use this to generate Xpaths to find elements containing text, all under a
 // common dataAttrValue. For example the right-click Log Detail Cell menu that
 // produces an option for "Log details" is the element:
 //
-//   <ul class="menu-list" data-test-locator="logCellMenu">
+//   <div class="context-menu" data-test-locator="contextMenu">
 //
-// genSelectorForTextUnderElement("logCellMenu") returns a function that can be used to
+// genSelectorForTextUnderElement("contextMenu") returns a function that can be used to
 // generate Xpaths to specific items contained in that menu, i.e.,
 //
-//   genSelectorForTextUnderElement("logCellMenu")("Open details")
+//   genSelectorForTextUnderElement("contextMenu")("Open details")
 //
 // Xpaths are used because CSS selectors don't have the capability to evaluate
 // whether a child text node has particular content.
@@ -143,13 +143,13 @@ export const selectors = {
     ingestProgress: dataAttrSelector("ingestProgress")
   },
   viewer: {
+    contextMenu: dataAttrSelector("contextMenu"),
+    contextMenuItem: genSelectorForTextUnderElement("contextMenu"),
     header_base: dataAttrSelector("viewer_header"),
     headers: dataAttrSelector("viewer_header") + " .header-cell",
     results_base: dataAttrSelector("viewer_results"),
     results: dataAttrSelector("viewer_results") + " .field-cell",
-    resultCellContaining: genSelectorForTextUnderElement("viewer_results"),
-    rightClickMenu: dataAttrSelector("logCellMenu"),
-    rightClickMenuItem: genSelectorForTextUnderElement("logCellMenu")
+    resultCellContaining: genSelectorForTextUnderElement("viewer_results")
   }
 }
 


### PR DESCRIPTION
We intercept the call to create the rightclick menu right before it gets sent to electron. Then we dispatch our own event to the dom, then build a simple html context menu that will only be used when `process.env.BRIM_ITEST === "true"`.

![D6eZyhUISQ](https://user-images.githubusercontent.com/3460638/81108384-788a7080-8ecd-11ea-9b21-5954cecf76d2.gif)

To test this locally, start the app normally, then open the console and type in the following:

<img width="278" alt="image" src="https://user-images.githubusercontent.com/3460638/81119946-a0cf9a80-8ee0-11ea-83ab-f90223c827a1.png">

Now the app will respond to right clicks by building an html version of the context menus.

@mikesbrown this should make those integration tests much easier to write.