### PR TITLE
Update zq to v0.18.0 and prep v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.14.0
 * Update zq to [v0.18.0](https://github.com/brimsec/zq/releases/tag/v0.18.0)
 * Add [geolocation](https://github.com/brimsec/brim/wiki/Geolocation) data to Zeek `conn` logs generated from imported pcaps (#959, #957, #935)
-* Add developer documentation for [adding migrations](https://github.com/brimsec/brim/wiki/Adding-Migrations) (#921)
+* Add developer documentation for [adding internal state migrations](https://github.com/brimsec/brim/wiki/Adding-Migrations) (#921)
 * Restore the scroll position when going back to prior search results (#929)
 * Add the [Zealot Client](https://github.com/brimsec/brim/blob/master/zealot/README.md) for communicating with [`zqd`](https://github.com/brimsec/zq/tree/master/cmd/zqd) via the REST API (#934)
 * Add support documentation explaining where Brim stores debug logs (#939, #943)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.14.0
+* Update zq to [v0.18.0](https://github.com/brimsec/zq/releases/tag/v0.18.0)
+* Add [geolocation](https://github.com/brimsec/brim/wiki/Geolocation) data to Zeek `conn` logs generated from imported pcaps (#959, #957, #935)
+* Add developer documentation for [adding migrations](https://github.com/brimsec/brim/wiki/Adding-Migrations) (#921)
+* Restore the scroll position when going back to prior search results (#929)
+* Add the [Zealot Client](https://github.com/brimsec/brim/blob/master/zealot/README.md) for communicating with [`zqd`](https://github.com/brimsec/zq/tree/master/cmd/zqd) via the REST API (#934)
+* Add support documentation explaining where Brim stores debug logs (#939, #943)
+* Fix an issue where records nested more than one level deep were not working correctly in Brim (#937)
+* Improve the Column Chooser (#925, #953)
+* Fix an issue where deleting a History entry incorrectly triggered its execution (#951)
+* Expose React/Redux DevTools when in developer mode (#956)
+
 ## v0.13.1
 * Ensure left panel is open by default, even on upgrades (#918)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4011,7 +4011,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -5445,7 +5445,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -10931,7 +10931,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "^1.0.0"
@@ -13265,7 +13265,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -15486,7 +15486,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -16952,7 +16952,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -17300,7 +17300,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -19369,7 +19369,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -19754,7 +19754,7 @@
     },
     "zq": {
       "version": "git+https://github.com/brimsec/zq.git#240df323b51d38a0a184331ee4be25673e281eef",
-      "from": "git+https://github.com/brimsec/zq.git#240df323b51d38a0a184331ee4be25673e281eef"
+      "from": "git+https://github.com/brimsec/zq.git#v0.18.0"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Brim",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Brim Desktop App",
   "repository": "https://github.com/brimsec/brim",
   "license": "BSD-3-Clause",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "main": "dist/js/electron/main.js",
   "author": "Brim Security, Inc.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "styled-components": "^5.1.1",
     "valid-url": "^1.0.9",
     "zealot": "./zealot",
-    "zq": "git+https://github.com/brimsec/zq.git#240df323b51d38a0a184331ee4be25673e281eef"
+    "zq": "git+https://github.com/brimsec/zq.git#v0.18.0"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",


### PR DESCRIPTION
https://github.com/brimsec/brim/compare/v0.13.1...d88d1d4a128b90e29edcc93d4fe3313974311f82

There also were some packages being accessed via `http://`, and when I did `npm install https://github.com/brimsec/zq#v0.18.0` to update the `zq` pointer, it corrected those to `https://` as well. Since I know we'd been standardizing on `https://` in the past for obvious reasons, I let those changes roll into here as well.