### PR TITLE
Migrations 2: CLI

### DIFF
--- a/bin/generator/index.js
+++ b/bin/generator/index.js
@@ -1,12 +1,14 @@
 /* @flow */
 
-const program = require("commander")
+import cli from "commander"
 
-const {handleReducer} = require("./reducer")
-const {handleStyle} = require("./style")
-const {handleIcon} = require("./icon")
+import {handleIcon} from "./icon"
+import {handleMigration} from "./migration"
+import {handleReducer} from "./reducer"
+import {handleStyle} from "./style"
 
-program.command("style <name>").action(handleStyle)
-program.command("reducer <name>").action(handleReducer)
-program.command("icon <path>").action(handleIcon)
-program.parse(process.argv)
+cli.command("style <name>").action(handleStyle)
+cli.command("reducer <name>").action(handleReducer)
+cli.command("icon <path>").action(handleIcon)
+cli.command("migration <name>").action(handleMigration)
+cli.parse(process.argv)

--- a/bin/generator/migration.js
+++ b/bin/generator/migration.js
@@ -1,0 +1,49 @@
+/* @flow */
+import {camelCase} from "lodash"
+import moment from "moment"
+
+import path from "path"
+
+import {write} from "../utils/file"
+import tron from "../../src/js/electron/tron"
+
+export async function handleMigration(input: string) {
+  let name = camelCase(input)
+  let version = moment().format("YYYYMMDDHHmm")
+  let title = version + "_" + name
+  let file = title + ".js"
+  let test = title + ".test.js"
+  let dir = path.join(__dirname, "../../src/js/state/migrations")
+
+  let migration = await tron.migration()
+  let prevVersion = migration.latestVersion()
+
+  write(path.join(dir, file), contents(name))
+  write(path.join(dir, test), testContents(title, version, prevVersion))
+}
+
+function contents(name) {
+  return `/* @flow */
+
+export default function ${name}(state: *) {
+  // Migrate state here
+  return state
+}
+`
+}
+
+function testContents(title, version, prevVersion) {
+  return `/* @flow */
+
+import getTestState from "../../test/helpers/getTestState"
+import migrate from "./${title}"
+
+test("migrating ${title}", () => {
+  let prev = getTestState("${prevVersion}")
+
+  let next = migrate(prev)
+
+  expect(next).toBe("what you'd expect")
+})
+`
+}

--- a/src/js/electron/tron/index.js
+++ b/src/js/electron/tron/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import migration from "./migration"
 import session from "./session"
 import window from "./window"
 import windowManager from "./windowManager"
@@ -7,5 +8,6 @@ import windowManager from "./windowManager"
 export default {
   window,
   windowManager,
-  session
+  session,
+  migration
 }

--- a/src/js/electron/tron/migration.js
+++ b/src/js/electron/tron/migration.js
@@ -1,0 +1,41 @@
+/* @flow */
+import path from "path"
+
+import {last} from "../../lib/Array"
+import lib from "../../lib"
+
+let dir = path.join(__dirname, "../../state/migrations")
+
+export default async function() {
+  let migrations = await lib
+    .file(dir)
+    .contents()
+    .then(excludeTests)
+    .then(build)
+
+  return {
+    latestVersion() {
+      return last(migrations).version
+    }
+  }
+}
+
+function excludeTests(files) {
+  return files.filter((f) => !/\.test\.js/.test(f))
+}
+
+function build(files) {
+  return files.map((f) => {
+    // $FlowFixMe
+    let migrate = require(path.join(dir, f)).default
+    return {
+      migrate,
+      ...destructure(f)
+    }
+  })
+}
+
+function destructure(f) {
+  let [version, name] = f.replace(".js", "").split("_")
+  return {version, name}
+}

--- a/src/js/state/migrations/9_initMigrations.js
+++ b/src/js/state/migrations/9_initMigrations.js
@@ -1,0 +1,4 @@
+/* @flow */
+export default function(state: *) {
+  return state
+}

--- a/src/js/test/helpers/getTestState.js
+++ b/src/js/test/helpers/getTestState.js
@@ -1,0 +1,18 @@
+/* @flow */
+import lib from "../../lib"
+import path from "path"
+
+export default (version: string) => {
+  let name = `${version}.json`
+  let file = path.join(__dirname, "../states", name)
+  let contents
+  try {
+    contents = lib.file(file).readSync()
+  } catch (e) {
+    throw new Error(`Missing Test state for Version ${version}
+No File: ${file}
+To create test state, run the app and navigate to...
+App Menu => Developer => Save Session for Testing Migrations`)
+  }
+  return JSON.parse(contents)
+}


### PR DESCRIPTION
A command line tool to use whenever you're developing and need to change the state of the app and include a migration.

For example, if I wanted to change min_time and max_time to now be called span, I'd create the migration like this:
```bash
bin/gen migration changeMinMaxTimeToSpan

  Created: src/js/state/migrations/202005141644_changeMinMaxTimeToSpan.js
  Created: src/js/state/migrations/202005141644_changeMinMaxTimeToSpan.test.js
```

These files would be created and stubbed out like this:
```js
// 202005141644_changeMinMaxTimeToSpan.js

export default function changeMinMaxTimeToSpan(state: *) {
  // Migrate state here
  return state
}
```

```js
// 202005141644_changeMinMaxTimeToSpan.test.js

import getTestState from "../../test/helpers/getTestState"
import migrate from "./202005141644_changeMinMaxTimeToSpan"

test("migrating 202005141644_changeMinMaxTimeToSpan", () => {
  let prev = getTestState("9")

  let next = migrate(prev)

  expect(next).toBe("what you'd expect")
})

```

Filling in these files is all that would be required to migrate the app. No more needing to increment version numbers.

In a future PR, the app will be changed to look at its own state version, look at the migrations folder, notice their is one or more pending migrations, run them, and update its version to the latest migration.

Based off: https://github.com/brimsec/brim/pull/781