### PR TITLE
add a test that creates a zar space under brim

### DIFF
--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -410,3 +410,7 @@ const waitForClickableButtonAndClick = async (
 export const clickPcapButton = async (app: Application) => {
   await waitForClickableButtonAndClick(app, selectors.pcaps.button)
 }
+
+export const reload = async (app: Application) => {
+  await appStep("app reload", () => app.browserWindow.reload())
+}

--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -355,6 +355,21 @@ export const ingestFile = async (app: Application, file: string) => {
     )
   )
 
+  try {
+    await appStep("wait for ingest to start", () =>
+      retryUntil(
+        () => app.client.isExisting(selectors.status.ingestProgress),
+        (ingesting) => ingesting === true,
+        100,
+        100
+      )
+    )
+  } catch {
+    LOG.debug(
+      "ingest never appeared; let's hope it finished and ended before we could observe it"
+    )
+  }
+
   await appStep("wait for ingest to finish", () =>
     retryUntil(
       () => app.client.isExisting(selectors.status.ingestProgress),

--- a/itest/lib/env.js
+++ b/itest/lib/env.js
@@ -12,3 +12,6 @@ export const itestDir = (): string =>
 
 export const testDataDir = (): string =>
   path.resolve(path.join(repoDir(), "itest", "testdata"))
+
+export const nodeZqDistDir = (): string =>
+  path.resolve(path.join(repoDir(), "node_modules", "zq", "dist"))

--- a/itest/tests/zar.test.js
+++ b/itest/tests/zar.test.js
@@ -56,8 +56,18 @@ describe("Zar tests", () => {
         // interesting stuff.
         execSync(`"${ZAR}" import -s 1024B -R "${zarRoot}" "${zngFile}"`)
         await Promise.all(
-          [":ip", ":port", "uid", "_path"].map((index) =>
-            exec(`"${ZAR}" index -R "${zarRoot}" ${index}`)
+          [":ip", ":port", "uid", "_path"].map(
+            (index) =>
+              new Promise((resolve, reject) => {
+                const cmd = `"${ZAR}" index -R "${zarRoot}" ${index}`
+                exec(cmd, (error, stdout, stderr) => {
+                  if (error) {
+                    reject(`${cmd}: ${stderr}`)
+                  } else {
+                    resolve(0)
+                  }
+                })
+              })
           )
         )
 

--- a/itest/tests/zar.test.js
+++ b/itest/tests/zar.test.js
@@ -1,0 +1,85 @@
+/* @flow */
+
+// This is needed to use zealot outside a browser.
+global.fetch = require("node-fetch")
+
+import {exec, execSync} from "child_process"
+import path from "path"
+
+import zealot from "../../src/js/services/zealot"
+
+import {nodeZqDistDir} from "../lib/env"
+import {handleError, stdTest} from "../lib/jest.js"
+import {
+  ingestFile,
+  newAppInstance,
+  startApp,
+  waitForNewTab,
+  waitForResults
+} from "../lib/app"
+
+describe("Zar tests", () => {
+  let app
+  let testIdx = 0
+  const ZAR = path.join(nodeZqDistDir(), "zar")
+  beforeEach(() => {
+    app = newAppInstance(path.basename(__filename), ++testIdx)
+    return startApp(app)
+  })
+
+  afterEach(async () => {
+    if (app && app.isRunning()) {
+      return await app.stop()
+    }
+  })
+
+  stdTest(`Brim starts when a Zar space is present`, (done) => {
+    ingestFile(app, "sample.tsv")
+      .then(async () => {
+        await waitForResults(app)
+
+        // Figure out underlying space directories. One will be a
+        // zarRoot. The other will be used to read zng into zar.
+        const client = zealot.client("localhost:9867")
+
+        const sampleSpace = (await client.spaces.list())[0]
+        const zarSpace = await client.spaces.create({name: "sample.zar"})
+
+        const zngFile = path.join(sampleSpace.data_path, "all.zng")
+        const zarRoot = zarSpace.data_path
+
+        // Now that the spaces are read, stop the app so we can convert
+        // zarSpace to an archive store and let the app read it when it
+        // restarts.
+        await app.stop()
+
+        // Create a zar archive inside the space and index some
+        // interesting stuff.
+        execSync(`"${ZAR}" import -s 1024B -R "${zarRoot}" "${zngFile}"`)
+        await Promise.all(
+          [":ip", ":port", "uid", "_path"].map((index) =>
+            exec(`"${ZAR}" index -R "${zarRoot}" ${index}`)
+          )
+        )
+
+        // Restart the app so that it reads the new space.
+        await startApp(app)
+        // There's inconsistency here on what page is presented when the
+        // app restarts. Sometimes, it's the results viewer for
+        // sample.tsv.brim. Other times, it's the new tab page. Instead
+        // of forking off the flow further, I'm stopping any testing at
+        // this point.
+        // TODO: Understand why different pages appear when the app is
+        // restarted.
+        try {
+          await waitForResults(app)
+        } catch {
+          await waitForNewTab(app)
+        }
+        done()
+      })
+      .catch((err) => {
+        handleError(app, err, done)
+      })
+  })
+})

--- a/itest/tests/zar.test.js
+++ b/itest/tests/zar.test.js
@@ -15,6 +15,7 @@ import {
   click,
   ingestFile,
   newAppInstance,
+  reload,
   startApp,
   waitForResults
 } from "../lib/app"
@@ -40,8 +41,9 @@ describe("Zar tests", () => {
       .then(async () => {
         await waitForResults(app)
 
-        // Figure out underlying space directories. One will be a
-        // zarRoot. The other will be used to read zng into zar.
+        // Use zealot to
+        // 1. Create a new space
+        // 2. Find the path to sample.tsv.brim's all.zng
         const client = zealot.client("localhost:9867")
 
         const sampleSpace = (await client.spaces.list())[0]
@@ -65,8 +67,8 @@ describe("Zar tests", () => {
           (spaces) => spaces.length === 2
         )
 
-        // Restart the app so that it reads the new space.
-        await app.browserWindow.reload()
+        // Reload the app so that it reads the new space.
+        await reload(app)
         await click(app, ".add-tab")
         await app.client.waitForVisible(
           `//*[@class="space-link"]/*[text()="${ZAR_SPACE_NAME}"]`


### PR DESCRIPTION
Brim isn't fully ready to handle zar spaces yet, but this test
establishes a temporary workflow for getting zar data into a space and
making sure Brim starts. As Brim's functionality to read a Zar space
improves, this test can be modified. The purpose of this is to put
something in place that changes alongside the functionality as opposed
to having nothing until all the functionality is ready. As such, there's
not as much abstraction as there otherwise would be: much of this should
get thrown away once Brim supports Zar.

The test uses Brim as the driver for starting zqd so that the test don't
have to do zqd orchestration itself. It ingests sample.tsv as usual.
Then it uses zealot to create a second, empty space called sample.zar
and also get space metadata from space sample.tsv.brim. The test then
imports samle.tsv.brim's all.zng into sample.zar, with a small enough
chop size to ensure multiple files. The test creates a number of
indexes. Finally, it reloads Brim and ensures Brim sees the second space.