### PR TITLE
fix: use the run/ dir if BRIM_ITEST=true

### DIFF
--- a/src/js/electron/appPathSetup.js
+++ b/src/js/electron/appPathSetup.js
@@ -11,14 +11,23 @@ import path from "path"
 function appPathSetup() {
   if (electronIsDev) {
     // isDev is true for general dev execution and integration tests.
-    if (process.env.BRIM_ITEST != "true") {
-      // For general developer execution, put state and logs under a
-      // "run" directory in the git directory.
-      app.setPath("userData", path.join(app.getAppPath(), "run"))
+    let hasDataDirArg = false
+    // The only known instance of isDev being true and --user-data-dir
+    // being set is under Spectron.
+    for (const arg of process.argv) {
+      if (arg.startsWith("--user-data-dir")) {
+        hasDataDirArg = true
+        break
+      }
     }
     // We don't override for integration tests as they set userData
     // via the user-data-dir chromeDriver command line argument,
     // so don't override it.
+    if (!hasDataDirArg) {
+      // For general developer execution, put state and logs under a
+      // "run" directory in the git directory.
+      app.setPath("userData", path.join(app.getAppPath(), "run"))
+    }
   }
   // Logs go under userData, to make finding logs consistent across platforms.
   app.setPath("logs", path.join(app.getPath("userData"), "logs"))

--- a/src/js/electron/appPathSetup.js
+++ b/src/js/electron/appPathSetup.js
@@ -11,19 +11,12 @@ import path from "path"
 function appPathSetup() {
   if (electronIsDev) {
     // isDev is true for general dev execution and integration tests.
-    let hasDataDirArg = false
     // The only known instance of isDev being true and --user-data-dir
     // being set is under Spectron.
-    for (const arg of process.argv) {
-      if (arg.startsWith("--user-data-dir")) {
-        hasDataDirArg = true
-        break
-      }
-    }
     // We don't override for integration tests as they set userData
     // via the user-data-dir chromeDriver command line argument,
     // so don't override it.
-    if (!hasDataDirArg) {
+    if (!app.commandLine.hasSwitch("user-data-dir")) {
       // For general developer execution, put state and logs under a
       // "run" directory in the git directory.
       app.setPath("userData", path.join(app.getAppPath(), "run"))


### PR DESCRIPTION
There is a case where `BRIM_ITEST=true` but `--user-data-dir` is not specified: manual runs of the app, via command like:
```
BRIM_ITEST=true npm run electron
```
Such cases are useful in order to observe app behavior with the mock context menu.

Before, this would use the default system user data directory. Now, this uses `run/`.