### PR TITLE
Persist event in useDoubleClick

### DIFF
--- a/src/js/components/hooks/useDoubleClick.js
+++ b/src/js/components/hooks/useDoubleClick.js
@@ -26,7 +26,8 @@ export default function useDoubleClick(
     return () => clearTimeout(singleClickTimer)
   }, [clicks])
 
-  return (e: MouseEvent) => {
+  return (e: SyntheticEvent<HTMLElement>) => {
+    e.persist()
     setEvent(e)
     setClicks((clicks) => clicks + 1)
   }

--- a/src/js/components/useSearchShortcuts.js
+++ b/src/js/components/useSearchShortcuts.js
@@ -10,7 +10,9 @@ import Tabs from "../state/Tabs"
 export default function() {
   let dispatch = useDispatch()
   useEffect(() => {
-    const bindings = new Mousetrap()
+    const el = document.documentElement
+    if (!el) throw new Error("No Document Element")
+    const bindings = new Mousetrap(el)
       .bind("mod+t", () => dispatch(Tabs.new()))
       .bind("mod+w", (e) => {
         e.preventDefault()


### PR DESCRIPTION
Two small changes here:

1. Because of React's [Event Pooling](https://reactjs.org/docs/events.html#event-pooling) which actually will be removed in [Version 17](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#no-event-pooling), anytime we save an event in an asycronous way, we need to call `event.persist()`.


2. The mousetrap bindings to switch tabs were not working consistently with the new constructor pattern, so I added them to the document Element. All seems to work well now.