### PR TITLE
bare repository_dispatch handler

### DIFF
--- a/.github/workflows/advance-zq.yml
+++ b/.github/workflows/advance-zq.yml
@@ -1,0 +1,12 @@
+name: Advance ZQ
+# This type must match the event type from zq.
+# https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
+on:
+  repository_dispatch:
+    types: [zq-pr-merged]
+jobs:
+  advance-zq:
+    name: Advance ZQ
+    runs-on: ubuntu-18.04
+    steps:
+      - run: jq < "${GITHUB_EVENT_PATH}"


### PR DESCRIPTION
https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch says

> This event will only trigger a workflow run if the workflow file is on the master or default branch.

Start with this bare one in order to at least show zq can communicate to brim.