### PR TITLE
Mention MaxMind/GeoLite2 in acknowledgments

### DIFF
--- a/acknowledgments.txt
+++ b/acknowledgments.txt
@@ -423,3 +423,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
  * POSSIBILITY OF SUCH DAMAGE.
  */
 # End brimsec/zeek/src/windows/strptime.c
+
+# Begin https://dev.maxmind.com/geoip/geoip2/geolite2/
+This product includes GeoLite2 data created by MaxMind, available from
+https://www.maxmind.com.
+# End https://dev.maxmind.com/geoip/geoip2/geolite2/


### PR DESCRIPTION
While this attribution is covered via https://github.com/brimsec/geoip-conn/blob/master/README.md, I figure it's good to avoid the level of indirection and also give the attribution up front in the Brim app itself.