### PR TITLE
show "restart required" for zeekRunner preference change

### DIFF
--- a/src/js/components/Preferences/FileInput.js
+++ b/src/js/components/Preferences/FileInput.js
@@ -38,17 +38,19 @@ export default function FileInput(props: Props) {
 
   function onChange(e) {
     setValue(e.target.value)
-    props.onChange && props.onChange(e)
+    props.onChange && props.onChange(e.target.value)
   }
 
   function onPick(e) {
     let path = Array.from(e.target.files).map((f) => f.path)[0]
     setValue(path)
+    props.onChange && props.onChange(path)
   }
 
   function onDrop(e) {
     let path = Array.from(e.dataTransfer.files).map((f) => f.path)[0]
     setValue(path)
+    props.onChange && props.onChange(path)
   }
 
   return (

--- a/src/js/components/Preferences/ZeekRunner.js
+++ b/src/js/components/Preferences/ZeekRunner.js
@@ -15,14 +15,14 @@ export default function ZeekRunner({config}: Props) {
   let {name, label, defaultValue} = config
   let [showFeedback, setShowFeedback] = useState(false)
 
-  function onChange(e) {
-    setShowFeedback(e.target.value !== defaultValue)
+  function onChange(val) {
+    setShowFeedback(val !== defaultValue)
   }
 
   return (
     <div className="setting-panel">
       <label>
-        {config.label}: <Link href={DOCS}>(docs)</Link>
+        {label}: <Link href={DOCS}>(docs)</Link>
       </label>
       <FileInput
         name={name}


### PR DESCRIPTION
fixes #777 

Looks like when onClick and onDrop occurs it doesn't end up propagating to an underlying onChange event. Since it's our own component, we can call the passed in `onChange` handler manually instead. I opted to directly pass in the changed value since it depends on the mechanism used and the caller will not have a way of knowing.


Signed-off-by: Mason Fish <mason@looky.cloud>