### PR TITLE
Space List Item Alignment When Ingesting

### DIFF
--- a/itest/tests/zar.test.js
+++ b/itest/tests/zar.test.js
@@ -57,9 +57,7 @@ describe("Zar tests", () => {
         // Reload the app so that it reads the new space.
         await appStep.reload(app)
         await appStep.click(app, ".add-tab")
-        await app.client.waitForVisible(
-          `//*[@class="space-link"]/*[text()="${ZAR_SPACE_NAME}"]`
-        )
+        await app.client.waitForVisible(`=${ZAR_SPACE_NAME}`)
         done()
       })
       .catch((err) => {

--- a/src/css/_saved-spaces-list.scss
+++ b/src/css/_saved-spaces-list.scss
@@ -38,9 +38,11 @@
 
   .space-link {
     @include label-small;
+    line-height: 18px;
     color: $aqua;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     text-decoration: none;
     flex: 1;
     height: 24px;
@@ -99,7 +101,7 @@
   }
 
   .small-progress-bar {
-    width: 100px;
+    flex: 1;
     margin: 0px 5px;
   }
 }

--- a/src/js/components/SavedSpacesList.js
+++ b/src/js/components/SavedSpacesList.js
@@ -2,6 +2,7 @@
 import {useDispatch, useSelector} from "react-redux"
 import React from "react"
 import classNames from "classnames"
+import styled from "styled-components"
 
 import type {Space} from "../state/Spaces/types"
 import {initSpace} from "../flows/initSpace"
@@ -19,6 +20,13 @@ type Props = {|
   spaces: Space[],
   spaceContextMenu: Function
 |}
+
+const NameWrap = styled.div`
+  display: flex;
+  align-items: center;
+  flex: 2;
+  overflow: hidden;
+`
 
 export default function SavedSpacesList({spaces, spaceContextMenu}: Props) {
   const dispatch = useDispatch()
@@ -60,13 +68,15 @@ export default function SavedSpacesList({spaces, spaceContextMenu}: Props) {
                   "current-space-link": s.id === currentSpaceId
                 })}
               >
-                {s.storage_kind === "archivestore" ? (
-                  <ArchiveBorderIcon className="space-icon" />
-                ) : (
-                  <FileBorder className="space-icon" />
-                )}
+                <NameWrap>
+                  {s.storage_kind === "archivestore" ? (
+                    <ArchiveBorderIcon className="space-icon" />
+                  ) : (
+                    <FileBorder className="space-icon" />
+                  )}
 
-                <span className="name">{s.name}</span>
+                  <span className="name">{s.name}</span>
+                </NameWrap>
                 {progress}
               </a>
             </li>


### PR DESCRIPTION

<img width="240" alt="Screen Shot 2020-08-10 at 4 38 42 PM" src="https://user-images.githubusercontent.com/3460638/89929283-e5449380-dbbd-11ea-97e6-164a5922d0c9.png">


The progress bar now will only ever take 33% of the width, it will always be on the right side. The text line height has been changed to an even number so that it centers vertically.