### PR TITLE
Zeek Runner User Preference

### DIFF
--- a/src/css/_ingest-warnings-modal.scss
+++ b/src/css/_ingest-warnings-modal.scss
@@ -1,6 +1,7 @@
 .ingest-warnings-modal {
   max-width: 90%;
   width: 800px;
+
   .text-content {
     display: flex;
     flex-direction: column;

--- a/src/css/_modal.scss
+++ b/src/css/_modal.scss
@@ -13,6 +13,7 @@
   padding: 2rem;
   padding-top: 4rem;
   z-index: 2;
+  user-select: none;
 }
 
 .modal-contents {

--- a/src/css/_modal.scss
+++ b/src/css/_modal.scss
@@ -13,7 +13,6 @@
   padding: 2rem;
   padding-top: 4rem;
   z-index: 2;
-  user-select: none;
 }
 
 .modal-contents {

--- a/src/css/_settings-modal.scss
+++ b/src/css/_settings-modal.scss
@@ -77,4 +77,16 @@
       @include label-small;
     }
   }
+
+  .feedback {
+    position: absolute;
+    right: 24px;
+    top: -11px;
+    @include label-small;
+    background: $blue;
+    color: white;
+    padding: 0 6px;
+    border-radius: 3px 3px 0 0;
+    animation: fadein 300ms;
+  }
 }

