### PR TITLE
Fix some zq auto update buglets

### DIFF
--- a/.github/workflows/advance-zq.yml
+++ b/.github/workflows/advance-zq.yml
@@ -27,12 +27,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Since we intend to push, we must have a full-depth checkout, a
-      # a writable token, and minimal git config settings to create
-      # commits.
+      # Since we intend to push, we must have a a writable token and
+      # minimal git config settings to create commits.
       - uses: actions/checkout@v2
         with:
-          depth: 0
           token: ${{ secrets.ZQ_UPDATE_PAT }}
       - run: git config --local user.email 'automation@brimsecurity.com'
       - run: git config --local user.name 'Brim Automation'

--- a/.github/workflows/advance-zq.yml
+++ b/.github/workflows/advance-zq.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Commit and push change
         run: |
           git diff
-          cat << EOF | git commit -a -F-
+          cat << 'EOF' | git commit -a -F-
           zq update through "${{ steps.zq_pr.outputs.title }}" by ${{ steps.zq_pr.outputs.user }}
 
           This is an auto-generated commit with a zq dependency update. The zq PR


### PR DESCRIPTION
I was passing in the wrong parameter name for depth. Since `actions/checkout@v2` was ignoring the wrong parameter name, the parameter isn't needed after all. Also, when creating the commit message, quote the here document delimiter to prevent substitution and expansions.