### PR TITLE
Use -sorted flag in histogram query

### DIFF
--- a/src/js/searches/histogramSearch.js
+++ b/src/js/searches/histogramSearch.js
@@ -14,5 +14,8 @@ export function addEveryCountProc(program: string, span: Span) {
   }
   const {number, unit} = histogramInterval(span)
 
-  return program + ` | every ${number}${BOOM_INTERVALS[unit]} count() by _path`
+  return (
+    program +
+    ` | every ${number}${BOOM_INTERVALS[unit]} count() by _path -sorted -1`
+  )
 }

--- a/src/js/state/Search/test.js
+++ b/src/js/state/Search/test.js
@@ -83,7 +83,7 @@ describe("selectors", () => {
     let state = store.getState()
 
     expect(Search.getArgs(state)).toEqual({
-      chartProgram: "* | every 1sec count() by _path",
+      chartProgram: "* | every 1sec count() by _path -sorted -1",
       spaceId: "",
       spaceName: "",
       span: [new Date(0), new Date(1000)],


### PR DESCRIPTION
Companion to brimsec/zq#869 that tweaks the zql query used to populate the histogram so that it continues to render progressively with results streamed back.