### PR TITLE
Add subspace endpoint to zealot

### DIFF
--- a/zealot/api/mod.ts
+++ b/zealot/api/mod.ts
@@ -3,5 +3,6 @@ import pcaps from "./pcaps.ts";
 import search from "./search.ts";
 import spaces from "./spaces.ts";
 import * as archive from "./archive.ts";
+import * as subspaces from "./subspaces.ts";
 
-export { logs, pcaps, search, spaces , archive};
+export { logs, pcaps, search, spaces, archive, subspaces };

--- a/zealot/api/subspaces.ts
+++ b/zealot/api/subspaces.ts
@@ -1,0 +1,15 @@
+import { FetchArgs } from "../fetcher/fetcher.ts";
+import { SubspaceCreateArgs } from "../types.ts";
+
+export function create({ name, logs, spaceId }: SubspaceCreateArgs): FetchArgs {
+  return {
+    method: "POST",
+    path: `/space/${spaceId}/subspace`,
+    body: JSON.stringify({
+      name,
+      open_options: {
+        log_filter: logs,
+      },
+    }),
+  };
+}

--- a/zealot/fetcher/fetcher.ts
+++ b/zealot/fetcher/fetcher.ts
@@ -3,6 +3,7 @@ import { parseContentType } from "./contentType.ts";
 import { Enhancer } from "../types.ts";
 import { createIterator } from "./iterator.ts";
 import { createStream } from "./stream.ts";
+import { createError } from "../util/error.ts";
 
 export type FetchArgs = {
   path: string;
@@ -18,7 +19,7 @@ export function createFetcher(host: string) {
       const { path, method, body, signal } = args;
       const resp = await fetch(url(host, path), { method, body, signal });
       const content = await parseContentType(resp);
-      return resp.ok ? content : Promise.reject(content);
+      return resp.ok ? content : Promise.reject(createError(content));
     },
     async stream(args: FetchArgs) {
       const { path, method, body, signal } = args;

--- a/zealot/test/error_test.ts
+++ b/zealot/test/error_test.ts
@@ -1,0 +1,33 @@
+import { test, assertThrows, assertEquals } from "./helper/mod.ts";
+import { createError } from "../util/error.ts";
+
+test("server error", () => {
+  const e = createError({ kind: "Bad", error: "things can happen" });
+
+  assertEquals(e.toString(), "Bad: things can happen");
+});
+
+test("object error", () => {
+  const e = createError({ boom: "bang" });
+
+  assertEquals(e.boom, "bang");
+  assertEquals(e.toString(), "Error");
+});
+
+test("Error error", () => {
+  const e = createError(new Error("my own error"));
+
+  assertEquals(e.toString(), "Error: my own error");
+});
+
+test("string error", () => {
+  const e = createError("im a string");
+
+  assertEquals(e.toString(), "Error: im a string");
+});
+
+test("null error", () => {
+  const e = createError(null);
+
+  assertEquals(e.toString(), "Error: null");
+});

--- a/zealot/test/subspace_test.ts
+++ b/zealot/test/subspace_test.ts
@@ -1,0 +1,21 @@
+import { testApi, assertThrowsAsync } from "./helper/mod.ts";
+
+testApi("creating a subspace", async (zealot) => {
+  const parent = await zealot.spaces.create(
+    { name: "space1", storage: { kind: "archivestore" } },
+  );
+
+  /* There is no way to ingest logs into an archive through a zqd server.
+     The only way is using the zar command. Once that changes, update this
+     test to first ingest into an archive, then create a subspace from one
+     of the logs. For now, just assert that the correct error message is 
+     returned. */
+  await assertThrowsAsync(
+    () =>
+      zealot.subspaces.create(
+        { name: "my subspace", logs: ["id1"], spaceId: parent.id },
+      ),
+    Error,
+    "OpenArchive: no logs left after filter",
+  );
+});

--- a/zealot/types.ts
+++ b/zealot/types.ts
@@ -35,6 +35,12 @@ export interface SpaceArgs {
   storage?: SpaceStorageArgs;
 }
 
+export interface SubspaceCreateArgs {
+  name: string;
+  logs: string[];
+  spaceId: string;
+}
+
 export interface PcapsPostArgs {
   spaceId: string;
   path: string;

--- a/zealot/util/error.ts
+++ b/zealot/util/error.ts
@@ -1,0 +1,16 @@
+import { isObject } from "./utils.ts";
+
+export function createError(input: any) {
+  if (input instanceof Error) return input;
+  if (isObject(input)) {
+    const e = Object.assign(new Error(), input);
+    if (input.error) {
+      e.message = input.error;
+    }
+    if (input.kind) {
+      e.name = input.kind;
+    }
+    return e;
+  }
+  return new Error(input);
+}

--- a/zealot/util/utils.ts
+++ b/zealot/util/utils.ts
@@ -11,7 +11,7 @@ export function url(host: string, path: string) {
   return `http://${host}${path}`;
 }
 
-export function isObject(thing: unknown): thing is {} {
+export function isObject(thing: unknown): thing is Object {
   return typeof thing === "object" && thing !== null;
 }
 

--- a/zealot/zealot.ts
+++ b/zealot/zealot.ts
@@ -1,5 +1,5 @@
 import { createFetcher } from "./fetcher/fetcher.ts";
-import { spaces, logs, pcaps, search, archive } from "./api/mod.ts";
+import { spaces, logs, pcaps, search, archive, subspaces } from "./api/mod.ts";
 import { getHost } from "./util/host.ts";
 import { getDefaultSearchArgs } from "./config/search_args.ts";
 import {
@@ -9,6 +9,7 @@ import {
   PcapsGetArgs,
   LogsPostArgs,
   ZealotArgs,
+  SubspaceCreateArgs,
 } from "./types.ts";
 import { IndexSearchArgs } from "./api/archive.ts";
 
@@ -32,9 +33,11 @@ export function createZealot(
       return stream(search(zql, { ...searchArgs, ...args }));
     },
     archive: {
-      search:  (args: IndexSearchArgs) => {
-        return stream({...archive.search(args), enhancers: searchArgs.enhancers} )
-      }
+      search: (args: IndexSearchArgs) => {
+        return stream(
+          { ...archive.search(args), enhancers: searchArgs.enhancers },
+        );
+      },
     },
     spaces: {
       list: () => {
@@ -44,7 +47,7 @@ export function createZealot(
         return promise(spaces.get(id));
       },
       stat: (id: string, args?: Partial<SearchArgs>) => {
-        return stream(spaces.stat(id, {...searchArgs, ...args}))
+        return stream(spaces.stat(id, { ...searchArgs, ...args }));
       },
       create: (args: SpaceArgs) => {
         return promise(spaces.create(args));
@@ -54,6 +57,11 @@ export function createZealot(
       },
       update: (id: string, args: Partial<SpaceArgs>) => {
         return promise(spaces.update(id, args));
+      },
+    },
+    subspaces: {
+      create: (args: SubspaceCreateArgs) => {
+        return promise(subspaces.create(args));
       },
     },
     pcaps: {


### PR DESCRIPTION
Relates to #926 

Hit the subspace create api with zealot. The endpoint was put in place through this PR https://github.com/brimsec/zq/pull/854

It looks like:
```
POST /space/{parent_space_id}/subspace
{
"name": "<name>",
"open_options": {
  "log_filter": ["logid1", ...]
  },
}
```