### PR TITLE
add rename right click

### DIFF
--- a/src/js/components/App.js
+++ b/src/js/components/App.js
@@ -15,6 +15,7 @@ import Prefs from "../state/Prefs"
 import View from "../state/View"
 import brim from "../brim"
 import refreshSpaceNames from "../flows/refreshSpaceNames"
+import SpaceModal from "./SpaceModal"
 
 export default function App() {
   brim.time.setZone(useSelector(View.getTimeZone))
@@ -36,6 +37,7 @@ export default function App() {
       <ErrorNotice />
       <Preferences />
       <AboutModal />
+      <SpaceModal />
       <HTMLContextMenu />
     </div>
   )

--- a/src/js/components/SavedSpacesList.js
+++ b/src/js/components/SavedSpacesList.js
@@ -11,12 +11,15 @@ import ProgressIndicator from "./ProgressIndicator"
 import TrashBin from "../icons/TrashBin"
 import brim from "../brim"
 import deleteSpace from "../flows/deleteSpace"
+import menu from "../electron/menu"
+import {showContextMenu} from "../lib/System"
 
 type Props = {|
-  spaces: Space[]
+  spaces: Space[],
+  spaceContextMenu: Function
 |}
 
-export default function SavedSpacesList({spaces}: Props) {
+export default function SavedSpacesList({spaces, spaceContextMenu}: Props) {
   let dispatch = useDispatch()
 
   const onClick = (space) => (e) => {
@@ -53,7 +56,14 @@ export default function SavedSpacesList({spaces}: Props) {
 
         return (
           <li key={s.id}>
-            <a href="#" onClick={onClick(s.id)} className="space-link">
+            <a
+              href="#"
+              onClick={onClick(s.id)}
+              onContextMenu={() => {
+                showContextMenu(spaceContextMenu(s.id))
+              }}
+              className="space-link"
+            >
               <Folder className="space-icon" />
               <span className="name">{s.name}</span>
             </a>

--- a/src/js/components/SpaceModal.js
+++ b/src/js/components/SpaceModal.js
@@ -1,0 +1,52 @@
+/* @flow */
+import React, {useState} from "react"
+
+import ModalBox from "./ModalBox/ModalBox"
+import {useDispatch, useSelector} from "react-redux"
+import {reactElementProps} from "../test/integration"
+import Modal from "../state/Modal"
+import Spaces from "../state/Spaces"
+import {Input, InputSubmit} from "./form/Inputs"
+import Form from "./form/Form"
+import renameSpace from "../flows/renameSpace"
+
+export default function SpaceModal() {
+  return (
+    <ModalBox
+      name="space"
+      title=""
+      buttons={[]}
+      {...reactElementProps("spaceModal")}
+    >
+      <SpaceModalContents />
+    </ModalBox>
+  )
+}
+
+const SpaceModalContents = () => {
+  const {spaceId, clusterId} = useSelector(Modal.getArgs)
+  const space = useSelector(Spaces.get(clusterId, spaceId))
+  const {name} = space || ""
+  const [nameInput, setNameInput] = useState(name)
+  const dispatch = useDispatch()
+
+  const onSubmit = () => {
+    dispatch(renameSpace(clusterId, spaceId, nameInput))
+    dispatch(Modal.hide())
+  }
+
+  return (
+    <div>
+      <Form onSubmit={onSubmit}>
+        <Input
+          label="Space Name"
+          value={nameInput}
+          onChange={(e) => {
+            setNameInput(e.target.value)
+          }}
+        />
+        <InputSubmit value={"Rename"} />
+      </Form>
+    </div>
+  )
+}

--- a/src/js/components/SpaceModal.js
+++ b/src/js/components/SpaceModal.js
@@ -26,7 +26,7 @@ export default function SpaceModal() {
 const SpaceModalContents = () => {
   const {spaceId, clusterId} = useSelector(Modal.getArgs)
   const space = useSelector(Spaces.get(clusterId, spaceId))
-  const {name} = space || ""
+  const {name} = space || {name: ""}
   const [nameInput, setNameInput] = useState(name)
   const dispatch = useDispatch()
 

--- a/src/js/components/TabWelcome.js
+++ b/src/js/components/TabWelcome.js
@@ -15,12 +15,14 @@ import errors from "../errors"
 import ingestFiles from "../flows/ingestFiles"
 import initNewTab from "../flows/initNewTab"
 import refreshSpaceNames from "../flows/refreshSpaceNames"
+import menu from "../electron/menu"
 
 export default function TabWelcome() {
   let dispatch = useDispatch()
   let id = useSelector(Tab.clusterId)
   let spaces = useSelector(Spaces.getSpaces(id))
   let spacesPresent = spaces.length !== 0
+  const spaceContextMenu = menu.spaceContextMenu(id)
 
   useEffect(() => {
     dispatch(initNewTab())
@@ -47,8 +49,11 @@ export default function TabWelcome() {
         {spacesPresent && (
           <>
             <section>
-              <label>Recent Spaces</label>
-              <SavedSpacesList spaces={spaces} />
+              <label>Spaces</label>
+              <SavedSpacesList
+                spaces={spaces}
+                spaceContextMenu={spaceContextMenu}
+              />
             </section>
             <div className="separator" />
           </>

--- a/src/js/electron/menu/actions/index.js
+++ b/src/js/electron/menu/actions/index.js
@@ -2,8 +2,10 @@
 
 import buildSearchActions from "./searchActions"
 import buildDetailActions from "./detailActions"
+import buildSpaceActions from "./spaceActions"
 
 export default {
   search: buildSearchActions,
-  detail: buildDetailActions
+  detail: buildDetailActions,
+  space: buildSpaceActions
 }

--- a/src/js/electron/menu/actions/spaceActions.js
+++ b/src/js/electron/menu/actions/spaceActions.js
@@ -1,0 +1,17 @@
+/* @flow */
+import action from "./action"
+import Modal from "../../../state/Modal/actions"
+
+function buildSpaceActions() {
+  return {
+    rename: action({
+      name: "space-rename",
+      label: "Rename",
+      listener(dispatch, clusterId, spaceId) {
+        dispatch(Modal.show("space", {clusterId, spaceId}))
+      }
+    })
+  }
+}
+
+export default buildSpaceActions()

--- a/src/js/electron/menu/index.js
+++ b/src/js/electron/menu/index.js
@@ -6,6 +6,7 @@ import actions from "./actions"
 import appMenu from "./appMenu"
 import detailFieldContextMenu from "./detailFieldContextMenu"
 import searchFieldContextMenu from "./searchFieldContextMenu"
+import spaceContextMenu from "./spaceContextMenu"
 
 export type $MenuItem =
   | {click?: Function, label: string, enabled?: boolean}
@@ -28,5 +29,6 @@ export default {
   actions,
   searchFieldContextMenu,
   detailFieldContextMenu,
+  spaceContextMenu,
   separator: () => ({type: "separator"})
 }

--- a/src/js/electron/menu/spaceContextMenu.js
+++ b/src/js/electron/menu/spaceContextMenu.js
@@ -1,0 +1,15 @@
+/* @flow */
+import menu from "./"
+
+export default function spaceContextMenu(clusterId: string) {
+  return function(spaceId: string) {
+    const spaceMenuActions = menu.actions.space
+
+    return [
+      spaceMenuActions.rename.menuItem([clusterId, spaceId], {
+        enabled: true,
+        visible: true
+      })
+    ]
+  }
+}

--- a/src/js/flows/renameSpace.js
+++ b/src/js/flows/renameSpace.js
@@ -1,0 +1,23 @@
+/* @flow */
+import type {Thunk} from "../state/types"
+import Spaces from "../state/Spaces"
+import Cluster from "../state/Clusters"
+import Tabs from "../state/Tabs"
+import Search from "../state/Search"
+
+export default (clusterId: string, spaceId: string, name: string): Thunk => (
+  dispatch,
+  getState
+) => {
+  const state = getState()
+  const zClient = Cluster.getZealot(clusterId)(state)
+  const tabs = Tabs.getData(state)
+
+  zClient.spaces.update(spaceId, {name}).then(() => {
+    dispatch(Spaces.rename(clusterId, spaceId, name))
+    tabs.forEach((t) => {
+      if (t.search.spaceId === spaceId)
+        dispatch(Search.setSpace(spaceId, name, t.id))
+    })
+  })
+}

--- a/src/js/flows/renameSpace.js
+++ b/src/js/flows/renameSpace.js
@@ -1,16 +1,16 @@
 /* @flow */
 import type {Thunk} from "../state/types"
 import Spaces from "../state/Spaces"
-import Cluster from "../state/Clusters"
 import Tabs from "../state/Tabs"
 import Search from "../state/Search"
+import Tab from "../state/Tab"
 
 export default (clusterId: string, spaceId: string, name: string): Thunk => (
   dispatch,
   getState
 ) => {
   const state = getState()
-  const zClient = Cluster.getZealot(clusterId)(state)
+  const zClient = Tab.getZealot(state)
   const tabs = Tabs.getData(state)
 
   zClient.spaces.update(spaceId, {name}).then(() => {

--- a/src/js/initializers/initMenuActionListeners.js
+++ b/src/js/initializers/initMenuActionListeners.js
@@ -9,4 +9,7 @@ export default function(dispatch: Dispatch) {
   for (let name in menu.actions.detail) {
     menu.actions.detail[name].listen(dispatch)
   }
+  for (let name in menu.actions.space) {
+    menu.actions.space[name].listen(dispatch)
+  }
 }

--- a/src/js/state/Clusters/selectors.js
+++ b/src/js/state/Clusters/selectors.js
@@ -1,15 +1,9 @@
 /* @flow */
 
 import type {State} from "../types"
-import zealot from "../../services/zealot"
 
 export default {
   id: (id: string) => (state: State) => state.clusters[id],
-  getZealot: (id: string) => (state: State) => {
-    const cl = state.clusters[id]
-    if (cl) return zealot.client(cl.host + ":" + cl.port)
-    return zealot.client("localhost:9867")
-  },
   all: (state: State) => Object.values(state.clusters),
   raw: (state: State) => state.clusters
 }

--- a/src/js/state/Clusters/selectors.js
+++ b/src/js/state/Clusters/selectors.js
@@ -1,9 +1,15 @@
 /* @flow */
 
 import type {State} from "../types"
+import zealot from "../../services/zealot"
 
 export default {
   id: (id: string) => (state: State) => state.clusters[id],
+  getZealot: (id: string) => (state: State) => {
+    const cl = state.clusters[id]
+    if (cl) return zealot.client(cl.host + ":" + cl.port)
+    return zealot.client("localhost:9867")
+  },
   all: (state: State) => Object.values(state.clusters),
   raw: (state: State) => state.clusters
 }

--- a/src/js/state/Modal/types.js
+++ b/src/js/state/Modal/types.js
@@ -21,3 +21,4 @@ export type ModalName =
   | "zq"
   | "about"
   | "ingest-warnings"
+  | "space"

--- a/src/js/state/Spaces/actions.js
+++ b/src/js/state/Spaces/actions.js
@@ -7,7 +7,8 @@ import type {
   SPACES_INGEST_WARNING_CLEAR,
   SPACES_SET,
   SPACES_REMOVE,
-  Space
+  Space,
+  SPACES_RENAME
 } from "./types"
 import type {SpaceDetailPayload} from "../../services/zealot/types"
 
@@ -25,6 +26,17 @@ export default {
     type: "SPACES_DETAIL",
     clusterId,
     space
+  }),
+
+  rename: (
+    clusterId: string,
+    spaceId: string,
+    newName: string
+  ): SPACES_RENAME => ({
+    type: "SPACES_RENAME",
+    clusterId,
+    spaceId,
+    newName
   }),
 
   remove: (clusterId: string, spaceId: string): SPACES_REMOVE => ({

--- a/src/js/state/Spaces/reducer.js
+++ b/src/js/state/Spaces/reducer.js
@@ -24,6 +24,10 @@ const spacesReducer = produce((draft, action: SpacesAction) => {
       draft[id] = defaults(id, name, {...draft[id], ...space})
       break
 
+    case "SPACES_RENAME":
+      getSpace(draft, action.spaceId).name = action.newName
+      break
+
     case "SPACES_INGEST_PROGRESS":
       getSpace(draft, action.spaceId).ingest.progress = action.value
       break

--- a/src/js/state/Spaces/test.js
+++ b/src/js/state/Spaces/test.js
@@ -174,3 +174,14 @@ test("setting the spanshot counter", () => {
 
   expect(Spaces.getIngestSnapshot("cluster1", testSpace1.id)(state)).toBe(1)
 })
+
+test("rename a space", () => {
+  const testRename = "renamed test space"
+
+  const state = store.dispatchAll([
+    Spaces.setSpaces("cluster1", [testSpace1]),
+    Spaces.rename("cluster1", testSpace1.id, testRename)
+  ])
+
+  expect(Spaces.get("cluster1", testSpace1.id)(state).name).toEqual(testRename)
+})

--- a/src/js/state/Spaces/types.js
+++ b/src/js/state/Spaces/types.js
@@ -14,6 +14,7 @@ export type SpacesState = {
 export type SpacesAction =
   | SPACES_SET
   | SPACES_DETAIL
+  | SPACES_RENAME
   | SPACES_INGEST_PROGRESS
   | SPACES_INGEST_WARNING_APPEND
   | SPACES_INGEST_WARNING_CLEAR
@@ -45,6 +46,13 @@ export type SPACES_DETAIL = {
   type: "SPACES_DETAIL",
   clusterId: string,
   space: $Shape<Space> | SpaceDetailPayload
+}
+
+export type SPACES_RENAME = {
+  type: "SPACES_RENAME",
+  clusterId: string,
+  spaceId: string,
+  newName: string
 }
 
 export type SPACES_INGEST_PROGRESS = {


### PR DESCRIPTION
fixes #674 

Uses a simple modal for the rename mechanism, after right clicking on a space.

![brim](https://user-images.githubusercontent.com/14865533/82610019-7f261280-9b72-11ea-80cb-f06f9a08b769.gif)

Signed-off-by: Mason Fish <mason@looky.cloud>