### PR TITLE
tests: adjust element-based timeouts from 60s to 15s

### DIFF
--- a/.github/workflows/advance-zq.yml
+++ b/.github/workflows/advance-zq.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         node-version: [12.x]
         os: [ubuntu-18.04]
-    timeout-minutes: 120
+    timeout-minutes: 60
     steps:
       # Only one of these should run at a time, and the checkout of brim
       # has to be in the "protected section". This will poll every 60s
@@ -105,7 +105,7 @@ jobs:
       - run: npm test -- --maxWorkers=2 --ci
       - name: Integration Tests
         run: xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" npm run itest -- --ci --forceExit
-        timeout-minutes: 90
+        timeout-minutes: 30
         env:
           WORKSPACE: /var/tmp/brimsec
 

--- a/itest/lib/control.js
+++ b/itest/lib/control.js
@@ -27,7 +27,7 @@ export function retry(
 export const retryUntil = (
   f: PromiseFunc,
   cond_f: (*) => boolean,
-  attempts: number = 60,
+  attempts: number = 15,
   delay: number = 1000
 ) =>
   // Retry f until a condition is met. cond_f receives the value from f after

--- a/itest/lib/newAppInstance.js
+++ b/itest/lib/newAppInstance.js
@@ -20,7 +20,7 @@ export default (name: string, idx: number): Application => {
   let appArgs = {
     chromeDriverArgs: [`--user-data-dir=${userDataDir}`],
     startTimeout: 60000,
-    waitTimeout: 60000,
+    waitTimeout: 15000,
     chromeDriverLogPath: path.join(userDataDir, "chromedriver.log"),
     webdriverLogPath: path.join(userDataDir, "webdriverLogFiles"),
     // Latest compatible spectron and webdriverio lead to the


### PR DESCRIPTION
It was discovered long ago that weak-powered CI-hosted instances can't
guarantee elements are ready within the default 5s for Spectron. At the
time I just set a very high timeout of 60s. But it has been shown that
there are pathological cases where all tests can fail (broken zqd), and
the test system spends too much time waiting (60s * number of tests).
After #888, the right side of that expression is improved, but the timeout
of 60s remained. This PR fixes that.

I've done some sanity testing on both CI systems and lower-powered cloud
instances and propose this 60s timeout be shifted to 15s. This seems
high enough to still get successful runs but it greatly reduces the time
spent waiting if zqd is broken.

Note that by changing the timeout values inside the integration tests,
we can change CI job-wide and integration test step timeouts as well.
So this reduces the numbers set in #888.

I have further plans to completely remove the job-wide timeout in a
separate bit of work.

The biggest area of uncertainty is what will happen when CI is busier. I
have tried to reproduce "busy" conditions by creating new branches and
running multiple jobs at the same time, but the only real certainty is
to wait and see.