### PR TITLE
Remove space name

### DIFF
--- a/src/js/brim/brimTab.js
+++ b/src/js/brim/brimTab.js
@@ -1,14 +1,20 @@
 /* @flow */
 
+import {get} from "lodash"
+
+import type {SpacesState} from "../state/Spaces/types"
 import type {TabState} from "../state/Tab/types"
 import lib from "../lib"
 
-export default function(tab: TabState) {
+export default function(tab: TabState, spaces: SpacesState) {
   return {
     title() {
-      return lib
-        .compact([tab.search.spaceName || "New Tab", tab.searchBar.previous])
-        .join(": ")
+      const name = get(
+        spaces,
+        [tab.search.clusterId, tab.search.spaceId, "name"],
+        "New Tab"
+      )
+      return lib.compact([name, tab.searchBar.previous]).join(": ")
     }
   }
 }

--- a/src/js/components/App.js
+++ b/src/js/components/App.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {useDispatch, useSelector} from "react-redux"
+import {useSelector} from "react-redux"
 import React, {useEffect} from "react"
 
 import {ipcRenderer} from "electron"
@@ -12,18 +12,15 @@ import ErrorNotice from "./ErrorNotice"
 import HTMLContextMenu from "./HTMLContextMenu"
 import Preferences from "./Preferences/Preferences"
 import Prefs from "../state/Prefs"
+import SpaceModal from "./SpaceModal"
 import View from "../state/View"
 import brim from "../brim"
-import refreshSpaceNames from "../flows/refreshSpaceNames"
-import SpaceModal from "./SpaceModal"
 
 export default function App() {
   brim.time.setZone(useSelector(View.getTimeZone))
   brim.time.setDefaultFormat(useSelector(Prefs.getTimeFormat))
-  let dispatch = useDispatch()
 
   useEffect(() => {
-    dispatch(refreshSpaceNames())
     ipcRenderer.invoke("windows:ready")
   }, [])
 

--- a/src/js/components/FilterTree.js
+++ b/src/js/components/FilterTree.js
@@ -44,12 +44,8 @@ export default function FilterTree() {
         ["data", "finding", "search", "spaceId"],
         ""
       )
-      const nodeSpaceName = get(
-        node,
-        ["data", "finding", "search", "spaceName"],
-        ""
-      )
-      dispatch(Search.setSpace(nodeSpaceId, nodeSpaceName))
+      const nodeSpaceName = "fix me"
+      dispatch(Search.setSpace(nodeSpaceId))
       dispatch(submitSearch(false))
     }
 

--- a/src/js/components/FilterTree.js
+++ b/src/js/components/FilterTree.js
@@ -26,12 +26,7 @@ export default function FilterTree() {
   let pinnedFilters = useSelector(SearchBar.getSearchBarPins)
   let previous = useSelector(SearchBar.getSearchBarPreviousInputValue)
   const clusterId = useSelector(Tab.clusterId)
-  const spaces = useSelector(Spaces.raw)[clusterId] || {}
-  const spaceIds = Object.keys(spaces)
-
-  function getSpaceName(id) {
-    return (spaces[id] && spaces[id].name) || ""
-  }
+  const spaceIds = useSelector(Spaces.ids(clusterId))
 
   function renderNode(node: Node, i: number) {
     function onNodeClick() {
@@ -70,9 +65,8 @@ export default function FilterTree() {
         ["data", "finding", "search", "spaceId"],
         ""
       )
-      const findingSpaceName = getSpaceName(findingSpaceId)
 
-      const tip = `'${findingSpaceName}' space no longer exists`
+      const tip = "This space no longer exists"
       if (includes(spaceIds, findingSpaceId)) return null
 
       return (

--- a/src/js/components/FilterTree.js
+++ b/src/js/components/FilterTree.js
@@ -3,7 +3,9 @@
 import {includes, isEqual} from "lodash"
 import {useDispatch, useSelector} from "react-redux"
 import React from "react"
+import ReactTooltip from "react-tooltip"
 import classNames from "classnames"
+import get from "lodash/get"
 
 import {Node} from "../models/Node"
 import {RemoveButton} from "./Buttons"
@@ -11,22 +13,25 @@ import {createInvestigationTree} from "./FilterTree/helpers"
 import {globalDispatch} from "../state/GlobalContext"
 import FilterNode from "./FilterNode"
 import Investigation from "../state/Investigation"
-import SearchBar from "../state/SearchBar"
-import submitSearch from "../flows/submitSearch"
-import Tab from "../state/Tab"
-import Spaces from "../state/Spaces/selectors"
-import get from "lodash/get"
-import Warning from "./icons/warning-sm.svg"
-import ReactTooltip from "react-tooltip"
 import Search from "../state/Search"
+import SearchBar from "../state/SearchBar"
+import Spaces from "../state/Spaces/selectors"
+import Tab from "../state/Tab"
+import Warning from "./icons/warning-sm.svg"
+import submitSearch from "../flows/submitSearch"
 
 export default function FilterTree() {
   let dispatch = useDispatch()
   let investigation = useSelector(Investigation.getInvestigation)
   let pinnedFilters = useSelector(SearchBar.getSearchBarPins)
   let previous = useSelector(SearchBar.getSearchBarPreviousInputValue)
-  const clusterID = useSelector(Tab.clusterId)
-  const spaceIds = useSelector(Spaces.ids(clusterID))
+  const clusterId = useSelector(Tab.clusterId)
+  const spaces = useSelector(Spaces.raw)[clusterId] || {}
+  const spaceIds = Object.keys(spaces)
+
+  function getSpaceName(id) {
+    return (spaces[id] && spaces[id].name) || ""
+  }
 
   function renderNode(node: Node, i: number) {
     function onNodeClick() {
@@ -44,7 +49,6 @@ export default function FilterTree() {
         ["data", "finding", "search", "spaceId"],
         ""
       )
-      const nodeSpaceName = "fix me"
       dispatch(Search.setSpace(nodeSpaceId))
       dispatch(submitSearch(false))
     }
@@ -66,11 +70,7 @@ export default function FilterTree() {
         ["data", "finding", "search", "spaceId"],
         ""
       )
-      const findingSpaceName = get(
-        node,
-        ["data", "finding", "search", "spaceName"],
-        ""
-      )
+      const findingSpaceName = getSpaceName(findingSpaceId)
 
       const tip = `'${findingSpaceName}' space no longer exists`
       if (includes(spaceIds, findingSpaceId)) return null

--- a/src/js/components/Investigation/FindingCard.js
+++ b/src/js/components/Investigation/FindingCard.js
@@ -24,12 +24,7 @@ type Props = {finding: Finding}
 export default React.memo<Props>(function FindingCard({finding}: Props) {
   const dispatch = useDispatch()
   const clusterId = useSelector(Tab.clusterId)
-  const spaces = useSelector(Spaces.raw)[clusterId] || {}
   const spaceIds = useSelector(Spaces.ids(clusterId))
-
-  function getSpaceName(id) {
-    return (spaces[id] && spaces[id].name) || ""
-  }
 
   function onClick() {
     dispatch(SearchBar.setSearchBarPins(finding.search.pins))
@@ -46,8 +41,7 @@ export default React.memo<Props>(function FindingCard({finding}: Props) {
 
   function renderWarning() {
     const findingSpaceId = get(finding, ["search", "spaceId"], "")
-    const findingSpaceName = getSpaceName(findingSpaceId)
-    const tip = `'${findingSpaceName}' space no longer exists`
+    const tip = "This space no longer exists"
 
     if (includes(spaceIds, findingSpaceId)) return null
 

--- a/src/js/components/Investigation/FindingCard.js
+++ b/src/js/components/Investigation/FindingCard.js
@@ -22,7 +22,14 @@ import submitSearch from "../../flows/submitSearch"
 type Props = {finding: Finding}
 
 export default React.memo<Props>(function FindingCard({finding}: Props) {
-  let dispatch = useDispatch()
+  const dispatch = useDispatch()
+  const clusterId = useSelector(Tab.clusterId)
+  const spaces = useSelector(Spaces.raw)[clusterId] || {}
+  const spaceIds = useSelector(Spaces.ids(clusterId))
+
+  function getSpaceName(id) {
+    return (spaces[id] && spaces[id].name) || ""
+  }
 
   function onClick() {
     dispatch(SearchBar.setSearchBarPins(finding.search.pins))
@@ -38,10 +45,8 @@ export default React.memo<Props>(function FindingCard({finding}: Props) {
   }
 
   function renderWarning() {
-    const clusterID = useSelector(Tab.clusterId)
-    const spaceIds = useSelector(Spaces.ids(clusterID))
     const findingSpaceId = get(finding, ["search", "spaceId"], "")
-    const findingSpaceName = get(finding, ["search", "spaceName"], "")
+    const findingSpaceName = getSpaceName(findingSpaceId)
     const tip = `'${findingSpaceName}' space no longer exists`
 
     if (includes(spaceIds, findingSpaceId)) return null

--- a/src/js/components/Investigation/FindingCard.js
+++ b/src/js/components/Investigation/FindingCard.js
@@ -1,8 +1,11 @@
 /* @flow */
 
+import {includes} from "lodash"
 import {useDispatch, useSelector} from "react-redux"
 import React from "react"
+import ReactTooltip from "react-tooltip"
 import classNames from "classnames"
+import get from "lodash/get"
 
 import type {Finding} from "../../state/Investigation/types"
 import {RemoveButton} from "../Buttons"
@@ -11,13 +14,10 @@ import FindingProgram from "./FindingProgram"
 import Investigation from "../../state/Investigation"
 import Search from "../../state/Search"
 import SearchBar from "../../state/SearchBar"
-import submitSearch from "../../flows/submitSearch"
-import Warning from "../icons/warning-sm.svg"
 import Spaces from "../../state/Spaces/selectors"
-import {includes} from "lodash"
 import Tab from "../../state/Tab"
-import get from "lodash/get"
-import ReactTooltip from "react-tooltip"
+import Warning from "../icons/warning-sm.svg"
+import submitSearch from "../../flows/submitSearch"
 
 type Props = {finding: Finding}
 
@@ -27,7 +27,7 @@ export default React.memo<Props>(function FindingCard({finding}: Props) {
   function onClick() {
     dispatch(SearchBar.setSearchBarPins(finding.search.pins))
     dispatch(SearchBar.changeSearchBarInput(finding.search.program))
-    dispatch(Search.setSpace(finding.search.spaceId, finding.search.spaceName))
+    dispatch(Search.setSpace(finding.search.spaceId))
     dispatch(Search.setSpanArgs(finding.search.spanArgs))
     dispatch(Search.setSpanFocus(null))
     dispatch(submitSearch(false))

--- a/src/js/components/RightPane.test.js
+++ b/src/js/components/RightPane.test.js
@@ -12,7 +12,7 @@ test("no errors if space does not exist", async () => {
   let {store} = await loginTo("cluster1", "space1")
 
   store.dispatch(Layout.showRightSidebar())
-  store.dispatch(Search.setSpace("", ""))
+  store.dispatch(Search.setSpace(""))
   store.dispatch(LogDetails.push([]))
   let el = provide(store, <XRightPane />)
   expect(el.html()).toBe("")

--- a/src/js/components/SavedSpacesList.js
+++ b/src/js/components/SavedSpacesList.js
@@ -27,17 +27,17 @@ export default function SavedSpacesList({spaces, spaceContextMenu}: Props) {
     dispatch(initSpace(space))
   }
 
-  const onDelete = (spaceId, spaceName) => (e) => {
+  const onDelete = (id, name) => (e) => {
     e.preventDefault()
     remote.dialog
       .showMessageBox({
         type: "warning",
         title: "Delete Space",
-        message: `Are you sure you want to delete ${spaceName}?`,
+        message: `Are you sure you want to delete ${name}?`,
         buttons: ["OK", "Cancel"]
       })
       .then(({response}) => {
-        if (response === 0) dispatch(deleteSpace(spaceId))
+        if (response === 0) dispatch(deleteSpace(id))
       })
   }
 

--- a/src/js/components/TabBar/TabBar.js
+++ b/src/js/components/TabBar/TabBar.js
@@ -6,6 +6,7 @@ import React, {useEffect, useState} from "react"
 import {useResizeObserver} from "../hooks/useResizeObserver"
 import AddTab from "./AddTab"
 import SearchTab from "./SearchTab"
+import Spaces from "../../state/Spaces"
 import Tabs from "../../state/Tabs"
 import brim from "../../brim"
 import lib from "../../lib"
@@ -17,6 +18,7 @@ const MAX_WIDTH = 240
 
 export default function TabBar() {
   let tabs = useSelector(Tabs.getData)
+  let spaces = useSelector(Spaces.raw)
   let count = tabs.length
   let {ref, rect} = useResizeObserver()
   let [width, setWidth] = useState(0)
@@ -26,7 +28,6 @@ export default function TabBar() {
   let ctl = useTabController(count, calcWidth)
 
   useEffect(() => calcWidth(), [rect.width])
-
   return (
     <div className="tab-bar">
       <div className="tabs-container" ref={ref} onMouseLeave={ctl.onMouseLeave}>
@@ -38,7 +39,7 @@ export default function TabBar() {
               onChange: (indices) => ctl.onTabMove(indices)
             })}
             key={tab.id}
-            title={brim.tab(tab).title()}
+            title={brim.tab(tab, spaces).title()}
             style={layout.getStyle(tab.id)}
             removeTab={(e) => ctl.onRemoveClick(e, tab.id)}
             active={tab.id === ctl.activeId}

--- a/src/js/electron/ipc/windows/messages.js
+++ b/src/js/electron/ipc/windows/messages.js
@@ -1,4 +1,6 @@
 /* @flow */
+import type {SpanArgs} from "../../../state/Search/types"
+import type {State} from "../../../state/types"
 import type {WindowName} from "../../tron/windowManager"
 import type {WindowParams} from "../../tron/window"
 import type {
@@ -9,14 +11,12 @@ import type {
   WindowsNewSearchTabMsg,
   WindowsOpenDirectorySelect
 } from "../types"
-import type {State} from "../../../state/types"
-import type {SpanArgs} from "../../../state/Search/types"
 
 export type NewTabSearchParams = {
   program: string,
   span: SpanArgs,
   spaceId: string,
-  spaceName: string
+  isNewWin?: boolean
 }
 
 export default {
@@ -37,7 +37,7 @@ export default {
       channel: "windows:close"
     }
   },
-  newSearchTab(params: Object): WindowsNewSearchTabMsg {
+  newSearchTab(params: NewTabSearchParams): WindowsNewSearchTabMsg {
     return {
       channel: "windows:newSearchTab",
       params

--- a/src/js/errors/index.js
+++ b/src/js/errors/index.js
@@ -5,9 +5,10 @@ import pcapIngest from "./pcapIngest"
 export default {
   pcapIngest,
   logsIngest,
-  spaceDeleted: (name: string) => ({
+  spaceDeleted: (id: string) => ({
     type: "SpaceDeletedError",
-    message: `The space "${name}" previously on this tab has been deleted.`
+    message: `The space previously on this tab has been deleted.`,
+    details: [`id: ${id}`]
   }),
   importInterrupt: () => ({
     type: "ImportInterruptError",

--- a/src/js/flows/fetchNextPage.test.js
+++ b/src/js/flows/fetchNextPage.test.js
@@ -29,7 +29,7 @@ beforeEach(() => {
   store = initTestStore(boom)
   tabId = Tabs.getActive(store.getState())
   store.dispatchAll([
-    Search.setSpace("defaultId", "default"),
+    Search.setSpace("defaultId"),
     Search.setSpanArgsFromDates([new Date(0), new Date(10 * 1000)]),
     tab.computeSpan(),
     Viewer.appendRecords(tabId, records)

--- a/src/js/flows/ingestFiles.js
+++ b/src/js/flows/ingestFiles.js
@@ -123,11 +123,11 @@ const postFiles = (client, jsonTypesPath) => ({
 })
 
 const setSpace = (dispatch, tabId) => ({
-  do({spaceId, name}) {
-    dispatch(Search.setSpace(spaceId, name, tabId))
+  do({spaceId}) {
+    dispatch(Search.setSpace(spaceId, tabId))
   },
   undo() {
-    dispatch(Search.setSpace("", "", tabId))
+    dispatch(Search.setSpace("", tabId))
   }
 })
 const trackProgress = (client, dispatch, clusterId) => {

--- a/src/js/flows/initNewTab.js
+++ b/src/js/flows/initNewTab.js
@@ -1,24 +1,20 @@
 /* @flow */
 import type {Thunk} from "../state/types"
-import Notice from "../state/Notice"
 import Search from "../state/Search"
 import Tab from "../state/Tab"
 import Tabs from "../state/Tabs"
-import errors from "../errors"
 import refreshSpaceNames from "./refreshSpaceNames"
 
 export default (): Thunk => (dispatch, getState) => {
   let state = getState()
   let space = Tab.space(state)
   let spaceId = Tab.getSpaceId(state)
-  let spaceName = Tab.getSpaceName(state)
   let id = Tab.clusterId(state)
   let spaceIsDeleted = spaceId && !space
 
   if (spaceIsDeleted) {
     dispatch(Tabs.clearActive())
     dispatch(Search.setCluster(id))
-    dispatch(Notice.set(errors.spaceDeleted(spaceName)))
     dispatch(refreshSpaceNames())
   }
 }

--- a/src/js/flows/initSpace.js
+++ b/src/js/flows/initSpace.js
@@ -57,7 +57,7 @@ function getCurrentSpaceId(spaces, desiredID) {
 
 function setSpace(dispatch, data, clusterId) {
   globalDispatch(Spaces.setDetail(clusterId, data))
-  dispatch(Search.setSpace(data.id, data.name))
+  dispatch(Search.setSpace(data.id))
   data = brim.interop.spacePayloadToSpace(data)
   return data
 }

--- a/src/js/flows/openNewSearchWindow.js
+++ b/src/js/flows/openNewSearchWindow.js
@@ -1,20 +1,20 @@
 /* @flow */
 
+import type {Thunk} from "redux-thunk"
+
+import SearchBar from "../state/SearchBar"
+import Tab from "../state/Tab"
 import invoke from "../electron/ipc/invoke"
 import ipc from "../electron/ipc"
-import type {Thunk} from "redux-thunk"
-import Tab from "../state/Tab"
-import SearchBar from "../state/SearchBar"
 
 export const openNewSearchTab = (): Thunk => (dispatch, getState) => {
   const state = getState()
 
   const params = {
-    spaceName: Tab.getSpaceName(state),
     spaceId: Tab.getSpaceId(state),
     span: Tab.getSpan(state),
     program: SearchBar.getSearchBarInputValue(state)
   }
-
+  // $FlowFixMe
   invoke(ipc.windows.newSearchTab(params))
 }

--- a/src/js/flows/refreshSpaceNames.js
+++ b/src/js/flows/refreshSpaceNames.js
@@ -10,7 +10,7 @@ export default function refreshSpaceNames(): Thunk {
     return dispatch(fetchSpaces()).then((spaces) => {
       spaces = spaces || []
       let id = Tab.clusterId(getState())
-      globalDispatch(Spaces.setSpaces(id, spaces))
+      return globalDispatch(Spaces.setSpaces(id, spaces))
     })
   }
 }

--- a/src/js/flows/renameSpace.js
+++ b/src/js/flows/renameSpace.js
@@ -16,8 +16,7 @@ export default (clusterId: string, spaceId: string, name: string): Thunk => (
   zClient.spaces.update(spaceId, {name}).then(() => {
     dispatch(Spaces.rename(clusterId, spaceId, name))
     tabs.forEach((t) => {
-      if (t.search.spaceId === spaceId)
-        dispatch(Search.setSpace(spaceId, name, t.id))
+      if (t.search.spaceId === spaceId) dispatch(Search.setSpace(spaceId, t.id))
     })
   })
 }

--- a/src/js/flows/submitSearch.test.js
+++ b/src/js/flows/submitSearch.test.js
@@ -38,7 +38,7 @@ test("fetching a regular search", () => {
   store.dispatchAll([
     Search.setCluster("1"),
     Spaces.setDetail("1", spaceInfo),
-    Search.setSpace("ranch-id", "ranch-logs"),
+    Search.setSpace("ranch-id"),
     initTimeWindow(),
     SearchBar.changeSearchBarInput("_path=conn")
   ])
@@ -54,7 +54,7 @@ test("not saving a search to history", () => {
   store.dispatchAll([
     Search.setCluster("1"),
     Spaces.setDetail("1", spaceInfo),
-    Search.setSpace("ranch-id", "ranch-logs"),
+    Search.setSpace("ranch-id"),
     SearchBar.changeSearchBarInput("_path=conn")
   ])
 
@@ -69,7 +69,7 @@ test("fetching an analytic search", () => {
   store.dispatchAll([
     Search.setCluster("1"),
     Spaces.setDetail("1", spaceInfo),
-    Search.setSpace("ranch-id", "ranch-logs"),
+    Search.setSpace("ranch-id"),
     initTimeWindow(),
     SearchBar.changeSearchBarInput("_path=conn | count()")
   ])
@@ -85,7 +85,7 @@ test("fetching an analytic search without history", () => {
   store.dispatchAll([
     Search.setCluster("1"),
     Spaces.setDetail("1", spaceInfo),
-    Search.setSpace("ranch-id", "ranch-logs"),
+    Search.setSpace("ranch-id"),
     initTimeWindow(),
     SearchBar.changeSearchBarInput("_path=conn | count()")
   ])
@@ -101,7 +101,7 @@ test("fetching an zoom search", () => {
   store.dispatchAll([
     Search.setCluster("1"),
     Spaces.setDetail("1", spaceInfo),
-    Search.setSpace("ranch-id", "ranch-logs"),
+    Search.setSpace("ranch-id"),
     initTimeWindow(),
     Search.setSpanFocus(brim.time.convertToSpan([new Date(0), new Date(1)])),
     SearchBar.changeSearchBarInput("_path=conn | count()")
@@ -118,7 +118,7 @@ test("fetching an zoom search without history", () => {
   store.dispatchAll([
     Search.setCluster("1"),
     Spaces.setDetail("1", spaceInfo),
-    Search.setSpace("ranch-id", "ranch-logs"),
+    Search.setSpace("ranch-id"),
     initTimeWindow(),
     SearchBar.changeSearchBarInput("_path=conn | count()"),
     submitSearch()
@@ -135,7 +135,7 @@ test("a bad search query", () => {
   const actions = [
     Search.setCluster("1"),
     Spaces.setDetail("1", spaceInfo),
-    Search.setSpace("ranch-id", "ranch-logs"),
+    Search.setSpace("ranch-id"),
     SearchBar.changeSearchBarInput("_ath="),
     submitSearch()
   ]

--- a/src/js/initializers/initNewSearchTab.js
+++ b/src/js/initializers/initNewSearchTab.js
@@ -1,13 +1,18 @@
 /* @flow */
 
 import type {Dispatch, Store} from "../state/types"
+import type {NewTabSearchParams} from "../electron/ipc/windows/messages"
 import Search from "../state/Search"
-import Tabs from "../state/Tabs/flows"
 import SearchBar from "../state/SearchBar"
+import Tabs from "../state/Tabs/flows"
 import submitSearch from "../flows/submitSearch"
 
-export default function(store: Store, dispatch: Dispatch, params: Object) {
-  const {spaceId, spaceName, span, program, isNewWin} = params
+export default function(
+  store: Store,
+  dispatch: Dispatch,
+  params: NewTabSearchParams
+) {
+  const {spaceId, span, program, isNewWin} = params
 
   if (!isNewWin) {
     dispatch(Tabs.new())

--- a/src/js/initializers/initNewSearchTab.js
+++ b/src/js/initializers/initNewSearchTab.js
@@ -13,7 +13,7 @@ export default function(store: Store, dispatch: Dispatch, params: Object) {
     dispatch(Tabs.new())
   }
 
-  dispatch(Search.setSpace(spaceId, spaceName))
+  dispatch(Search.setSpace(spaceId))
   dispatch(Search.setSpanArgs(span))
   dispatch(SearchBar.removeAllSearchBarPins())
   dispatch(SearchBar.changeSearchBarInput(program))

--- a/src/js/initializers/initSearch.js
+++ b/src/js/initializers/initSearch.js
@@ -14,6 +14,7 @@ import initStore from "./initStore"
 import initUserInputClasses from "./initUserInputClasses"
 import invoke from "../electron/ipc/invoke"
 import ipc from "../electron/ipc"
+import refreshSpaceNames from "../flows/refreshSpaceNames"
 import refreshWindow from "../flows/refreshWindow"
 
 let {id} = getQueryParams()
@@ -22,7 +23,7 @@ export default () => {
   return Promise.all([
     invoke(ipc.windows.initialState(id)),
     initGlobalStore()
-  ]).then(([windowState, globalStore]) => {
+  ]).then(async ([windowState, globalStore]) => {
     let globalState = globalStore.getState()
     let initState = {...windowState, ...globalState}
 
@@ -45,6 +46,8 @@ export default () => {
     })
     ipcRenderer.on("close", () => dispatch(closeWindow()))
     global.onbeforeunload = () => dispatch(refreshWindow())
+
+    await dispatch(refreshSpaceNames())
 
     return {store, globalStore}
   })

--- a/src/js/state/Boomd/test.js
+++ b/src/js/state/Boomd/test.js
@@ -34,7 +34,7 @@ test("#getBoomOptions", () => {
     Search.setCluster("abc"),
     Search.setSpanArgsFromDates([new Date(0), new Date(1)]),
     Tab.computeSpan(),
-    Search.setSpace("spaceId", "spaceName"),
+    Search.setSpace("spaceId"),
     Boomd.useCache(true),
     Boomd.useIndex(false)
   ])

--- a/src/js/state/GlobalContext.js
+++ b/src/js/state/GlobalContext.js
@@ -7,7 +7,7 @@ import ipc from "../electron/ipc"
 const GlobalContext = React.createContext<*>(null)
 
 export const globalDispatch = (action: Object) => {
-  invoke(ipc.globalStore.dispatch(action))
+  return invoke(ipc.globalStore.dispatch(action))
 }
 
 export default GlobalContext

--- a/src/js/state/Search/actions.js
+++ b/src/js/state/Search/actions.js
@@ -12,12 +12,8 @@ import type {
 import brim, {type Span} from "../../brim"
 
 export default {
-  setSpace(
-    spaceId: string,
-    spaceName: string,
-    tabId?: string
-  ): SEARCH_SPACE_SET {
-    return {type: "SEARCH_SPACE_SET", spaceId, spaceName, tabId}
+  setSpace(spaceId: string, tabId?: string): SEARCH_SPACE_SET {
+    return {type: "SEARCH_SPACE_SET", spaceId, tabId}
   },
   setSpan(span: Span): SEARCH_SPAN_SET {
     return {type: "SEARCH_SPAN_SET", span}

--- a/src/js/state/Search/reducer.js
+++ b/src/js/state/Search/reducer.js
@@ -9,7 +9,6 @@ export const initSearchState: SearchState = {
   spanArgs: ["now - 5m", "now"],
   spanFocus: null,
   spaceId: "",
-  spaceName: "",
   clusterId: "",
   ts: 0
 }
@@ -28,7 +27,7 @@ export default function reducer(
     case "SEARCH_SPAN_FOCUS_SET":
       return {...state, spanFocus: action.spanFocus}
     case "SEARCH_SPACE_SET":
-      return {...state, spaceId: action.spaceId, spaceName: action.spaceName}
+      return {...state, spaceId: action.spaceId}
     case "SEARCH_CLUSTER_SET":
       return {...state, clusterId: action.clusterId}
     case "SEARCH_CLEAR":

--- a/src/js/state/Search/types.js
+++ b/src/js/state/Search/types.js
@@ -3,15 +3,14 @@ import type {DateTuple} from "../../lib/TimeWindow"
 import type {SEARCH_BAR_SUBMIT} from "../SearchBar/types"
 import type {Span, Ts} from "../../brim"
 
-export type SearchState = {
+export type SearchState = {|
   span: Span,
   spanArgs: SpanArgs,
   spanFocus: ?Span,
-  spaceName: string,
   spaceId: string,
   clusterId: string,
   ts: number
-}
+|}
 
 export type SearchArgs = {
   tableProgram: string,
@@ -41,7 +40,6 @@ export type SEARCH_CLUSTER_SET = {
 export type SEARCH_SPACE_SET = {
   type: "SEARCH_SPACE_SET",
   spaceId: string,
-  spaceName: string,
   tabId?: string
 }
 export type SEARCH_SPAN_SET = {

--- a/src/js/state/Spaces/selectors.js
+++ b/src/js/state/Spaces/selectors.js
@@ -12,6 +12,10 @@ export default {
   get: (clusterId: string, spaceId: string) => (state: State) => {
     return getCluster(state, clusterId)[spaceId]
   },
+  getName: (clusterId: string, spaceId: string) => (state: State) => {
+    const space = getCluster(state, clusterId)[spaceId]
+    return space ? space.name : ""
+  },
   raw: (state: State) => state.spaces,
   getSpaces: (clusterId: string) => (state: State): Space[] => {
     let clus = getCluster(state, clusterId)

--- a/src/js/state/Tab/activeTabSelect.js
+++ b/src/js/state/Tab/activeTabSelect.js
@@ -5,6 +5,12 @@ import type {State} from "../types"
 import type {TabState} from "./types"
 import Tabs from "../Tabs"
 
-export default function activeTabSelect<T>(fn: (TabState) => T): (State) => T {
-  return createSelector<State, void, T, TabState>(Tabs.getActiveTab, fn)
+export default function activeTabSelect<T>(
+  fn: (TabState, State) => T
+): (State) => T {
+  return createSelector<State, void, T, TabState, State>(
+    Tabs.getActiveTab,
+    (state) => state,
+    fn
+  )
 }

--- a/src/js/state/Tab/selectors.js
+++ b/src/js/state/Tab/selectors.js
@@ -96,7 +96,9 @@ export default {
   cluster,
   clusterUrl,
   getZealot,
-  getSpaceName: activeTabSelect((tab) => tab.search.spaceName),
+  getSpaceName: activeTabSelect((tab, state) =>
+    Spaces.getName(tab.search.clusterId, tab.search.spaceId)(state)
+  ),
   getSpaceId: activeTabSelect((tab) => tab.search.spaceId),
   space,
   currentEntry: activeTabSelect(History.current),

--- a/src/js/state/Tabs/flows.js
+++ b/src/js/state/Tabs/flows.js
@@ -9,7 +9,7 @@ export default {
   new: (): Thunk => (dispatch, getState) => {
     let {search} = Tabs.getActiveTab(getState())
     let id = brim.randomHash()
-    dispatch(Tabs.add(id, {...search, spaceId: "", spaceName: ""}))
+    dispatch(Tabs.add(id, {...search, spaceId: ""}))
     dispatch(Tabs.activate(id))
     let el = document.getElementById("main-search-input")
     if (el) el.focus()

--- a/src/js/state/Tabs/test.js
+++ b/src/js/state/Tabs/test.js
@@ -151,7 +151,7 @@ test("reorder tabs does not throw error if invalid", () => {
 
 test("reset tab", () => {
   let state = store.dispatchAll([
-    Search.setSpace("myspaceid", "myspace"),
+    Search.setSpace("myspaceid"),
     Tabs.clearActive()
   ])
 

--- a/src/js/state/getPersistable.js
+++ b/src/js/state/getPersistable.js
@@ -5,6 +5,7 @@ export default function getPersistable(state: *) {
   delete persist.errors
   delete persist.notice
   delete persist.handlers
+  delete persist.spaces
 
   return persist
 }

--- a/src/js/state/globalReducer.js
+++ b/src/js/state/globalReducer.js
@@ -2,18 +2,16 @@
 import {combineReducers} from "redux"
 
 import type {InvestigationState} from "./Investigation/types"
-import type {SpacesState} from "./Spaces/types"
+import type {PrefsState} from "./Prefs/types"
 import Investigation from "./Investigation"
 import Prefs from "./Prefs"
-import Spaces from "./Spaces"
 
 export type GlobalState = {
   investigation: InvestigationState,
-  spaces: SpacesState
+  prefs: PrefsState
 }
 
 export default combineReducers<*, *>({
   investigation: Investigation.reducer,
-  spaces: Spaces.reducer,
   prefs: Prefs.reducer
 })

--- a/src/js/test/setup.js
+++ b/src/js/test/setup.js
@@ -61,4 +61,4 @@ global.SVGElement.prototype.getTotalLength = () => 0
 enzyme.configure({adapter: new Adapter()})
 //$FlowFixMe
 document.execCommand = jest.fn()
-initDOM()
+initDOM("app-root")

--- a/src/js/test/setup.js
+++ b/src/js/test/setup.js
@@ -61,4 +61,4 @@ global.SVGElement.prototype.getTotalLength = () => 0
 enzyme.configure({adapter: new Adapter()})
 //$FlowFixMe
 document.execCommand = jest.fn()
-initDOM("app-root")
+initDOM()


### PR DESCRIPTION
fixes #856 

Get the name of a space from the spaces state slice rather than from the cached spaceName property on the SearchRecord.

This allows zqd to migrate the space names, and have the app be up to date with those changes.

An side effect of no longer storing the names is that we cannot display the name in the "deleted" messages. So I've changed them to be more generic. Previously this message included the space name in it like: "Default" space has been deleted.
<img width="276" alt="image" src="https://user-images.githubusercontent.com/3460638/84698692-12016500-af05-11ea-969a-419ea8c593dc.png">
