### PR TITLE
clear snapshot on space change

### DIFF
--- a/src/js/components/hooks/useThrottle.js
+++ b/src/js/components/hooks/useThrottle.js
@@ -7,6 +7,12 @@ export default function(value: *, wait: number) {
   let pending = useRef(false)
   let nextValue = useRef(null)
 
+  const cancel = () => {
+    if (timeout.current) {
+      clearTimeout(timeout.current)
+    }
+  }
+
   useEffect(() => {
     if (!timeout.current) {
       setState(value)
@@ -28,5 +34,5 @@ export default function(value: *, wait: number) {
     }
   }, [value])
 
-  return state
+  return [state, cancel]
 }


### PR DESCRIPTION
fixes #904 

This turned out to be a little tricky since there ended up being a few culprits:

1. My change [here](https://github.com/brimsec/brim/blob/f5a37b2f786e913bb3d216e1ca56a90840964220/src/js/flows/initSpace.js#L35) prevented a new search to be saved to history every time we switch spaces. I did this because the history view would get diluted with a bunch of empty searches that didn't mean anything to the user, but by removing that this `<IngestRefresh />` component was no longer getting updated properly since the existing effects we have setup were depending on the `historyCount` changing to know when we have switched spaces. So when switching spaces after the change linked above, the `snapshotAck` would not get `ack()`ed like it had been before. The solution then was to add a new effect which listens specifically for space changes, and syncs the snapshots then.

2. While investigating I found that there had been an existing bug here which produced the same undesired behavior, though it was a much smaller corner case. By navigating to a different space within the 3 second throttle window we use to tame the snapshot updates, you could also trigger a false ingest update notification. To fix this, we just need to cancel the current throttle effect whenever we switch spaces.   

Signed-off-by: Mason Fish <mason@looky.cloud>