### PR TITLE
Column Visibility Defaults

### DIFF
--- a/src/js/models/TableColumns.js
+++ b/src/js/models/TableColumns.js
@@ -16,21 +16,23 @@ export default class TableColumns {
     columns: Column[] = [],
     tableSetting: ColumnSettingsMap = {}
   ) {
+    // $FlowFixMe
+    const defaultVisible = Object.values(tableSetting).every((c) => c.isVisible)
     this.id = id
     this.cols = columnOrder(columns)
       .map((col, index) => ({
         ...col,
-        ...TableColumns.columnDefaults(index),
+        ...TableColumns.columnDefaults(index, defaultVisible),
         ...tableSetting[columnKey(col)]
       }))
       .sort((a, b) => (a.position > b.position ? 1 : -1))
   }
 
-  static columnDefaults(index: number) {
+  static columnDefaults(position: number, isVisible: boolean) {
     return {
       width: undefined,
-      isVisible: true,
-      position: index
+      isVisible,
+      position
     }
   }
 


### PR DESCRIPTION
Now the logic is:

If all of the columns in the "set" are visible, any columns that come along without an explicit setting are "visible".
If NOT all of the columns in the "set" visible (only some are), then any columns without a setting are "not visible".

This replicates the behavior we had prior to the redesign.

![JoZGtaowi2](https://user-images.githubusercontent.com/3460638/88613798-1ad87100-d043-11ea-941e-311cb27b09e5.gif)
