### PR TITLE
Nested records more than one level deep

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,7 @@
 <PROJECT_ROOT>/zealot/.*
 <PROJECT_ROOT>/.vscode/.*
 
+>>>>>>> Update flow config
 [include]
 
 [libs]

--- a/.flowconfig
+++ b/.flowconfig
@@ -8,7 +8,6 @@
 <PROJECT_ROOT>/zealot/.*
 <PROJECT_ROOT>/.vscode/.*
 
->>>>>>> Update flow config
 [include]
 
 [libs]

--- a/src/js/brim/flatRecordsBuffer/index.js
+++ b/src/js/brim/flatRecordsBuffer/index.js
@@ -62,7 +62,7 @@ export default function flatRecordBuffers() {
 function flattenType(descriptor, prefix = "") {
   return descriptor.reduce((flat, {name, type}) => {
     let cols = isArray(type)
-      ? flattenType(type, `${name}.`)
+      ? flattenType(type, `${prefix}${name}.`)
       : [{name: prefix + name, type}]
 
     return flat.concat(cols)

--- a/src/js/brim/flatRecordsBuffer/nestedRecord.js
+++ b/src/js/brim/flatRecordsBuffer/nestedRecord.js
@@ -40,6 +40,6 @@ function flattenRecord(record, prefix): FieldData[] {
 function flatFields({name, value, type}, prefix = "") {
   // $FlowFixMe
   return type === "record"
-    ? flattenRecord(value, `${name}.`)
+    ? flattenRecord(value, `${prefix}${name}.`)
     : [{name: prefix + name, type, value}]
 }

--- a/src/js/brim/flatRecordsBuffer/test.js
+++ b/src/js/brim/flatRecordsBuffer/test.js
@@ -23,11 +23,15 @@ test("coverts to an array of nested records", () => {
 test("triple nested", () => {
   let buffer = brim.flatRecordsBuffer()
   buffer.add(0, tripleNest)
-  expect(buffer.channels()[0].records()).toEqual([[{
-    name: "a.b.c",
-    type: "addr",
-    value: "192.168.0.1"
-  }]])
+  expect(buffer.channels()[0].records()).toEqual([
+    [
+      {
+        name: "a.b.c",
+        type: "addr",
+        value: "192.168.0.1"
+      }
+    ]
+  ])
 })
 
 let records = [
@@ -104,9 +108,7 @@ let nestedRecords = [
 const tripleNest = [
   {
     id: 0,
-    type: [
-      {name: "a", type: [{name: "b", type: [{name: "c", type: "addr"}]}]},
-    ],
+    type: [{name: "a", type: [{name: "b", type: [{name: "c", type: "addr"}]}]}],
     values: [[["192.168.0.1"]]]
-  },
+  }
 ]

--- a/src/js/brim/flatRecordsBuffer/test.js
+++ b/src/js/brim/flatRecordsBuffer/test.js
@@ -20,6 +20,16 @@ test("coverts to an array of nested records", () => {
   expect(buffer.channels()[0].records()).toMatchSnapshot()
 })
 
+test("triple nested", () => {
+  let buffer = brim.flatRecordsBuffer()
+  buffer.add(0, tripleNest)
+  expect(buffer.channels()[0].records()).toEqual([[{
+    name: "a.b.c",
+    type: "addr",
+    value: "192.168.0.1"
+  }]])
+})
+
 let records = [
   {
     id: 0,
@@ -89,4 +99,14 @@ let nestedRecords = [
       null
     ]
   }
+]
+
+const tripleNest = [
+  {
+    id: 0,
+    type: [
+      {name: "a", type: [{name: "b", type: [{name: "c", type: "addr"}]}]},
+    ],
+    values: [[["192.168.0.1"]]]
+  },
 ]


### PR DESCRIPTION
Updated the code that "flattens" nested records to work with nests more than 1 level deep.

<img width="619" alt="Screen Shot 2020-07-22 at 12 58 21 PM" src="https://user-images.githubusercontent.com/3460638/88222814-5cb88000-cc1b-11ea-82fc-2133d39b968f.png">
<img width="179" alt="Screen Shot 2020-07-22 at 12 52 33 PM" src="https://user-images.githubusercontent.com/3460638/88222816-5f1ada00-cc1b-11ea-9c8d-b3cc3154564e.png">

fixes #933 