### PR TITLE
Fix advance zq: change -datadir flag

### DIFF
--- a/itest/tests/zar.test.js
+++ b/itest/tests/zar.test.js
@@ -42,7 +42,7 @@ describe("Zar tests", () => {
         const sampleSpace = (await client.spaces.list())[0]
         const zarSpace = await client.spaces.create({name: ZAR_SPACE_NAME})
 
-        const zngFile = path.join(sampleSpace.data_path, "all.zng")
+        const zngFile = sampleSpace.data_path + "/all.zng"
         const zarRoot = zarSpace.data_path
 
         // Create a zar archive inside the space.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19776,8 +19776,8 @@
       }
     },
     "zq": {
-      "version": "git+https://github.com/brimsec/zq.git#1b143857ecfe01aa246ce3e051a30f34a5f84a8f",
-      "from": "git+https://github.com/brimsec/zq.git#1b143857ecfe01aa246ce3e051a30f34a5f84a8f"
+      "version": "git+https://github.com/brimsec/zq.git#8fa71aa37f260dc42e501bdb3156c5ffac4c917c",
+      "from": "git+https://github.com/brimsec/zq.git#8fa71aa37f260dc42e501bdb3156c5ffac4c917c"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "styled-components": "^5.1.1",
     "valid-url": "^1.0.9",
     "zealot": "./zealot",
-    "zq": "git+https://github.com/brimsec/zq.git#1b143857ecfe01aa246ce3e051a30f34a5f84a8f"
+    "zq": "git+https://github.com/brimsec/zq.git#8fa71aa37f260dc42e501bdb3156c5ffac4c917c"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",

--- a/src/js/zqd/zqd.js
+++ b/src/js/zqd/zqd.js
@@ -117,7 +117,7 @@ export class ZQD {
       "listen",
       "-l",
       this.addr(),
-      "-datadir",
+      "-data",
       this.root,
       "-config",
       confFile,


### PR DESCRIPTION
From the merging of brimsec/zq#1072 where the -datadir flag was renamed -data