### PR TITLE
Fix deleting a history item issuing a search

### DIFF
--- a/src/js/components/Investigation/FindingCard.js
+++ b/src/js/components/Investigation/FindingCard.js
@@ -48,7 +48,8 @@ export default React.memo<Props>(function FindingCard({finding}: Props) {
     dispatch(submitSearch({history: false, investigation: false}))
   }
 
-  function onRemove() {
+  function onRemove(e) {
+    e.stopPropagation()
     globalDispatch(Investigation.deleteFindingByTs(finding.ts))
   }
 

--- a/src/js/components/Investigation/FindingCard.test.js
+++ b/src/js/components/Investigation/FindingCard.test.js
@@ -1,0 +1,43 @@
+/* @flow */
+
+import React from "react"
+
+import FindingCard from "./FindingCard"
+import brim from "../../brim"
+import loginTo from "../../test/helpers/loginTo"
+import provide from "../../test/helpers/provide"
+
+let store
+beforeEach(async () => {
+  const setup = await loginTo("cluster1", "space1")
+  store = setup.store
+})
+
+function getActionTypes() {
+  return store.getActions().map((a) => a.type)
+}
+
+const finding = {
+  ts: brim.time().toTs(),
+  search: {
+    program: "finding card test",
+    pins: [],
+    spanArgs: [brim.time().toTs(), brim.time().toTs()],
+    spaceId: "1",
+    spaceName: "space1"
+  }
+}
+
+test("Clicking the history submits the search", () => {
+  const el = provide(store, <FindingCard finding={finding} />)
+  store.clearActions()
+  el.simulate("click")
+  expect(getActionTypes()).toContain("SEARCH_BAR_SUBMIT")
+})
+
+test("Clicking remove does not submit the search", () => {
+  const el = provide(store, <FindingCard finding={finding} />)
+  store.clearActions()
+  el.find(".remove-button").simulate("click")
+  expect(getActionTypes()).not.toContain("SEARCH_BAR_SUBMIT")
+})

--- a/src/js/components/SearchPage.test.js
+++ b/src/js/components/SearchPage.test.js
@@ -4,8 +4,6 @@ import React from "react"
 import SearchPage from "./SearchPage"
 import loginTo from "../test/helpers/loginTo"
 import provide from "../test/helpers/provide"
-import theme from "../style-theme"
-import {ThemeProvider} from "styled-components"
 
 let store, cluster
 beforeEach(async () => {
@@ -17,10 +15,5 @@ beforeEach(async () => {
 })
 
 test("Render the search page", () => {
-  provide(
-    store,
-    <ThemeProvider theme={theme}>
-      <SearchPage cluster={cluster} />
-    </ThemeProvider>
-  )
+  provide(store, <SearchPage cluster={cluster} />)
 })

--- a/src/js/test/helpers/provide.js
+++ b/src/js/test/helpers/provide.js
@@ -1,10 +1,17 @@
 /* @flow */
 import {Provider} from "react-redux"
+import {ThemeProvider} from "styled-components"
 import React from "react"
 
 import {mount} from "enzyme"
 
+import theme from "../../style-theme"
+
 export default function provide(store: any, children: *) {
   // $FlowFixMe
-  return mount(<Provider store={store}>{children}</Provider>)
+  return mount(
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </Provider>
+  )
 }


### PR DESCRIPTION
Now when you click the "x" on a history entry, it removes that entry and does not issue a search. Fixes #947 

The issue was that a nested click handler was not stopping the event propagation.

Unit tests have been added to ensure this doesn't regress.