### PR TITLE
Uniqly Generate Space Names

### DIFF
--- a/src/js/brim/ingest/getParams.js
+++ b/src/js/brim/ingest/getParams.js
@@ -1,9 +1,11 @@
 /* @flow */
-import type {IngestFileType} from "./detectFileType"
-import fileList, {type FileListData} from "./fileList"
-import time from "../time"
-import lib from "../../lib"
 import path from "path"
+
+import type {IngestFileType} from "./detectFileType"
+import {getUniqName} from "../../lib/uniqName"
+import fileList, {type FileListData} from "./fileList"
+import lib from "../../lib"
+import time from "../time"
 
 export type IngestParams = {
   dataDir: string,
@@ -18,6 +20,7 @@ export type IngestParamsError = {
 export default function getParams(
   data: FileListData,
   dataDir?: string,
+  existingNames?: string[] = [],
   now: Date = new Date()
 ): IngestParams | IngestParamsError {
   let files = fileList(data)
@@ -38,7 +41,7 @@ export default function getParams(
     else if (files.inSameDir()) name = files.dirName()
     else name = generateDirName(now)
 
-    return name + ".brim"
+    return getUniqName(name, existingNames)
   }
 
   return {

--- a/src/js/brim/ingest/test.js
+++ b/src/js/brim/ingest/test.js
@@ -6,7 +6,7 @@ test("one pcap default", () => {
 
   expect(data).toEqual({
     dataDir: "",
-    name: "my.pcap.brim",
+    name: "my.pcap",
     endpoint: "pcap",
     paths: ["/work/my.pcap"]
   })
@@ -16,7 +16,7 @@ test("one zeek log default", () => {
   let data = ingest.getParams([{type: "log", path: "/work/zeek.log"}])
 
   expect(data).toEqual({
-    name: "zeek.log.brim",
+    name: "zeek.log",
     dataDir: "",
     endpoint: "log",
     paths: ["/work/zeek.log"]
@@ -30,7 +30,7 @@ test("two zeek logs in same dir default", () => {
   ])
 
   expect(data).toEqual({
-    name: "work.brim",
+    name: "work",
     dataDir: "",
     endpoint: "log",
     paths: ["/work/zeek-1.log", "/work/zeek-2.log"]
@@ -44,11 +44,12 @@ test("two zeek logs in different dir default", () => {
       {type: "log", path: "/work/day-2/zeek.log"}
     ],
     "",
+    [],
     new Date(0)
   )
 
   expect(data).toEqual({
-    name: "zeek_1969-12-31_16:00:00.brim",
+    name: "zeek_1969-12-31_16:00:00",
     dataDir: "",
     endpoint: "log",
     paths: ["/work/day-1/zeek.log", "/work/day-2/zeek.log"]

--- a/src/js/lib/uniqName.js
+++ b/src/js/lib/uniqName.js
@@ -1,0 +1,10 @@
+/* @flow */
+function join(name, num) {
+  return num === 0 ? name : [name, `(${num})`].join(" ")
+}
+
+export function getUniqName(proposal: string, existing: string[]) {
+  let i = 0
+  while (existing.includes(join(proposal, i))) i++
+  return join(proposal, i)
+}

--- a/src/js/state/Spaces/selectors.js
+++ b/src/js/state/Spaces/selectors.js
@@ -23,6 +23,10 @@ export default {
       return {...clus[key]}
     })
   },
+  getSpaceNames: (clusterId: string) => (state: State): string[] => {
+    let clus = getCluster(state, clusterId)
+    return Object.keys(clus).map((key) => clus[key].name)
+  },
   getIngestProgress: (clusterId: string, spaceId: string) => (state: State) => {
     let cluster = getCluster(state, clusterId)
     let space = cluster[spaceId]


### PR DESCRIPTION
It was a poor user experience to import a pcap with the same name and get a "there is already a space with this name" error. Now we add a numeric suffix to the name if it already exists. I've also removed the `.brim` suffix since "brim folders" are no longer a thing. This uniq function will also help when we are create subspaces.

<img width="137" alt="Screen Shot 2020-08-11 at 4 59 39 PM" src="https://user-images.githubusercontent.com/3460638/89961123-aa5e5200-dbf5-11ea-8983-3ae1b7631cee.png">

It also works if you provide a custom data dir option to Brim.

<img width="139" alt="Screen Shot 2020-08-11 at 4 59 48 PM" src="https://user-images.githubusercontent.com/3460638/89961137-b34f2380-dbf5-11ea-944c-5d64db4126b6.png">
