### PR TITLE
User dataDir preference

### DIFF
--- a/src/js/brim/ingest/getParams.js
+++ b/src/js/brim/ingest/getParams.js
@@ -17,7 +17,7 @@ export type IngestParamsError = {
 
 export default function getParams(
   data: FileListData,
-  dataDir: string,
+  dataDir?: string,
   now: Date = new Date()
 ): IngestParams | IngestParamsError {
   let files = fileList(data)

--- a/src/js/brim/ingest/getParams.js
+++ b/src/js/brim/ingest/getParams.js
@@ -3,6 +3,7 @@ import type {IngestFileType} from "./detectFileType"
 import fileList, {type FileListData} from "./fileList"
 import time from "../time"
 import lib from "../../lib"
+import path from "path"
 
 export type IngestParams = {
   dataDir: string,
@@ -16,6 +17,7 @@ export type IngestParamsError = {
 
 export default function getParams(
   data: FileListData,
+  dataDir: string,
   now: Date = new Date()
 ): IngestParams | IngestParamsError {
   let files = fileList(data)
@@ -27,8 +29,7 @@ export default function getParams(
   }
 
   function getDataDir() {
-    // TODO: use user preferences when they exist https://github.com/brimsec/brim/issues/676
-    return ""
+    return dataDir ? path.join(dataDir, getSpaceName()) : ""
   }
 
   function getSpaceName() {

--- a/src/js/brim/ingest/test.js
+++ b/src/js/brim/ingest/test.js
@@ -43,6 +43,7 @@ test("two zeek logs in different dir default", () => {
       {type: "log", path: "/work/day-1/zeek.log"},
       {type: "log", path: "/work/day-2/zeek.log"}
     ],
+    "",
     new Date(0)
   )
 

--- a/src/js/components/Preferences/DataDirInput.js
+++ b/src/js/components/Preferences/DataDirInput.js
@@ -1,0 +1,19 @@
+/* @flow */
+import React from "react"
+
+import type {FormFieldConfig} from "../../brim/form"
+import FileInput from "./FileInput"
+
+type Props = {
+  config: FormFieldConfig
+}
+
+export default function DataDirInput({config}: Props) {
+  let {name, label, defaultValue} = config
+  return (
+    <div className="setting-panel">
+      <label>{label}</label>
+      <FileInput isDirInput {...{name, defaultValue, placeholder: "default"}} />
+    </div>
+  )
+}

--- a/src/js/components/Preferences/Preferences.js
+++ b/src/js/components/Preferences/Preferences.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React, {useCallback, useState} from "react"
+import React, {useCallback, useState, useEffect} from "react"
 
 import {reactElementProps} from "../../test/integration"
 import FormErrors from "./FormErrors"
@@ -13,6 +13,7 @@ import ZeekRunner from "./ZeekRunner"
 import brim from "../../brim"
 import useCallbackRef from "../hooks/useCallbackRef"
 import usePreferencesForm from "./usePreferencesForm"
+import DataDirInput from "./DataDirInput"
 
 export default function Preferences() {
   let [f, setForm] = useCallbackRef<HTMLFormElement>()
@@ -25,6 +26,7 @@ export default function Preferences() {
       let form = brim.form(f, prefsForm)
 
       if (await form.isValid()) {
+        setErrors([])
         form.submit()
         closeModal()
       } else {
@@ -49,6 +51,7 @@ export default function Preferences() {
           <TimeFormat config={prefsForm.timeFormat} />
           <ZeekRunner config={prefsForm.zeekRunner} />
           <JSONTypeConfig config={prefsForm.jsonTypeConfig} />
+          <DataDirInput config={prefsForm.dataDir} />
         </form>
       </TextContent>
     </ModalBox>

--- a/src/js/components/Preferences/Preferences.js
+++ b/src/js/components/Preferences/Preferences.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React, {useCallback, useState, useEffect} from "react"
+import React, {useCallback, useState} from "react"
 
 import {reactElementProps} from "../../test/integration"
 import FormErrors from "./FormErrors"

--- a/src/js/components/Preferences/usePreferencesForm.js
+++ b/src/js/components/Preferences/usePreferencesForm.js
@@ -59,6 +59,25 @@ export default function usePreferencesForm(): FormConfig {
             }
           })
       }
+    },
+    dataDir: {
+      name: "dataDir",
+      label: "Data Directory",
+      defaultValue: useSelector(Prefs.getDataDir),
+      submit: (value) => globalDispatch(Prefs.setDataDir(value)),
+      check: (path) => {
+        if (path === "") return [true, ""]
+        return lib
+          .file(path)
+          .isDirectory()
+          .then((isDir) => [isDir, "Selection must be a directory"])
+          .catch((e) => {
+            let msg = e.name + ": " + e.message
+            return /ENOENT/.test(msg)
+              ? [false, "Directory does not exist."]
+              : [false, msg]
+          })
+      }
     }
   }
 }

--- a/src/js/electron/ipc/types.js
+++ b/src/js/electron/ipc/types.js
@@ -10,6 +10,7 @@ export type IpcMsg =
   | WindowsInitialStateMsg
   | WindowsDestroyMsg
   | WindowsNewSearchTabMsg
+  | WindowsOpenDirectorySelect
   | GlobalStoreInitMsg
   | GlobalStoreDispatchMsg
 

--- a/src/js/electron/ipc/types.js
+++ b/src/js/electron/ipc/types.js
@@ -38,6 +38,10 @@ export type WindowsNewSearchTabMsg = {
   params: NewTabSearchParams
 }
 
+export type WindowsOpenDirectorySelect = {
+  channel: "windows:openDirectorySelect"
+}
+
 export type GlobalStoreInitMsg = {
   channel: "globalStore:init"
 }

--- a/src/js/electron/ipc/windows/mainHandler.js
+++ b/src/js/electron/ipc/windows/mainHandler.js
@@ -1,5 +1,5 @@
 /* @flow */
-import {BrowserWindow, ipcMain} from "electron"
+import {BrowserWindow, dialog, ipcMain} from "electron"
 import log from "electron-log"
 
 import type {$WindowManager} from "../../tron/windowManager"
@@ -52,5 +52,12 @@ export default function(manager: $WindowManager) {
 
   ipcMain.handle("windows:log", (e, {id, args}) => {
     log.info(`[${id}]: `, ...args)
+  })
+
+  ipcMain.handle("windows:openDirectorySelect", async (e) => {
+    const win = BrowserWindow.fromWebContents(e.sender)
+    return await dialog.showOpenDialog(win, {
+      properties: ["openDirectory"]
+    })
   })
 }

--- a/src/js/electron/ipc/windows/messages.js
+++ b/src/js/electron/ipc/windows/messages.js
@@ -52,5 +52,10 @@ export default {
       channel: "windows:initialState",
       id
     }
+  },
+  openDirectorySelect(): WindowsOpenDirectorySelect {
+    return {
+      channel: "windows:openDirectorySelect"
+    }
   }
 }

--- a/src/js/electron/ipc/windows/messages.js
+++ b/src/js/electron/ipc/windows/messages.js
@@ -6,7 +6,8 @@ import type {
   WindowsDestroyMsg,
   WindowsInitialStateMsg,
   WindowsOpenMsg,
-  WindowsNewSearchTabMsg
+  WindowsNewSearchTabMsg,
+  WindowsOpenDirectorySelect
 } from "../types"
 import type {State} from "../../../state/types"
 import type {SpanArgs} from "../../../state/Search/types"

--- a/src/js/flows/ingestFiles.js
+++ b/src/js/flows/ingestFiles.js
@@ -25,9 +25,10 @@ export default (
   let tabId = Tabs.getActive(getState())
   let requestId = brim.randomHash()
   let jsonTypeConfigPath = Prefs.getJSONTypeConfig(getState())
+  const dataDir = Prefs.getDataDir(getState())
 
   return lib.transaction([
-    validateInput(paths),
+    validateInput(paths, dataDir),
     createDir(),
     createSpace(client, gDispatch, clusterId),
     registerHandler(dispatch, requestId),
@@ -38,11 +39,11 @@ export default (
   ])
 }
 
-const validateInput = (paths) => ({
+const validateInput = (paths, dataDir) => ({
   async do() {
     let params = await ingest
       .detectFileTypes(paths)
-      .then(ingest.getParams)
+      .then((data) => ingest.getParams(data, dataDir))
       .catch((e) => {
         if (e.message.startsWith("EISDIR"))
           throw new Error(
@@ -68,7 +69,7 @@ const createSpace = (client, dispatch, clusterId) => ({
   async do(params) {
     let createParams
     if (params.dataDir) {
-      createParams = {data_dir: params.dataDir}
+      createParams = {data_path: params.dataDir}
     } else {
       createParams = {name: params.name}
     }

--- a/src/js/lib/file.js
+++ b/src/js/lib/file.js
@@ -18,19 +18,21 @@ export default function file(p: string) {
     },
 
     allFiles() {
-      return this.stats().then((stats) => {
-        if (stats.isDirectory()) {
-          return this.contents()
-            .then((files) =>
-              Promise.all(files.map((f) => file(path.join(p, f)).allFiles()))
-            )
-            .then((results) =>
-              results.reduce<string[]>((all, one) => all.concat(one), [])
-            )
-        } else {
-          return [p]
-        }
+      return this.isDirectory().then((isDir) => {
+        return isDir
+          ? this.contents()
+              .then((files) =>
+                Promise.all(files.map((f) => file(path.join(p, f)).allFiles()))
+              )
+              .then((results) =>
+                results.reduce<string[]>((all, one) => all.concat(one), [])
+              )
+          : [p]
       })
+    },
+
+    isDirectory() {
+      return this.stats().then((stats) => stats.isDirectory())
     },
 
     contents() {

--- a/src/js/services/zealot/spacesApi.js
+++ b/src/js/services/zealot/spacesApi.js
@@ -1,5 +1,5 @@
 /* @flow */
-export type SpacesCreateArgs = {name?: string, data_dir?: string}
+export type SpacesCreateArgs = {name?: string, data_path?: string}
 export type SpacesUpdateArgs = {name: string}
 
 export default {

--- a/src/js/state/Prefs/actions.js
+++ b/src/js/state/Prefs/actions.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import type {
+  PREFS_DATA_DIR_SET,
   PREFS_JSON_TYPES_CONFIG_SET,
   PREFS_TIME_FORMAT_SET,
   PREFS_ZEEK_RUNNER_SET
@@ -20,5 +21,10 @@ export default {
   setZeekRunner: (zeekRunner: string): PREFS_ZEEK_RUNNER_SET => ({
     type: "PREFS_ZEEK_RUNNER_SET",
     zeekRunner
+  }),
+
+  setDataDir: (dataDir: string): PREFS_DATA_DIR_SET => ({
+    type: "PREFS_DATA_DIR_SET",
+    dataDir
   })
 }

--- a/src/js/state/Prefs/reducer.js
+++ b/src/js/state/Prefs/reducer.js
@@ -5,7 +5,8 @@ import type {PrefsAction, PrefsState} from "./types"
 const init: PrefsState = {
   jsonTypeConfig: "",
   timeFormat: "",
-  zeekRunner: ""
+  zeekRunner: "",
+  dataDir: ""
 }
 
 export default function reducer(
@@ -27,6 +28,11 @@ export default function reducer(
       return {
         ...state,
         zeekRunner: action.zeekRunner
+      }
+    case "PREFS_DATA_DIR_SET":
+      return {
+        ...state,
+        dataDir: action.dataDir
       }
     default:
       return state

--- a/src/js/state/Prefs/selectors.js
+++ b/src/js/state/Prefs/selectors.js
@@ -5,5 +5,6 @@ import type {State} from "../types"
 export default {
   getJSONTypeConfig: (state: State) => state.prefs.jsonTypeConfig,
   getTimeFormat: (state: State) => state.prefs.timeFormat,
-  getZeekRunner: (state: State) => state.prefs.zeekRunner
+  getZeekRunner: (state: State) => state.prefs.zeekRunner,
+  getDataDir: (state: State) => state.prefs.dataDir
 }

--- a/src/js/state/Prefs/test.js
+++ b/src/js/state/Prefs/test.js
@@ -31,3 +31,10 @@ test("set the zeek runner", () => {
 
   expect(Prefs.getZeekRunner(state)).toEqual("/run/zeek/run")
 })
+
+test("set the dataDir", () => {
+  const testDir = "/my/own/data/dir"
+  const state = store.dispatchAll([Prefs.setDataDir(testDir)])
+
+  expect(Prefs.getDataDir(state)).toEqual(testDir)
+})

--- a/src/js/state/Prefs/types.js
+++ b/src/js/state/Prefs/types.js
@@ -3,13 +3,15 @@
 export type PrefsState = {|
   jsonTypeConfig: string,
   timeFormat: string,
-  zeekRunner: string
+  zeekRunner: string,
+  dataDir: string
 |}
 
 export type PrefsAction =
   | PREFS_JSON_TYPES_CONFIG_SET
   | PREFS_TIME_FORMAT_SET
   | PREFS_ZEEK_RUNNER_SET
+  | PREFS_DATA_DIR_SET
 
 export type PREFS_JSON_TYPES_CONFIG_SET = {
   type: "PREFS_JSON_TYPES_CONFIG_SET",
@@ -24,4 +26,9 @@ export type PREFS_TIME_FORMAT_SET = {
 export type PREFS_ZEEK_RUNNER_SET = {
   type: "PREFS_ZEEK_RUNNER_SET",
   zeekRunner: string
+}
+
+export type PREFS_DATA_DIR_SET = {
+  type: "PREFS_DATA_DIR_SET",
+  dataDir: string
 }


### PR DESCRIPTION
fixes #676 

Turns out html `input` forms **really** prefer files over directories. There is apparently a `webkitdirectory` option which I experimented with first. The result was that the selector dialog would behave correctly but the `onChange` handler was no longer being called internally inside react. That property also is not recommended in the [docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory) (though I believe the primary reason for this is browser compatibility, which we are in control of in electron).

To fix this then, I added an ipc call so that the dialog that appears comes from electron and the main process. What's nice about this is that it will actually not allow users to select anything BUT a directory. Still, the form has validation in case someone manually types in a bad path.

![datadirpref](https://user-images.githubusercontent.com/14865533/82263984-ea74a800-9918-11ea-9020-7094abfc620e.gif)
