### PR TITLE
fix: run ci on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Brim CI
 
-on: [push]
+on:
+  pull_request:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Brim CI
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
We got a forked pull request! This change will allow pull requests from forks to run CI. 

If you're a member of brimsec and want CI, the previous behavior of getting CI on any push is gone. You now must open a pull request to get a CI run. The convention in brimsec/zq is to open a draft if you're not ready for review but need a CI run.

The behavior from forked repos works. Since zq was already set up this way, I created a toy PR from a fork that shows CI runs on the initial pull_request and also an additional commit. https://github.com/brimsec/zq/pull/940