### PR TITLE
fix: Store spaceId in request handler state

### DIFF
--- a/src/js/flows/confirmUnload.js
+++ b/src/js/flows/confirmUnload.js
@@ -3,14 +3,18 @@ import {isEmpty} from "lodash"
 
 import type {Thunk} from "../state/types"
 import Handlers from "../state/Handlers"
+import Spaces from "../state/Spaces"
+import Tab from "../state/Tab"
 import showIngestWarning from "./showIngestWarning"
 
 export default (): Thunk => (dispatch, getState) => {
-  let spaces = Handlers.getIngestSpaceNames(getState())
+  let spaceIds = Handlers.getIngestSpaceIds(getState())
 
-  if (isEmpty(spaces)) {
+  if (isEmpty(spaceIds)) {
     return Promise.resolve()
   } else {
-    return showIngestWarning(spaces)
+    let clusterId = Tab.clusterId(getState())
+    let names = spaceIds.map((id) => Spaces.get(clusterId, id)(getState()).name)
+    return showIngestWarning(names)
   }
 }

--- a/src/js/flows/confirmUnload.js
+++ b/src/js/flows/confirmUnload.js
@@ -14,7 +14,11 @@ export default (): Thunk => (dispatch, getState) => {
     return Promise.resolve()
   } else {
     let clusterId = Tab.clusterId(getState())
-    let names = spaceIds.map((id) => Spaces.get(clusterId, id)(getState()).name)
+    let names = spaceIds.map((id) => {
+      let space = Spaces.get(clusterId, id)(getState())
+      if (space) return space.name
+      else return id
+    })
     return showIngestWarning(names)
   }
 }

--- a/src/js/flows/deletePartialSpaces.js
+++ b/src/js/flows/deletePartialSpaces.js
@@ -6,17 +6,17 @@ import rpc from "../electron/rpc"
 
 export default (): Thunk => (_, getState) => {
   let client = Tab.getZealot(getState())
-  let spaces = Handlers.getIngestSpaceNames(getState())
+  let spaceIds = Handlers.getIngestSpaceIds(getState())
   return Promise.all(
-    spaces.map((name) => {
-      rpc.log("starting delete for", name)
+    spaceIds.map((id) => {
+      rpc.log("starting delete for", id)
       return client.spaces
-        .delete(name)
+        .delete(id)
         .then(() => {
-          rpc.log("Deleted", name)
+          rpc.log("Deleted", id)
         })
         .catch((e) => {
-          rpc.log(`Unable to delete space: ${name}, reason: ${e}`)
+          rpc.log(`Unable to delete space: ${id}, reason: ${JSON.stringify(e)}`)
         })
     })
   )

--- a/src/js/flows/ingestFiles.js
+++ b/src/js/flows/ingestFiles.js
@@ -90,8 +90,8 @@ const createSpace = (client, dispatch, clusterId) => ({
 })
 
 const registerHandler = (dispatch, id) => ({
-  do({name}) {
-    let handle = {type: "INGEST", spaceName: name}
+  do({spaceId}) {
+    let handle = {type: "INGEST", spaceId}
     dispatch(Handlers.register(id, handle))
   },
   undo() {

--- a/src/js/flows/ingestFiles.test.js
+++ b/src/js/flows/ingestFiles.test.js
@@ -66,6 +66,22 @@ test("opening a pcap", async () => {
   })
 })
 
+test("register a handler with a space id", async () => {
+  let store = initTestStore()
+  let globalDispatch = store.dispatch
+  await store.dispatch(
+    ingestFiles([itestFile("sample.pcap")], mockClient, globalDispatch)
+  )
+
+  let handler = store.getActions().find((a) => a.type === "HANDLERS_REGISTER")
+
+  expect(handler).toEqual({
+    type: "HANDLERS_REGISTER",
+    handler: {type: "INGEST", spaceId: "spaceId"},
+    id: expect.any(String)
+  })
+})
+
 test("when there is an error", async () => {
   let store = initTestStore()
   let globalDispatch = store.dispatch

--- a/src/js/state/Handlers/selectors.js
+++ b/src/js/state/Handlers/selectors.js
@@ -4,8 +4,8 @@ import type {IngestHandler} from "./types"
 import type {State} from "../types"
 
 export default {
-  getIngestSpaceNames: (state: State): string[] => {
-    return getIngestHandlers(state).map((i) => i.spaceName)
+  getIngestSpaceIds: (state: State): string[] => {
+    return getIngestHandlers(state).map((i) => i.spaceId)
   }
 }
 

--- a/src/js/state/Handlers/types.js
+++ b/src/js/state/Handlers/types.js
@@ -11,7 +11,7 @@ export type SearchHandler = {
 
 export type IngestHandler = {
   type: "INGEST",
-  spaceName: string
+  spaceId: string
 }
 
 export type HandlersAction =


### PR DESCRIPTION
fixes #778 

We save the names of all spaces that are currently ingesting. This way we can clean up the spaces if they decided to quit the app.

Instead of saving the names, save the ids.