### PR TITLE
Remember scroll position

### DIFF
--- a/src/js/brim/entries.js
+++ b/src/js/brim/entries.js
@@ -24,7 +24,11 @@ export default function({
     push(entry: *, scrollPos: *) {
       if (!isEqual(entry, this.getCurrentEntry())) {
         entries.splice(position + 1, entries.length, entry)
-        scrollPositions.splice(position + 1, scrollPositions.length, scrollPos)
+        scrollPositions.splice(position + 1, scrollPositions.length, {
+          x: 0,
+          y: 0
+        })
+        scrollPositions[position] = scrollPos
         position = entries.length - 1
       }
       return this

--- a/src/js/brim/entries.js
+++ b/src/js/brim/entries.js
@@ -4,20 +4,27 @@ import isEqual from "lodash/isEqual"
 
 type Args = {
   position: number,
-  entries: *[]
+  entries: *[],
+  scrollPositions: *[]
 }
 
-export default function({entries: initEntries, position}: Args) {
+export default function({
+  entries: initEntries,
+  position,
+  scrollPositions: initScrollPositions = []
+}: Args) {
   let entries = [...initEntries]
+  let scrollPositions = [...initScrollPositions]
 
   if (position < -1 || position >= entries.length) {
     throw new Error("Position out of bounds")
   }
 
   return {
-    push(entry: *) {
+    push(entry: *, scrollPos: *) {
       if (!isEqual(entry, this.getCurrentEntry())) {
         entries.splice(position + 1, entries.length, entry)
+        scrollPositions.splice(position + 1, scrollPositions.length, scrollPos)
         position = entries.length - 1
       }
       return this
@@ -43,7 +50,7 @@ export default function({entries: initEntries, position}: Args) {
       return entries[position]
     },
     data() {
-      return {position, entries}
+      return {position, entries, scrollPositions}
     }
   }
 }

--- a/src/js/brim/entries.test.js
+++ b/src/js/brim/entries.test.js
@@ -9,7 +9,11 @@ beforeEach(() => {
 
 test("#constructor throws error if position is out of bounds", () => {
   expect(() => {
-    brim.entries({entries: ["a"], position: 999, scrollPositions: {x: 0, y: 0}})
+    brim.entries({
+      entries: ["a"],
+      position: 999,
+      scrollPositions: [{x: 0, y: 0}]
+    })
   }).toThrow("Position out of bounds")
 })
 

--- a/src/js/brim/entries.test.js
+++ b/src/js/brim/entries.test.js
@@ -4,12 +4,12 @@ import brim from "./"
 
 let history
 beforeEach(() => {
-  history = brim.entries({entries: [], position: -1})
+  history = brim.entries({entries: [], position: -1, scrollPositions: []})
 })
 
 test("#constructor throws error if position is out of bounds", () => {
   expect(() => {
-    brim.entries({entries: ["a"], position: 999})
+    brim.entries({entries: ["a"], position: 999, scrollPositions: {x: 0, y: 0}})
   }).toThrow("Position out of bounds")
 })
 

--- a/src/js/components/SearchResults/ResultsTable.js
+++ b/src/js/components/SearchResults/ResultsTable.js
@@ -8,7 +8,7 @@ import throttle from "lodash/throttle"
 
 import type {DispatchProps, State} from "../../state/types"
 import type {Space} from "../../state/Spaces/types"
-import type {ViewerDimens} from "../../types"
+import type {ScrollPosition, ViewerDimens} from "../../types"
 import {endMessage} from "../Viewer/Styler"
 import {fetchNextPage} from "../../flows/fetchNextPage"
 import {openLogDetailsWindow} from "../../flows/openLogDetailsWindow"
@@ -42,8 +42,7 @@ type StateProps = {|
   tableColumns: TableColumns,
   program: string,
   space: Space,
-  scrollX: number,
-  scrollY: number
+  scrollPos: ScrollPosition
 |}
 
 type OwnProps = {|
@@ -171,8 +170,7 @@ export default function ResultsTable(props: Props) {
       timeFormat={props.timeFormat}
       onLastChunk={onLastChunk}
       renderEnd={renderEnd}
-      scrollX={props.scrollX}
-      scrollY={props.scrollY}
+      scrollPos={props.scrollPos}
     />
   )
 }
@@ -187,8 +185,7 @@ function stateToProps(state: State) {
     logs: Viewer.getLogs(state),
     program: SearchBar.getSearchProgram(state),
     space: Tab.space(state),
-    scrollX: Viewer.getScrollX(state),
-    scrollY: Viewer.getScrollY(state),
+    scrollPos: Viewer.getScrollPos(state),
     state
   }
 }

--- a/src/js/components/Viewer/Viewer.js
+++ b/src/js/components/Viewer/Viewer.js
@@ -2,7 +2,7 @@
 
 import React, {useEffect, useRef, useState} from "react"
 
-import type {RowRenderer, ViewerDimens} from "../../types"
+import type {RowRenderer, ScrollPosition, ViewerDimens} from "../../types"
 import {reactElementProps} from "../../test/integration"
 import Chunk from "./Chunk"
 import Chunker from "./Chunker"
@@ -22,8 +22,7 @@ type Props = {
   logs: Log[],
   onLastChunk?: Function,
   renderEnd: () => *,
-  scrollX: number,
-  scrollY: number
+  scrollPos: ScrollPosition
 }
 
 export default function Viewer(props: Props) {
@@ -68,8 +67,10 @@ export default function Viewer(props: Props) {
   useEffect(() => {
     let view = ref.current
     if (!view) return
-    view.scrollTo(props.scrollX, props.scrollY)
-  }, [props.scrollX, props.scrollY])
+    if (props.scrollPos) {
+      view.scrollTo(props.scrollPos.x, props.scrollPos.y)
+    }
+  }, [props.scrollPos.x, props.scrollPos.y])
 
   return (
     <div className="viewer">

--- a/src/js/flows/scrollToLog.js
+++ b/src/js/flows/scrollToLog.js
@@ -9,6 +9,6 @@ export default (log: Log): Thunk => (dispatch, getState) => {
   const logs = Viewer.getLogs(state)
   const index = logs.findIndex((log2) => Log.isSame(log2, log))
   const rowHeight = 25 // pixels
-  const scrollY = index * rowHeight
-  dispatch(Viewer.setScroll(0, scrollY))
+  const scrollPos = {x: 0, y: index * rowHeight}
+  dispatch(Viewer.setScroll(scrollPos))
 }

--- a/src/js/flows/submitSearch.js
+++ b/src/js/flows/submitSearch.js
@@ -26,9 +26,16 @@ export default function submitSearch(
 
     const state = getState()
 
+    let view = document.getElementsByClassName("view")[0]
+
     if (save) {
       let record = Search.getRecord(state)
-      dispatch(History.push(record, time.toTs()))
+      let scrollPos = {x: 0, y: 0}
+      if (view) {
+        scrollPos.x = view.scrollLeft
+        scrollPos.y = view.scrollTop
+      }
+      dispatch(History.push(record, time.toTs(), scrollPos))
       globalDispatch(Investigation.push(record, time.toTs()))
     }
     let tabId = Tabs.getActive(state)

--- a/src/js/state/History/actions.js
+++ b/src/js/state/History/actions.js
@@ -6,7 +6,7 @@ import type {
   HISTORY_FORWARD,
   HISTORY_PUSH
 } from "./types"
-import type {SearchRecord} from "../../types"
+import type {ScrollPosition, SearchRecord} from "../../types"
 import brim, {type Ts} from "../../brim"
 
 export default {
@@ -19,9 +19,14 @@ export default {
   clear: (): HISTORY_CLEAR => ({
     type: "HISTORY_CLEAR"
   }),
-  push: (record: SearchRecord, ts: Ts = brim.time().toTs()): HISTORY_PUSH => ({
+  push: (
+    record: SearchRecord,
+    ts: Ts = brim.time().toTs(),
+    scrollPos: ScrollPosition
+  ): HISTORY_PUSH => ({
     type: "HISTORY_PUSH",
     entry: record,
-    ts: ts
+    ts: ts,
+    scrollPos: scrollPos
   })
 }

--- a/src/js/state/History/reducer.js
+++ b/src/js/state/History/reducer.js
@@ -5,7 +5,8 @@ import brim from "../../brim"
 
 const init: HistoryState = {
   position: -1,
-  entries: []
+  entries: [],
+  scrollPositions: []
 }
 
 export default function reducer(
@@ -19,7 +20,7 @@ export default function reducer(
     case "HISTORY_PUSH":
       return brim
         .entries(state)
-        .push(action.entry)
+        .push(action.entry, action.scrollPos)
         .data()
 
     case "HISTORY_BACK":

--- a/src/js/state/History/selectors.js
+++ b/src/js/state/History/selectors.js
@@ -9,6 +9,8 @@ export default {
   current: (state: TabState) => state.history.entries[state.history.position],
   canGoBack: (state: TabState) => brim.entries(state.history).canGoBack(),
   canGoForward: (state: TabState) => brim.entries(state.history).canGoForward(),
+  getScrollPos: (state: TabState) =>
+    state.history.scrollPositions[state.history.position],
   first: activeTabSelect((state: TabState) => state.history.entries[0]),
   count: activeTabSelect((state: TabState) => state.history.entries.length)
 }

--- a/src/js/state/History/types.js
+++ b/src/js/state/History/types.js
@@ -1,11 +1,12 @@
 /* @flow */
 
-import type {SearchRecord} from "../../types"
+import type {ScrollPosition, SearchRecord} from "../../types"
 import type {Ts} from "../../brim"
 
 export type HistoryState = {
   position: number,
-  entries: SearchRecord[]
+  entries: SearchRecord[],
+  scrollPositions: ScrollPosition[]
 }
 
 export type HistoryAction =
@@ -18,6 +19,11 @@ export type HISTORY_BACK = {type: "HISTORY_BACK"}
 
 export type HISTORY_FORWARD = {type: "HISTORY_FORWARD"}
 
-export type HISTORY_PUSH = {type: "HISTORY_PUSH", entry: SearchRecord, ts: Ts}
+export type HISTORY_PUSH = {
+  type: "HISTORY_PUSH",
+  entry: SearchRecord,
+  ts: Ts,
+  scrollPos: ScrollPosition
+}
 
 export type HISTORY_CLEAR = {type: "HISTORY_CLEAR"}

--- a/src/js/state/SearchBar/flows.js
+++ b/src/js/state/SearchBar/flows.js
@@ -10,18 +10,23 @@ import SearchBar from "../SearchBar"
 import Tab from "../Tab"
 import brim from "../../brim"
 import submitSearch from "../../flows/submitSearch"
+import Viewer from "../Viewer/actions"
 
 export default {
   goBack: (): Thunk => (dispatch, getState) => {
     dispatch(History.back())
     dispatch(Search.restore(Tab.currentEntry(getState())))
-    dispatch(submitSearch(false))
+    dispatch(submitSearch(false)).then(() => {
+      dispatch(Viewer.setScroll(Tab.scrollPos(getState())))
+    })
   },
 
   goForward: (): Thunk => (dispatch, getState) => {
     dispatch(History.forward())
     dispatch(Search.restore(Tab.currentEntry(getState())))
-    dispatch(submitSearch(false))
+    dispatch(submitSearch(false)).then(() => {
+      dispatch(Viewer.setScroll(Tab.scrollPos(getState())))
+    })
   },
 
   validate: (): Thunk => (dispatch, getState) => {

--- a/src/js/state/Tab/selectors.js
+++ b/src/js/state/Tab/selectors.js
@@ -104,6 +104,7 @@ export default {
   currentEntry: activeTabSelect(History.current),
   canGoBack: activeTabSelect(History.canGoBack),
   canGoForward: activeTabSelect(History.canGoForward),
+  scrollPos: activeTabSelect(History.getScrollPos),
   isFetching: activeTabSelect<boolean>(tabIsFetching),
   getSearchTs: activeTabSelect<number>((tab) => tab.search.ts),
   getSpan,

--- a/src/js/state/Viewer/actions.js
+++ b/src/js/state/Viewer/actions.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {Descriptors} from "../../types"
+import type {Descriptors, ScrollPosition} from "../../types"
 import type {RecordData} from "../../types/records"
 import type {SearchStatus} from "../../types/searches"
 import type {
@@ -49,7 +49,7 @@ export default {
     }
   },
 
-  setScroll(scrollX: number, scrollY: number) {
-    return {type: "VIEWER_SCROLL", scrollY, scrollX}
+  setScroll(scrollPos: ScrollPosition) {
+    return {type: "VIEWER_SCROLL", scrollPos}
   }
 }

--- a/src/js/state/Viewer/reducer.js
+++ b/src/js/state/Viewer/reducer.js
@@ -8,8 +8,7 @@ const init: ViewerState = {
   endStatus: "INCOMPLETE",
   status: "INIT",
   columns: {},
-  scrollY: 0,
-  scrollX: 0,
+  scrollPos: {x: 0, y: 0},
   stats: {updateTime: 0, startTime: 0, bytesRead: 0}
 }
 
@@ -33,7 +32,7 @@ export default function(
     case "VIEWER_COLUMNS":
       return {...state, columns: {...state.columns, ...action.columns}}
     case "VIEWER_SCROLL":
-      return {...state, scrollY: action.scrollY, scrollX: action.scrollX}
+      return {...state, scrollPos: action.scrollPos}
     default:
       return state
   }

--- a/src/js/state/Viewer/selectors.js
+++ b/src/js/state/Viewer/selectors.js
@@ -51,13 +51,8 @@ export default {
     (viewer) => viewer.stats
   ),
 
-  getScrollX: createSelector<State, void, *, ViewerState>(
+  getScrollPos: createSelector<State, void, *, ViewerState>(
     getViewer,
-    (viewer) => viewer.scrollX
-  ),
-
-  getScrollY: createSelector<State, void, *, ViewerState>(
-    getViewer,
-    (viewer) => viewer.scrollY
+    (viewer) => viewer.scrollPos
   )
 }

--- a/src/js/state/Viewer/types.js
+++ b/src/js/state/Viewer/types.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {Descriptor} from "../../types"
+import type {Descriptor, ScrollPosition} from "../../types"
 import type {RecordData} from "../../types/records"
 import type {SearchStatus} from "../../types/searches"
 
@@ -18,8 +18,7 @@ export type ViewerState = {|
   endStatus: ViewerStatus,
   status: SearchStatus,
   stats: ViewerStats,
-  scrollX: number,
-  scrollY: number
+  scrollPos: ScrollPosition
 |}
 
 export type ViewerAction =
@@ -75,6 +74,5 @@ export type VIEWER_STATS = {
 
 export type VIEWER_SCROLL = {
   type: "VIEWER_SCROLL",
-  scrollY: number,
-  scrollX: number
+  scrollPos: ScrollPosition
 }

--- a/src/js/types/index.js
+++ b/src/js/types/index.js
@@ -85,6 +85,11 @@ export type LongTimeUnit =
   | "day"
   | "month"
 
+export type ScrollPosition = {
+  x: number,
+  y: number
+}
+
 export type SearchRecord = {
   program: string,
   pins: string[],


### PR DESCRIPTION
Functionality requested in #899 is done.

## Demo
![scroll_demo](https://user-images.githubusercontent.com/67417714/86243049-f608ef00-bba5-11ea-8c21-bf672818754d.gif)


## Approach
In `submitSearch` I've leveraged the save routine to save the scrollposition of the current view in `History`.

Then I forward it to `brim.entries.push` to splice it in.

And then `Searchbar/flows` is responsible for setting the scrollposition when forward and backward buttons are pressed.

## Tests
Passing