### PR TITLE
Escape backslashes in strings

### DIFF
--- a/src/js/brim/field.js
+++ b/src/js/brim/field.js
@@ -16,6 +16,8 @@ const COMMA = /,/
 const STRING_TYPE = /^b?string$/
 const DOUBLE_QUOTE = /"/g
 const ESCAPED_DOUBLE_QUOTE = '\\"'
+const BACK_SLASH = /\\/
+const ESCAPED_BACK_SLASH = "\\\\"
 
 function field({name, type, value}: FieldData): $Field {
   return {
@@ -34,7 +36,9 @@ function field({name, type, value}: FieldData): $Field {
       if (this.type === "bool") return this.value === "T" ? "true" : "false"
       let quote = [WHITE_SPACE, COMMA].some((reg) => reg.test(this.value))
       if (STRING_TYPE.test(this.type)) quote = true
-      const str = this.value.replace(DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE)
+      const str = this.value
+        .replace(BACK_SLASH, ESCAPED_BACK_SLASH)
+        .replace(DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE)
       return quote ? `"${str}"` : str
     },
     stringValue(): string {

--- a/src/js/brim/field.test.js
+++ b/src/js/brim/field.test.js
@@ -20,6 +20,11 @@ test("string escapes double quotes", () => {
   expect(f.queryableValue()).toEqual('"\\"test\\""')
 })
 
+test("string escapes backslash", () => {
+  let f = brim.field({name: "sub", type: "string", value: "Networks,\\"})
+  expect(f.queryableValue()).toBe('"Networks,\\\\"')
+})
+
 describe("#queryableValue", () => {
   const fn = (data: any) => brim.field(data).queryableValue()
 


### PR DESCRIPTION
Fixes #887 

We now turn all backslashes into escaped backslashes when manipulating the search input.

For example: 
```
CN=*.hs.llnwd.net,O=Limelight Networks\, Inc.,L=Tempe,ST=Arizona,C=US,serialNumber=nWN8nk7zDz13jhftc2SuuqMXZx2v8hZK
```

Becomes
```
CN=*.hs.llnwd.net,O=Limelight Networks\\, Inc.,L=Tempe,ST=Arizona,C=US,serialNumber=nWN8nk7zDz13jhftc2SuuqMXZx2v8hZK
```
