### PR TITLE
adjust advance zq ci timeouts

### DIFF
--- a/.github/workflows/advance-zq.yml
+++ b/.github/workflows/advance-zq.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         node-version: [12.x]
         os: [ubuntu-18.04]
-    timeout-minutes: 30
+    timeout-minutes: 120
     steps:
       # Only one of these should run at a time, and the checkout of brim
       # has to be in the "protected section". This will poll every 60s
@@ -103,7 +103,9 @@ jobs:
       - run: npm install --no-audit
       - run: npm run build
       - run: npm test -- --maxWorkers=2 --ci
-      - run: xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" npm run itest -- --ci --forceExit
+      - name: Integration Tests
+        run: xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" npm run itest -- --ci --forceExit
+        timeout-minutes: 90
         env:
           WORKSPACE: /var/tmp/brimsec
 

--- a/itest/config.json
+++ b/itest/config.json
@@ -1,4 +1,5 @@
 {
+  "bail": 10,
   "collectCoverageFrom": [
     "**/*.js",
     "!**/flow-typed/**",


### PR DESCRIPTION
Webdriver-style tests wait for elements to appear or to be set to a
specific state. This means a lot of test failures are timeout-driven.
An overall job timeout is already set here in case turnstyle hangs.
However, the current value is too short in cases where Zq and Brim are
so broken as to cause every integration test to fail. Locally under
these conditions, the integration tests took 63 minutes to fail. In CI,
assume that could take up to 90 minutes. Set that as the integration
test step timeout. Increase the job timeout to 120.

Other PRs will make other adjustments and hopefully allow for these
numbers to be reduced or removed.