### PR TITLE
Correct two refs that were to Issues, not PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 * **NOTE**: Prior state such as Search History will be lost on upgrade to this version
 * Update zq to [v0.13.0](https://github.com/brimsec/zq/releases/tag/v0.13.0) (#750)
 * Start the [Brim wiki](https://github.com/brimsec/brim/wiki) for documentation (#660)
-* Import of Zeek logs in TSV, JSON, and ZNG formats (see the [wiki](https://github.com/brimsec/brim/wiki/Zeek-JSON-Import) for info on JSON). (#594, #720, #727, #625, #581, #643, #672, #716, #700, #717, #719, #735, #721, #729, #616)
+* Import of Zeek logs in TSV, JSON, and ZNG formats (see the [wiki](https://github.com/brimsec/brim/wiki/Zeek-JSON-Import) for info on JSON). (#594, #720, #727, #625, #581, #643, #672, #716, #700, #717, #719, #735, #721, #729, #713)
 * Support for Brim on Linux: `.deb` (#631) and `.rpm` (#636) installer packages
 * Fix an issue where holding down arrow keys could freeze Brim (#670, #692)
 * Allow Log Details to be popped out to a separate window by double-clicking an event or via a control at the top of Log Details panel (#651)
 * Fix an issue where ZQL queries with double quotes were not escaped in right-click operations (#682)
-* Fix an issue where Brim would crash when revisiting a tab for a deleted Space where a pcap had been opened (#652)
+* Fix an issue where Brim would crash when revisiting a tab for a deleted Space where a pcap had been opened (#681)
 * The main search pane now auto-refreshes during pcap import to show additional Zeek logs as they're created (#713)
 * Fix an issue where the Wireshark button was not active when re-opening a deleted Space (#722)
 * Fix an issue where filenames containing the `#` character could not be opened in Brim (#723)


### PR DESCRIPTION
While copying the `v0.9.0` changelog into the notes in the Releases tab on GitHub, I saw that I'd mistakenly put in the Issue links for two items instead of the PR links. I fixed them on the Releases tab, but here I'm circling back to correct them in the changelog for consistency.