### PR TITLE
hit enter to rename

### DIFF
--- a/src/css/_space-modal.scss
+++ b/src/css/_space-modal.scss
@@ -1,0 +1,5 @@
+.space-modal {
+  .space-modal-contents {
+    margin-bottom: 20px;
+  }
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -49,6 +49,7 @@
 @import "search-stats";
 @import "search-page";
 @import "settings-modal";
+@import "space-modal";
 @import "drag-anchor";
 @import "pane";
 @import "log-detail-pane";

--- a/src/js/components/SpaceModal.js
+++ b/src/js/components/SpaceModal.js
@@ -43,7 +43,7 @@ const SpaceModalContents = ({value, onChange}) => {
   return (
     <div className="space-modal-contents">
       <Input
-      autoFocus
+        autoFocus
         label="Space Name"
         value={value}
         onChange={(e) => {

--- a/src/js/components/SpaceModal.js
+++ b/src/js/components/SpaceModal.js
@@ -43,6 +43,7 @@ const SpaceModalContents = ({value, onChange}) => {
   return (
     <div className="space-modal-contents">
       <Input
+      autoFocus
         label="Space Name"
         value={value}
         onChange={(e) => {

--- a/src/js/components/SpaceModal.js
+++ b/src/js/components/SpaceModal.js
@@ -1,34 +1,25 @@
 /* @flow */
-import React, {useState} from "react"
+import React, {useState, useEffect} from "react"
 
 import ModalBox from "./ModalBox/ModalBox"
 import {useDispatch, useSelector} from "react-redux"
 import {reactElementProps} from "../test/integration"
 import Modal from "../state/Modal"
 import Spaces from "../state/Spaces"
-import {Input, InputSubmit} from "./form/Inputs"
-import Form from "./form/Form"
+import {Input} from "./form/Inputs"
 import renameSpace from "../flows/renameSpace"
 
 export default function SpaceModal() {
-  return (
-    <ModalBox
-      name="space"
-      title=""
-      buttons={[]}
-      {...reactElementProps("spaceModal")}
-    >
-      <SpaceModalContents />
-    </ModalBox>
-  )
-}
-
-const SpaceModalContents = () => {
-  const {spaceId, clusterId} = useSelector(Modal.getArgs)
+  const args = useSelector(Modal.getArgs) || {}
+  const {clusterId, spaceId} = args
   const space = useSelector(Spaces.get(clusterId, spaceId))
   const {name} = space || {name: ""}
   const [nameInput, setNameInput] = useState(name)
   const dispatch = useDispatch()
+
+  useEffect(() => {
+    setNameInput(name)
+  }, [name])
 
   const onSubmit = () => {
     dispatch(renameSpace(clusterId, spaceId, nameInput))
@@ -36,17 +27,28 @@ const SpaceModalContents = () => {
   }
 
   return (
-    <div>
-      <Form onSubmit={onSubmit}>
-        <Input
-          label="Space Name"
-          value={nameInput}
-          onChange={(e) => {
-            setNameInput(e.target.value)
-          }}
-        />
-        <InputSubmit value={"Rename"} />
-      </Form>
+    <ModalBox
+      name="space"
+      title=""
+      buttons={[{label: "OK", click: onSubmit}]}
+      className="space-modal"
+      {...reactElementProps("spaceModal")}
+    >
+      <SpaceModalContents value={nameInput} onChange={setNameInput} />
+    </ModalBox>
+  )
+}
+
+const SpaceModalContents = ({value, onChange}) => {
+  return (
+    <div className="space-modal-contents">
+      <Input
+        label="Space Name"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value)
+        }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
fixes #674 

refactors the rename modal to use the existing buttons api that our own `<ModalBox />` already provides. 

Signed-off-by: Mason Fish <mason@looky.cloud>