### PR TITLE
Point to new Zeek artifact that includes JA3/HASSH

### DIFF
--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -143,7 +143,7 @@ async function main() {
   try {
     // We encode the zeek version here for now to avoid the unncessary
     // git clone if it were in package.json.
-    const zeekVersion = "v3.2.0-dev-brim2"
+    const zeekVersion = "v3.2.0-dev-brim3"
     await zeekDownload(zeekVersion, zdepsPath)
 
     // The zq dependency should be a git tag or commit. Any tag that


### PR DESCRIPTION
Testing with this branch shows the JA3 and HASSH fields are appearing where we expect them after importing a pcap.

![image](https://user-images.githubusercontent.com/5934157/83816302-ef568d00-a676-11ea-824c-e84b90700082.png)

![image](https://user-images.githubusercontent.com/5934157/83816540-7d327800-a677-11ea-904a-c35d87a91c69.png)
