### PR TITLE
Clear Preferences Errors After Closing

### DIFF
--- a/src/js/components/ModalBox/ModalContents.js
+++ b/src/js/components/ModalBox/ModalContents.js
@@ -11,10 +11,17 @@ import useModalController from "./useModalController"
 
 // $FlowFixMe
 const ModalContents = React.forwardRef(function ModalContents(
-  {children, className, title, buttons: template, ...rest}: ModalContentsProps,
+  {
+    children,
+    className,
+    title,
+    onClose,
+    buttons: template,
+    ...rest
+  }: ModalContentsProps,
   ref
 ) {
-  let {closeModal, buttons} = useModalController(template)
+  let {closeModal, buttons} = useModalController(template, onClose)
 
   return ReactDOM.createPortal(
     <div className="modal-overlay" ref={ref}>

--- a/src/js/components/ModalBox/types.js
+++ b/src/js/components/ModalBox/types.js
@@ -9,7 +9,8 @@ export type ModalBoxProps = {
   title: string,
   name: ModalName,
   className?: string,
-  buttons: ModalButtonTemplate
+  buttons: ModalButtonTemplate,
+  onClose?: Function
 }
 
 export type ModalContentsProps = {

--- a/src/js/components/ModalBox/useModalController.js
+++ b/src/js/components/ModalBox/useModalController.js
@@ -8,7 +8,10 @@ import {last} from "../../lib/Array"
 import Modal from "../../state/Modal"
 import useEventListener from "../hooks/useEventListener"
 
-export default function useModalController(template: ModalButtonTemplate) {
+export default function useModalController(
+  template: ModalButtonTemplate,
+  onClose?: Function
+) {
   let dispatch = useDispatch()
   let buttons = []
 
@@ -22,6 +25,7 @@ export default function useModalController(template: ModalButtonTemplate) {
 
   function closeModal() {
     dispatch(Modal.hide())
+    onClose && onClose()
   }
 
   function keyDown(e) {

--- a/src/js/components/Preferences/Preferences.js
+++ b/src/js/components/Preferences/Preferences.js
@@ -3,6 +3,7 @@
 import React, {useCallback, useState} from "react"
 
 import {reactElementProps} from "../../test/integration"
+import DataDirInput from "./DataDirInput"
 import FormErrors from "./FormErrors"
 import JSONTypeConfig from "./JSONTypeConfig"
 import ModalBox from "../ModalBox/ModalBox"
@@ -13,12 +14,13 @@ import ZeekRunner from "./ZeekRunner"
 import brim from "../../brim"
 import useCallbackRef from "../hooks/useCallbackRef"
 import usePreferencesForm from "./usePreferencesForm"
-import DataDirInput from "./DataDirInput"
 
 export default function Preferences() {
   let [f, setForm] = useCallbackRef<HTMLFormElement>()
   let [errors, setErrors] = useState([])
   let prefsForm = usePreferencesForm()
+
+  const onClose = () => setErrors([])
 
   const onSubmit = useCallback(
     async (closeModal) => {
@@ -38,6 +40,7 @@ export default function Preferences() {
 
   return (
     <ModalBox
+      onClose={onClose}
       name="settings"
       title="Preferences"
       buttons={[{label: "OK", click: onSubmit}]}

--- a/src/js/flows/executeUidSearch.js
+++ b/src/js/flows/executeUidSearch.js
@@ -11,6 +11,7 @@ import brim from "../brim"
 import executeSearch from "./executeSearch"
 
 export default (log: Log): Thunk => (dispatch, getState) => {
+  if (!log) return
   let uid = log.correlationId()
   if (isEmpty(uid)) return
 


### PR DESCRIPTION
The problem was that the errors were not being cleared when you close the Preferences modal then reopen it.

I thought that the Preferences component would unmount, but it looks it never does since it's a global component. In light of this, we add a callback to hook into when the modal closes. We can then clear the errors from the state.

![I6IwoB7hs6](https://user-images.githubusercontent.com/3460638/83192185-0bdc4d80-a0ea-11ea-8a77-7128128a6f8b.gif)


fixes #809 