### PR TITLE
Make sure backslash escape is global

### DIFF
--- a/src/js/brim/field.js
+++ b/src/js/brim/field.js
@@ -16,7 +16,7 @@ const COMMA = /,/
 const STRING_TYPE = /^b?string$/
 const DOUBLE_QUOTE = /"/g
 const ESCAPED_DOUBLE_QUOTE = '\\"'
-const BACK_SLASH = /\\/
+const BACK_SLASH = /\\/g
 const ESCAPED_BACK_SLASH = "\\\\"
 
 function field({name, type, value}: FieldData): $Field {


### PR DESCRIPTION
My first attempt to verify #887 with just the fix in #993 was a failure because my repro case happened to be a field value containing _two_ backslashes. Only the first backslash was being escaped and so a parse error was still triggered. I'm not claiming JavaScript expertise, but following the info I found online and mimicking the working replacement that we already have in there, I was able to put up this one-character fix. 😅 

Fixes #887.