--- a/src/css/_settings-modal.scss
+++ b/src/css/_settings-modal.scss
@@ -13,7 +13,6 @@
     }
 
     select {
-      border: none;
       height: 24px;
       border: 1px solid rgba(0, 0, 0, 0.1);
       width: 240px;
@@ -21,6 +20,7 @@
 
     label {
       @include label-normal;
+      user-select: none;
     }
 
     input {

--- a/src/js/components/IngestWarningsModal.js
+++ b/src/js/components/IngestWarningsModal.js
@@ -3,7 +3,9 @@
 import {useSelector} from "react-redux"
 import React from "react"
 
+import {JSON_TYPE_CONFIG_DOCS} from "./Preferences/JSONTypeConfig"
 import {globalDispatch} from "../state/GlobalContext"
+import Link from "./common/Link"
 import ModalBox from "./ModalBox/ModalBox"
 import Spaces from "../state/Spaces"
 import Tab from "../state/Tab"
@@ -31,7 +33,15 @@ export default function IngestWarningsModal() {
     >
       <TextContent>
         {warnings.length ? (
-          <pre className="output">{warnings.join("\n")}</pre>
+          <>
+            <p>
+              If you are trying to import JSON logs, please review the{" "}
+              <Link href={JSON_TYPE_CONFIG_DOCS}>
+                JSON type configuration docs.
+              </Link>
+            </p>
+            <pre className="output">{warnings.join("\n")}</pre>
+          </>
         ) : (
           <p>Warnings cleared.</p>
         )}

--- a/src/js/components/Preferences/FileInput.js
+++ b/src/js/components/Preferences/FileInput.js
@@ -1,0 +1,59 @@
+/* @flow */
+import React, {useState} from "react"
+import classNames from "classnames"
+
+import ToolbarButton from "../ToolbarButton"
+import useCallbackRef from "../hooks/useCallbackRef"
+import useDropzone from "../hooks/useDropzone"
+
+type Props = {|
+  defaultValue: string,
+  name: string,
+  placeholder?: string,
+  onChange?: Function
+|}
+
+export default function FileInput(props: Props) {
+  let [picker, ref] = useCallbackRef()
+  let [bindDropzone, dragging] = useDropzone(onDrop)
+  let [value, setValue] = useState(props.defaultValue)
+
+  function onChange(e) {
+    setValue(e.target.value)
+    props.onChange && props.onChange(e)
+  }
+
+  function onPick(e) {
+    let path = Array.from(e.target.files).map((f) => f.path)[0]
+    setValue(path)
+  }
+
+  function onDrop(e) {
+    let path = Array.from(e.dataTransfer.files).map((f) => f.path)[0]
+    setValue(path)
+  }
+
+  return (
+    <div className="file-input-picker">
+      <ToolbarButton
+        className={classNames({dragging})}
+        text="Choose..."
+        onClick={() => picker && picker.click()}
+        {...bindDropzone()}
+      />
+      <input
+        name={props.name}
+        type="text"
+        value={value}
+        onChange={onChange}
+        placeholder={props.placeholder}
+      />
+      <input
+        ref={ref}
+        type="file"
+        style={{display: "none"}}
+        onChange={onPick}
+      />
+    </div>
+  )
+}

--- a/src/js/components/Preferences/JSONTypeConfig.js
+++ b/src/js/components/Preferences/JSONTypeConfig.js
@@ -1,59 +1,25 @@
 /* @flow */
-import React, {useState} from "react"
-import classNames from "classnames"
+import React from "react"
 
 import type {FormFieldConfig} from "../../brim/form"
-import ToolbarButton from "../ToolbarButton"
-import useCallbackRef from "../hooks/useCallbackRef"
-import useDropzone from "../hooks/useDropzone"
+import FileInput from "./FileInput"
+import Link from "../common/Link"
 
 type Props = {
   config: FormFieldConfig
 }
 
+export const JSON_TYPE_CONFIG_DOCS =
+  "https://github.com/brimsec/brim/wiki/Zeek-JSON-Import"
+
 export default function JSONTypeConfig({config}: Props) {
-  let [picker, ref] = useCallbackRef()
-  let [bindDropzone, dragging] = useDropzone(onDrop)
-  let [value, setValue] = useState(config.defaultValue)
-
-  function onChange(value) {
-    setValue(value)
-  }
-
-  function onPick(e) {
-    let path = Array.from(e.target.files).map((f) => f.path)[0]
-    onChange(path)
-  }
-
-  function onDrop(e) {
-    let path = Array.from(e.dataTransfer.files).map((f) => f.path)[0]
-    onChange(path)
-  }
-
+  let {name, label, defaultValue} = config
   return (
     <div className="setting-panel">
-      <label>{config.label}: </label>
-      <div className="file-input-picker">
-        <ToolbarButton
-          className={classNames({dragging})}
-          text="Choose..."
-          onClick={() => picker && picker.click()}
-          {...bindDropzone()}
-        />
-        <input
-          name={config.name}
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder="default"
-        />
-        <input
-          ref={ref}
-          type="file"
-          style={{display: "none"}}
-          onChange={onPick}
-        />
-      </div>
+      <label>
+        {label}: <Link href={JSON_TYPE_CONFIG_DOCS}>(docs)</Link>
+      </label>
+      <FileInput {...{name, defaultValue, placeholder: "default"}} />
     </div>
   )
 }

--- a/src/js/components/Preferences/Preferences.js
+++ b/src/js/components/Preferences/Preferences.js
@@ -9,6 +9,7 @@ import ModalBox from "../ModalBox/ModalBox"
 import TextContent from "../TextContent"
 import TimeFormat from "./TimeFormat"
 import Timezone from "./Timezone"
+import ZeekRunner from "./ZeekRunner"
 import brim from "../../brim"
 import useCallbackRef from "../hooks/useCallbackRef"
 import usePreferencesForm from "./usePreferencesForm"
@@ -46,6 +47,7 @@ export default function Preferences() {
         <form ref={setForm} className="settings-form">
           <Timezone config={prefsForm.timeZone} />
           <TimeFormat config={prefsForm.timeFormat} />
+          <ZeekRunner config={prefsForm.zeekRunner} />
           <JSONTypeConfig config={prefsForm.jsonTypeConfig} />
         </form>
       </TextContent>

--- a/src/js/components/Preferences/TimeFormat.js
+++ b/src/js/components/Preferences/TimeFormat.js
@@ -1,21 +1,19 @@
 /* @flow */
 import React from "react"
 
-import {shell} from "electron"
-
 import type {FormFieldConfig} from "../../brim/form"
+import Link from "../common/Link"
 
 type Props = {config: FormFieldConfig}
 
-export default function TimeFormat({config}: Props) {
-  const openDocs = () =>
-    shell.openExternal("https://momentjs.com/docs/#/displaying/format/")
+const DOCS = "https://momentjs.com/docs/#/displaying/format/"
 
+export default function TimeFormat({config}: Props) {
   return (
     <div className="setting-panel">
       <div>
         <label>
-          {config.label}: <a onClick={openDocs}>(docs)</a>
+          {config.label}: <Link href={DOCS}>(docs)</Link>
         </label>
       </div>
       <input

--- a/src/js/components/Preferences/ZeekRunner.js
+++ b/src/js/components/Preferences/ZeekRunner.js
@@ -1,61 +1,36 @@
 /* @flow */
 import React, {useState} from "react"
-import classNames from "classnames"
 
 import type {FormFieldConfig} from "../../brim/form"
-import ToolbarButton from "../ToolbarButton"
-import useCallbackRef from "../hooks/useCallbackRef"
-import useDropzone from "../hooks/useDropzone"
+import FileInput from "./FileInput"
+import Link from "../common/Link"
 
 type Props = {
   config: FormFieldConfig
 }
 
+const DOCS = "https://github.com/brimsec/brim/wiki"
+
 export default function ZeekRunner({config}: Props) {
-  let [picker, ref] = useCallbackRef()
-  let [bindDropzone, dragging] = useDropzone(onDrop)
-  let [value, setValue] = useState(config.defaultValue)
-  let showRestartMsg = value !== config.defaultValue
+  let {name, label, defaultValue} = config
+  let [showFeedback, setShowFeedback] = useState(false)
 
-  function onChange(value) {
-    setValue(value)
-  }
-
-  function onPick(e) {
-    let path = Array.from(e.target.files).map((f) => f.path)[0]
-    onChange(path)
-  }
-
-  function onDrop(e) {
-    let path = Array.from(e.dataTransfer.files).map((f) => f.path)[0]
-    onChange(path)
+  function onChange(e) {
+    setShowFeedback(e.target.value !== defaultValue)
   }
 
   return (
     <div className="setting-panel">
-      <label>{config.label}:</label>
-      <div className="file-input-picker">
-        <ToolbarButton
-          className={classNames({dragging})}
-          text="Choose..."
-          onClick={() => picker && picker.click()}
-          {...bindDropzone()}
-        />
-        <input
-          name={config.name}
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder="default"
-        />
-        <input
-          ref={ref}
-          type="file"
-          style={{display: "none"}}
-          onChange={onPick}
-        />
-        {showRestartMsg ? <p className="feedback">Restart required.</p> : null}
-      </div>
+      <label>
+        {config.label}: <Link href={DOCS}>(docs)</Link>
+      </label>
+      <FileInput
+        name={name}
+        defaultValue={defaultValue}
+        onChange={onChange}
+        placeholder="default"
+      />
+      {showFeedback ? <p className="feedback">Restart required.</p> : null}
     </div>
   )
 }

--- a/src/js/components/Preferences/ZeekRunner.js
+++ b/src/js/components/Preferences/ZeekRunner.js
@@ -1,0 +1,59 @@
+/* @flow */
+import React, {useState} from "react"
+import classNames from "classnames"
+
+import type {FormFieldConfig} from "../../brim/form"
+import ToolbarButton from "../ToolbarButton"
+import useCallbackRef from "../hooks/useCallbackRef"
+import useDropzone from "../hooks/useDropzone"
+
+type Props = {
+  config: FormFieldConfig
+}
+
+export default function ZeekRunner({config}: Props) {
+  let [picker, ref] = useCallbackRef()
+  let [bindDropzone, dragging] = useDropzone(onDrop)
+  let [value, setValue] = useState(config.defaultValue)
+
+  function onChange(value) {
+    setValue(value)
+  }
+
+  function onPick(e) {
+    let path = Array.from(e.target.files).map((f) => f.path)[0]
+    onChange(path)
+  }
+
+  function onDrop(e) {
+    let path = Array.from(e.dataTransfer.files).map((f) => f.path)[0]
+    onChange(path)
+  }
+
+  return (
+    <div className="setting-panel">
+      <label>{config.label}: </label>
+      <div className="file-input-picker">
+        <ToolbarButton
+          className={classNames({dragging})}
+          text="Choose..."
+          onClick={() => picker && picker.click()}
+          {...bindDropzone()}
+        />
+        <input
+          name={config.name}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="default"
+        />
+        <input
+          ref={ref}
+          type="file"
+          style={{display: "none"}}
+          onChange={onPick}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/js/components/Preferences/ZeekRunner.js
+++ b/src/js/components/Preferences/ZeekRunner.js
@@ -15,6 +15,7 @@ export default function ZeekRunner({config}: Props) {
   let [picker, ref] = useCallbackRef()
   let [bindDropzone, dragging] = useDropzone(onDrop)
   let [value, setValue] = useState(config.defaultValue)
+  let showRestartMsg = value !== config.defaultValue
 
   function onChange(value) {
     setValue(value)
@@ -32,7 +33,7 @@ export default function ZeekRunner({config}: Props) {
 
   return (
     <div className="setting-panel">
-      <label>{config.label}: </label>
+      <label>{config.label}:</label>
       <div className="file-input-picker">
         <ToolbarButton
           className={classNames({dragging})}
@@ -53,6 +54,7 @@ export default function ZeekRunner({config}: Props) {
           style={{display: "none"}}
           onChange={onPick}
         />
+        {showRestartMsg ? <p className="feedback">Restart required.</p> : null}
       </div>
     </div>
   )

--- a/src/js/components/Preferences/usePreferencesForm.js
+++ b/src/js/components/Preferences/usePreferencesForm.js
@@ -27,8 +27,8 @@ export default function usePreferencesForm(): FormConfig {
     zeekRunner: {
       name: "zeekRunner",
       label: "Zeek Runner",
-      defaultValue: "run zeek, run!",
-      submit: () => {},
+      defaultValue: useSelector(Prefs.getZeekRunner),
+      submit: (value) => globalDispatch(Prefs.setZeekRunner(value)),
       check: (path) => {
         if (path === "") return [true, ""]
         return lib

--- a/src/js/components/Preferences/usePreferencesForm.js
+++ b/src/js/components/Preferences/usePreferencesForm.js
@@ -8,7 +8,7 @@ import Prefs from "../../state/Prefs"
 import View from "../../state/View"
 import lib from "../../lib"
 
-export default function(): FormConfig {
+export default function usePreferencesForm(): FormConfig {
   let dispatch = useDispatch()
   return {
     timeZone: {
@@ -23,6 +23,19 @@ export default function(): FormConfig {
       label: "Time Format",
       defaultValue: useSelector(Prefs.getTimeFormat),
       submit: (value) => globalDispatch(Prefs.setTimeFormat(value))
+    },
+    zeekRunner: {
+      name: "zeekRunner",
+      label: "Zeek Runner",
+      defaultValue: "run zeek, run!",
+      submit: () => {},
+      check: (path) => {
+        if (path === "") return [true, ""]
+        return lib
+          .file(path)
+          .exists()
+          .then((exists) => [exists, "file does not exist."])
+      }
     },
     jsonTypeConfig: {
       name: "jsonTypeConfig",

--- a/src/js/components/common/Link.js
+++ b/src/js/components/common/Link.js
@@ -1,0 +1,10 @@
+/* @flow */
+import React from "react"
+
+import {shell} from "electron"
+
+type Props = {|href: string, children: *|}
+
+export default function Link({href, children}: Props) {
+  return <a onClick={() => shell.openExternal(href)}>{children}</a>
+}

--- a/src/js/components/common/Link.js
+++ b/src/js/components/common/Link.js
@@ -6,5 +6,13 @@ import {shell} from "electron"
 type Props = {|href: string, children: *|}
 
 export default function Link({href, children}: Props) {
-  return <a onClick={() => shell.openExternal(href)}>{children}</a>
+  const click = (e) => {
+    e.preventDefault()
+    shell.openExternal(href)
+  }
+  return (
+    <a href={"" /* triggers underline style */} onClick={click}>
+      {children}
+    </a>
+  )
 }

--- a/src/js/electron/main.js
+++ b/src/js/electron/main.js
@@ -1,5 +1,6 @@
 /* @flow */
 import {appPathSetup} from "./appPathSetup"
+import Prefs from "../state/Prefs"
 import userTasks from "./userTasks"
 
 // app path and log setup should happen before other imports.
@@ -37,7 +38,8 @@ async function main() {
   )
 
   const spaceDir = path.join(app.getPath("userData"), "data", "spaces")
-  const zqd = new ZQD(spaceDir)
+  const zeekRunner = Prefs.getZeekRunner(store.getState())
+  const zqd = new ZQD(spaceDir, zeekRunner)
 
   menu.setMenu(winMan)
   zqdMainHandler(zqd)

--- a/src/js/state/Prefs/actions.js
+++ b/src/js/state/Prefs/actions.js
@@ -1,6 +1,10 @@
 /* @flow */
 
-import type {PREFS_JSON_TYPES_CONFIG_SET, PREFS_TIME_FORMAT_SET} from "./types"
+import type {
+  PREFS_JSON_TYPES_CONFIG_SET,
+  PREFS_TIME_FORMAT_SET,
+  PREFS_ZEEK_RUNNER_SET
+} from "./types"
 
 export default {
   setJSONTypeConfig: (path: string): PREFS_JSON_TYPES_CONFIG_SET => ({
@@ -11,5 +15,10 @@ export default {
   setTimeFormat: (format: string): PREFS_TIME_FORMAT_SET => ({
     type: "PREFS_TIME_FORMAT_SET",
     format
+  }),
+
+  setZeekRunner: (zeekRunner: string): PREFS_ZEEK_RUNNER_SET => ({
+    type: "PREFS_ZEEK_RUNNER_SET",
+    zeekRunner
   })
 }

--- a/src/js/state/Prefs/reducer.js
+++ b/src/js/state/Prefs/reducer.js
@@ -4,7 +4,8 @@ import type {PrefsAction, PrefsState} from "./types"
 
 const init: PrefsState = {
   jsonTypeConfig: "",
-  timeFormat: ""
+  timeFormat: "",
+  zeekRunner: ""
 }
 
 export default function reducer(
@@ -21,6 +22,11 @@ export default function reducer(
       return {
         ...state,
         timeFormat: action.format
+      }
+    case "PREFS_ZEEK_RUNNER_SET":
+      return {
+        ...state,
+        zeekRunner: action.zeekRunner
       }
     default:
       return state

--- a/src/js/state/Prefs/selectors.js
+++ b/src/js/state/Prefs/selectors.js
@@ -4,5 +4,6 @@ import type {State} from "../types"
 
 export default {
   getJSONTypeConfig: (state: State) => state.prefs.jsonTypeConfig,
-  getTimeFormat: (state: State) => state.prefs.timeFormat
+  getTimeFormat: (state: State) => state.prefs.timeFormat,
+  getZeekRunner: (state: State) => state.prefs.zeekRunner
 }

--- a/src/js/state/Prefs/test.js
+++ b/src/js/state/Prefs/test.js
@@ -25,3 +25,9 @@ test("set the preferred time format", () => {
 
   expect(Prefs.getTimeFormat(state)).toEqual("YYYY")
 })
+
+test("set the zeek runner", () => {
+  let state = store.dispatchAll([Prefs.setZeekRunner("/run/zeek/run")])
+
+  expect(Prefs.getZeekRunner(state)).toEqual("/run/zeek/run")
+})

--- a/src/js/state/Prefs/types.js
+++ b/src/js/state/Prefs/types.js
@@ -1,11 +1,15 @@
 /* @flow */
 
-export type PrefsState = {
+export type PrefsState = {|
   jsonTypeConfig: string,
-  timeFormat: string
-}
+  timeFormat: string,
+  zeekRunner: string
+|}
 
-export type PrefsAction = PREFS_JSON_TYPES_CONFIG_SET | PREFS_TIME_FORMAT_SET
+export type PrefsAction =
+  | PREFS_JSON_TYPES_CONFIG_SET
+  | PREFS_TIME_FORMAT_SET
+  | PREFS_ZEEK_RUNNER_SET
 
 export type PREFS_JSON_TYPES_CONFIG_SET = {
   type: "PREFS_JSON_TYPES_CONFIG_SET",
@@ -15,4 +19,9 @@ export type PREFS_JSON_TYPES_CONFIG_SET = {
 export type PREFS_TIME_FORMAT_SET = {
   type: "PREFS_TIME_FORMAT_SET",
   format: string
+}
+
+export type PREFS_ZEEK_RUNNER_SET = {
+  type: "PREFS_ZEEK_RUNNER_SET",
+  zeekRunner: string
 }


### PR DESCRIPTION
The ZQD class will now look in the global preferences for a user specified zeek runner. This means that if a user changes the value, it will not be in effect until the app is restarted. Because of this, whenever the value changes, we show a message "Restart required."

<img width="972" alt="image" src="https://user-images.githubusercontent.com/3460638/81755597-0d611100-946e-11ea-8f54-336f65b8c413.png">

<img width="314" alt="Screen Shot 2020-05-12 at 4 27 25 PM" src="https://user-images.githubusercontent.com/3460638/81755612-17830f80-946e-11ea-872b-36b4d7e32931.png">

fixes: #741