### PR TITLE
go to download page instead

### DIFF
--- a/src/js/electron/autoUpdater.js
+++ b/src/js/electron/autoUpdater.js
@@ -38,7 +38,7 @@ const autoUpdateLinux = async () => {
     }
 
     dialog.showMessageBox(dialogOpts).then((returnValue) => {
-      const navUrl = `https://github.com/brimsec/brim/releases/tag/${latestVersion}`
+      const navUrl = "https://www.brimsecurity.com/download/"
       if (returnValue.response === 0) open(navUrl)
     })
   } catch (err) {


### PR DESCRIPTION
fixes #902 

Wanted to get this one in for the next release, points to download page instead of github releases

Signed-off-by: Mason Fish <mason@looky.cloud>