### PR TITLE
Add deno install to remaining workflows

### DIFF
--- a/.github/workflows/advance-zq.yml
+++ b/.github/workflows/advance-zq.yml
@@ -73,6 +73,9 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.14'
+      - uses: denolib/setup-deno@v2
+        with:
+          deno-version: v1.x
       - name: setup node version ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -15,6 +15,9 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.14'
+    - uses: denolib/setup-deno@v2
+      with:
+        deno-version: v1.x
     - name: setup node
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -13,6 +13,9 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.14'
+    - uses: denolib/setup-deno@v2
+      with:
+        deno-version: v1.x
     - name: setup node
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -13,6 +13,9 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.14'
+    - uses: denolib/setup-deno@v2
+      with:
+        deno-version: v1.x
     - name: setup node
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Deno is needed anywhere we `npm install` the Brim repo. I forgot to add it to the remaining workflows in github actions.

It seems that we duplicate a lot of the Brim setup across five of our workflows. It might be a good idea soon to create our own action that can be reused called `brimsec/setup-brim@v2`.

But for now this just adds the `setup-deno@v2` to each of the workflows.