### PR TITLE
Migrate state changes since v0.9.1

### DIFF
--- a/src/js/electron/menu/appMenu.js
+++ b/src/js/electron/menu/appMenu.js
@@ -4,7 +4,7 @@ import {shell, app, dialog} from "electron"
 import path from "path"
 
 import type {$WindowManager} from "../tron/windowManager"
-import {type Session} from "../tron"
+import type {Session} from "../tron"
 import config from "../config"
 import electronIsDev from "../isDev"
 import formatSessionState from "../tron/formatSessionState"

--- a/src/js/initializers/initShortcuts.js
+++ b/src/js/initializers/initShortcuts.js
@@ -43,6 +43,10 @@ export default (store: Store) => {
     ipcRenderer.send(channel, getPersistable(store.getState()))
   })
 
+  ipcRenderer.on("getState", (event, channel) => {
+    ipcRenderer.send(channel, getPersistable(store.getState()))
+  })
+
   ipcRenderer.on("showPreferences", () => {
     store.dispatch(Modal.show("settings"))
   })

--- a/src/js/state/migrations/202005181133_addTimeFormatPref.js
+++ b/src/js/state/migrations/202005181133_addTimeFormatPref.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+import {getAllStates} from "../../test/helpers/getTestState"
+
+export default function addTimeFormatPref(state: *) {
+  for (let s of getAllStates(state)) {
+    s.prefs.timeFormat = ""
+  }
+  return state
+}

--- a/src/js/state/migrations/202005181133_addTimeFormatPref.test.js
+++ b/src/js/state/migrations/202005181133_addTimeFormatPref.test.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+import Prefs from "../Prefs"
+import getTestState from "../../test/helpers/getTestState"
+import migrate from "./202005181133_addTimeFormatPref"
+
+test("migrating 202005181133_addTimeFormatPref", () => {
+  let prev = getTestState("v0.9.1")
+
+  let next = migrate(prev)
+
+  let timeFormat = Prefs.getTimeFormat(next.globalState)
+  expect(timeFormat).toBe("")
+})

--- a/src/js/state/migrations/202005181140_searchStateSpaceId.js
+++ b/src/js/state/migrations/202005181140_searchStateSpaceId.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import {getAllStates} from "../../test/helpers/getTestState"
+
+export default function searchStateSpaceId(state: *) {
+  for (let s of getAllStates(state)) {
+    if (!s.tabs) continue
+
+    for (let tab of s.tabs.data) {
+      let oldName = tab.search.space
+      tab.search.spaceName = oldName
+      tab.search.spaceId = oldName
+      delete tab.search.space
+    }
+  }
+
+  return state
+}

--- a/src/js/state/migrations/202005181140_searchStateSpaceId.test.js
+++ b/src/js/state/migrations/202005181140_searchStateSpaceId.test.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+import getTestState from "../../test/helpers/getTestState"
+import migrate from "./202005181140_searchStateSpaceId"
+
+// $FlowFixMe
+const getWinStates = (sess) => Object.values(sess.windows).map((w) => w.state)
+const getTabs = (state) => state.tabs.data
+const getNameId = (tab) => [tab.search.spaceName, tab.search.spaceId]
+
+test("migrating 202005181140_searchStateSpaceId", () => {
+  let prev = getTestState("v0.9.1")
+  expect(getWinStates(prev).length).toBe(1)
+
+  let next = migrate(prev)
+  expect(getWinStates(next).length).toBe(1)
+
+  for (let state of getWinStates(next)) {
+    let tabs = getTabs(state)
+
+    // Check that it removes the old key
+    for (let tab of tabs) expect(tab.search.space).toBe(undefined)
+
+    // Check each tab for the expected migration
+    expect(getNameId(tabs[0])).toEqual(["", ""])
+    expect(getNameId(tabs[1])).toEqual(["pcaps.brim", "pcaps.brim"])
+    expect(getNameId(tabs[2])).toEqual(["", ""])
+  }
+})

--- a/src/js/state/migrations/202005181158_spacesStateId.js
+++ b/src/js/state/migrations/202005181158_spacesStateId.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import {getAllStates} from "../../test/helpers/getTestState"
+
+export default function spacesStateId(sess: *) {
+  for (let s of getAllStates(sess)) {
+    for (let clusterId in s.spaces) {
+      let cluster = s.spaces[clusterId]
+      if (!cluster) continue
+
+      for (let spaceId in cluster) {
+        let space = cluster[spaceId]
+        if (!space) continue
+
+        space.id = space.name
+        space.pcap_support = space.packet_support
+        delete space.packet_support
+      }
+    }
+  }
+
+  return sess
+}

--- a/src/js/state/migrations/202005181158_spacesStateId.test.js
+++ b/src/js/state/migrations/202005181158_spacesStateId.test.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+import getTestState from "../../test/helpers/getTestState"
+import migrate from "./202005181158_spacesStateId"
+
+test("migrating 202005181158_spacesStateId", () => {
+  let prev = getTestState("v0.9.1")
+
+  let next = migrate(prev)
+
+  expect(next.globalState.spaces).toEqual({
+    zqd: {
+      "pcaps.brim": {
+        id: "pcaps.brim",
+        ingest: {
+          progress: null,
+          snapshot: 0,
+          warnings: []
+        },
+        max_time: {
+          ns: 140103001,
+          sec: 1428917565
+        },
+        min_time: {
+          ns: 47800000,
+          sec: 1425567042
+        },
+        name: "pcaps.brim",
+        packet_path: "",
+        packet_size: 0,
+        pcap_support: false,
+        size: 50281455
+      }
+    }
+  })
+})


### PR DESCRIPTION
Finally, we use the new migration framework to migrate the following.


```diff
src/js/state/Prefs/types.js

 export type PrefsState = {
   jsonTypeConfig: string
+  timeFormat: string,
+  zeekRunner: string
 }
```

```diff
src/js/state/Search/types.js

@@ -7,7 +7,8 @@ export type SearchState = {
   span: Span,
   spanArgs: SpanArgs,
   spanFocus: ?Span,
-  space: string,
+  spaceName: string,
+  spaceId: string,
   clusterId: string,
   ts: number
 }
```

```diff
src/js/state/Spaces/types.js

 export type SpacesState = {
   // clusterId
   [string]: {
-    // spaceName
+    // spaceId
     [string]: Space
   }
 }

 export type Space = {
   name: string,
+  id: string,
   min_time: Ts,
   max_time: Ts,
-  packet_support: boolean,
+  pcap_support: boolean,
   ingest: SpaceIngest
 }
```

The command used to find these changes was this: 
```
git diff v0.9.1..head -- `find src/js/state -name types.js`
```