### PR TITLE
Temporarily enable normal searching of an archive space

### DIFF
--- a/src/js/components/TabContent.js
+++ b/src/js/components/TabContent.js
@@ -3,7 +3,6 @@ import {useSelector} from "react-redux"
 import React from "react"
 
 import Tab from "../state/Tab"
-import TabArchiveSearch from "./TabArchiveSearch"
 import TabSearch from "./TabSearch"
 import TabSearchLoading from "./TabSearchLoading"
 import TabWelcome from "./TabWelcome"
@@ -20,8 +19,5 @@ export default function TabContent() {
     return <TabSearchLoading />
   }
 
-  if (space.storage_kind === "archivestore") {
-    return <TabArchiveSearch />
-  }
   return <TabSearch />
 }


### PR DESCRIPTION
We can now run zqd so that it stores all of its data (including spaces & their data) in S3, and we were using a zar archive. For dev/testing, it'd be convenient now to allow typical zql searches against an archivestore space.