### PR TITLE
Split wiki into sections

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -5,8 +5,14 @@ effective use of the Brim desktop application and related tools.
 
 ## Support Resources
 * [[Supported Platforms]]
-* [[Troubleshooting]]
 * [[Microsoft Windows beta limitations]]
+* [[Troubleshooting]]
+
+## User Documentation
+
 * [[Zeek JSON Import]]
 * [[Zeek Customization]]
+
+## Developer Resources
+
 * [[Code Base Walkthrough]]

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,7 +1,11 @@
 **Support Resources**
 * [[Supported Platforms]]
-* [[Troubleshooting]]
 * [[Microsoft Windows beta limitations]]
+* [[Troubleshooting]]
+
+**User Documentation**
 * [[Zeek JSON Import]]
 * [[Zeek Customization]]
+
+**Developer Resources**
 * [[Code Base Walkthrough]]


### PR DESCRIPTION
Seeing https://github.com/brimsec/brim/pull/921 under review made me realize that we're probably due to split the wiki into a few sections so different audiences can more easily find the specific stuff they're looking for. Specifically, that PR will bring us to the point where we'll have multiple docs targeted at developers, which is definitely a targeted audience. While I was at it, I realized that Support-like stuff (general use info folks should know before filing bugs) is different from User docs (detail on how to effectively use certain features) so I've split those out while I'm at it.

If you want to see an example of what this looks like rendered in the wiki, check out https://github.com/philrz/scratchwiki/wiki.