### PR TITLE
Add error message for space renames

### DIFF
--- a/src/css/settings/_colors.scss
+++ b/src/css/settings/_colors.scss
@@ -36,6 +36,9 @@ $green: #399c81;
 $green-dark: darken(#399c81, 15%);
 
 $red: #e65835;
+:root {
+  --red: #e65835;
+}
 $red-light: lighten($red, 15%);
 $red-dark: darken($red, 15%);
 

--- a/src/js/components/SpaceModal.js
+++ b/src/js/components/SpaceModal.js
@@ -5,6 +5,7 @@ import React, {useState, useEffect} from "react"
 import {reactElementProps} from "../test/integration"
 import InputField from "./common/forms/InputField"
 import InputLabel from "./common/forms/InputLabel"
+import InputLabelError from "./common/forms/InputLabelError"
 import Modal from "../state/Modal"
 import ModalBox from "./ModalBox/ModalBox"
 import Spaces from "../state/Spaces"
@@ -17,6 +18,7 @@ export default function SpaceModal() {
   const space = useSelector(Spaces.get(clusterId, spaceId))
   const {name} = space || {name: ""}
   const [nameInput, setNameInput] = useState(name)
+  const [error, setError] = useState(null)
   const dispatch = useDispatch()
 
   useEffect(() => {
@@ -24,8 +26,14 @@ export default function SpaceModal() {
   }, [name])
 
   const onSubmit = () => {
+    setError(null)
     dispatch(renameSpace(clusterId, spaceId, nameInput))
-    dispatch(Modal.hide())
+      .then(() => {
+        dispatch(Modal.hide())
+      })
+      .catch((e) => {
+        setError(e.error)
+      })
   }
 
   return (
@@ -36,16 +44,23 @@ export default function SpaceModal() {
       className="space-modal"
       {...reactElementProps("spaceModal")}
     >
-      <SpaceModalContents value={nameInput} onChange={setNameInput} />
+      <SpaceModalContents
+        value={nameInput}
+        onChange={setNameInput}
+        error={error}
+      />
     </ModalBox>
   )
 }
 
-const SpaceModalContents = ({value, onChange}) => {
+const SpaceModalContents = ({value, onChange, error}) => {
   return (
     <div className="space-modal-contents">
       <InputField>
-        <InputLabel>New Name</InputLabel>
+        <InputLabel>
+          New Name
+          {error && <InputLabelError> Error: {error}</InputLabelError>}
+        </InputLabel>
         <TextInput
           autoFocus
           value={value}

--- a/src/js/components/common/forms/InputLabelError.js
+++ b/src/js/components/common/forms/InputLabelError.js
@@ -1,0 +1,10 @@
+/* @flow */
+import styled from "styled-components"
+
+// $FlowFixMe
+const InputLabelError = styled.span`
+  color: var(--red);
+  font-weight: 400;
+`
+
+export default InputLabelError

--- a/src/js/components/common/forms/InputLabelError.js
+++ b/src/js/components/common/forms/InputLabelError.js
@@ -1,8 +1,9 @@
 /* @flow */
 import styled from "styled-components"
 
-// $FlowFixMe
-const InputLabelError = styled.span`
+import type {Styled} from "../../../types/styled"
+
+const InputLabelError: Styled<> = styled.span`
   color: var(--red);
   font-weight: 400;
 `

--- a/src/js/flows/renameSpace.js
+++ b/src/js/flows/renameSpace.js
@@ -1,9 +1,9 @@
 /* @flow */
 import type {Thunk} from "../state/types"
-import Spaces from "../state/Spaces"
-import Tabs from "../state/Tabs"
 import Search from "../state/Search"
+import Spaces from "../state/Spaces"
 import Tab from "../state/Tab"
+import Tabs from "../state/Tabs"
 
 export default (clusterId: string, spaceId: string, name: string): Thunk => (
   dispatch,
@@ -13,7 +13,7 @@ export default (clusterId: string, spaceId: string, name: string): Thunk => (
   const zClient = Tab.getZealot(state)
   const tabs = Tabs.getData(state)
 
-  zClient.spaces.update(spaceId, {name}).then(() => {
+  return zClient.spaces.update(spaceId, {name}).then(() => {
     dispatch(Spaces.rename(clusterId, spaceId, name))
     tabs.forEach((t) => {
       if (t.search.spaceId === spaceId) dispatch(Search.setSpace(spaceId, t.id))

--- a/src/js/types/styled.js
+++ b/src/js/types/styled.js
@@ -1,0 +1,7 @@
+/* @flow */
+import * as React from "react"
+
+export type Styled<Props = {}> = React$ComponentType<{
+  ...Props,
+  children?: React.Node
+}>


### PR DESCRIPTION
Fixes #900 

If zqd responds with an error, we show it in the form next to the label.

<img width="621" alt="Screen Shot 2020-06-25 at 8 32 46 PM" src="https://user-images.githubusercontent.com/3460638/85817653-6e455f80-b723-11ea-848c-339929a69906.png">

Whatever zqd returns as the {error: "message goes here"} is forwarded to the UI.
