### PR TITLE
Reset state if less than v0.9.1

### DIFF
--- a/src/js/electron/tron/migrations.js
+++ b/src/js/electron/tron/migrations.js
@@ -21,7 +21,8 @@ export type Migrations = {
   run: (VersionedData, Migration[]) => VersionedData,
   getLatestVersion: () => number,
   getPending: () => Migration[],
-  getAll: () => Migration[]
+  getAll: () => Migration[],
+  setCurrentVersion: (number) => void
 }
 
 export default async function migrations(

--- a/src/js/electron/tron/migrations.js
+++ b/src/js/electron/tron/migrations.js
@@ -27,6 +27,7 @@ export type Migrations = {
 export default async function migrations(
   currentVersion: string | number = 0
 ): Promise<Migrations> {
+  let cv = parseInt(currentVersion)
   // $FlowFixMe
   let files = await lib.file(dir).contents()
   let migrations = files
@@ -52,13 +53,15 @@ export default async function migrations(
     },
 
     getPending() {
-      return migrations.filter<Migration>(
-        (m) => parseInt(m.version) > parseInt(currentVersion)
-      )
+      return migrations.filter<Migration>((m) => parseInt(m.version) > cv)
     },
 
     getAll() {
       return migrations
+    },
+
+    setCurrentVersion(version: number) {
+      cv = version
     }
   }
 }

--- a/src/js/electron/tron/session.js
+++ b/src/js/electron/tron/session.js
@@ -56,10 +56,16 @@ async function migrate(appState): Promise<VersionedState> {
   log.info(`migrations: currentVersion=${state.version} pending=${pending}`)
 
   if (pending) {
-    log.info("migrations: running")
-    let nextState = migrations.runPending(state)
-    log.info(`migrations: currentVersion=${nextState.version}`)
-    return nextState
+    try {
+      log.info("migrations: running")
+      let nextState = migrations.runPending(state)
+      log.info(`migrations: currentVersion=${nextState.version}`)
+      return nextState
+    } catch (e) {
+      log.error("Unable to migrate data")
+      log.error(e)
+      return freshState(migrations.getLatestVersion())
+    }
   } else {
     return state
   }
@@ -78,4 +84,8 @@ function ensureVersioned(state) {
       version: 0,
       data: state
     }
+}
+
+function freshState(version) {
+  return {data: undefined, version}
 }

--- a/src/js/electron/tron/session.test.js
+++ b/src/js/electron/tron/session.test.js
@@ -1,9 +1,15 @@
 /* @flow */
 import fsExtra from "fs-extra"
 
+import path from "path"
+
+import disableLogger from "../../test/helpers/disableLogger"
 import formatSessionState from "./formatSessionState"
 import initTestStore from "../../test/initTestStore"
 import tron from "./"
+
+const file = "tmp/appState.json"
+disableLogger()
 
 beforeEach(() => fsExtra.ensureDir("tmp"))
 afterEach(() => fsExtra.remove("tmp"))
@@ -11,10 +17,49 @@ afterEach(() => fsExtra.remove("tmp"))
 test("session loading with migrations", async () => {
   let state = initTestStore().getState()
   let migrations = await tron.migrations()
-  let session = tron.session("tmp/appState.json")
+  let session = tron.session(file)
   let data = formatSessionState({}, state)
-  await session.save(data)
 
+  await session.save(data)
   await session.load()
+
   expect(session.getVersion()).toEqual(migrations.getLatestVersion())
+})
+
+test("loading state from release 0.8.0 resets state", async () => {
+  const v8 = {
+    order: [],
+    windows: {},
+    globalState: {investigation: [], spaces: {zqd: {}}, version: "6"}
+  }
+  fsExtra.writeJSONSync(file, v8)
+
+  const session = tron.session(file)
+  const data = await session.load()
+  const latestVersion = (await tron.migrations()).getLatestVersion()
+
+  expect(data).toBe(undefined)
+  expect(session.getVersion()).toBe(latestVersion)
+})
+
+test("loading state from a 0.9.1 release migrates", () => {
+  const testState = path.join(__dirname, "../../test/states/v0.9.1.json")
+  fsExtra.copySync(testState, file)
+  const session = tron.session(file)
+
+  return expect(session.load()).resolves.toEqual({
+    globalState: expect.any(Object),
+    order: expect.any(Array),
+    windows: expect.any(Object)
+  })
+})
+
+test("failing to load sets session to latest version", async () => {
+  fsExtra.writeFileSync(file, "this aint json")
+  const session = tron.session(file)
+  const data = await session.load()
+  const latestVersion = (await tron.migrations()).getLatestVersion()
+
+  expect(session.getVersion()).toEqual(latestVersion)
+  expect(data).toBe(undefined)
 })

--- a/src/js/test/helpers/disableLogger.js
+++ b/src/js/test/helpers/disableLogger.js
@@ -1,0 +1,12 @@
+/* @flow */
+import log from "electron-log"
+
+export default () => {
+  beforeAll(() => {
+    log.transports.console.level = false
+  })
+
+  afterAll(() => {
+    log.transports.console.level = "silly"
+  })
+}


### PR DESCRIPTION
If a user has a version prior to v0.9.1, we don't try to migrate their state.

If you open the app in v0.8.0, ingest some data, perform some searches, then quit, then open the app at master, you'll see a message in the logs that says:

```
[2020-05-27 14:45:59.759] [info] migrations: unsupported version, using fresh state
```

It will indeed clear the state and start fresh. However, the spaces that you ingested will remain. 

**Known Bug With Space Names**

Testing this revealed a bug in zqd. The spaces created in v0.8.0 (before space ids), are returned without a name after upgrading to the latest brim version. It results in the app looking like this when you load up the newest version. 

<img width="957" alt="image" src="https://user-images.githubusercontent.com/3460638/83077977-5ea3ff80-a02d-11ea-9b58-87b30c8d1661.png">

In this example, I ingested a file called `a.pcap` in v0.8.0, then quit, upgraded, and re-opened brim.

Work on the zqd migration is being tracked in https://github.com/brimsec/zq/issues/791
