### PR TITLE
Create Subspace Flow

### DIFF
--- a/.importjs.js
+++ b/.importjs.js
@@ -28,6 +28,7 @@ module.exports = {
       "kebabCase",
       "camelCase"
     ],
+    zealot: ["createZealot", "createZealotMock"],
     "react-spring": ["useTrail", "useSpring", "useSprings"],
     "react-router-dom": ["Redirect"],
     "react-redux": ["useDispatch"]

--- a/src/css/_log-viewer.scss
+++ b/src/css/_log-viewer.scss
@@ -5,6 +5,9 @@
   *::selection {
     background: transparent;
   }
+  .using-keyboard &:focus {
+    outline: none;
+  }
 }
 
 .viewer .view {

--- a/src/css/_toolbar-button.scss
+++ b/src/css/_toolbar-button.scss
@@ -47,9 +47,13 @@
     .icon {
       opacity: 0.25;
     }
+    .text {
+      opacity: 0.5;
+    }
     & + label {
       opacity: 0.5;
     }
+    cursor: not-allowed;
   }
 
   &.dragging {

--- a/src/js/brim/interop.js
+++ b/src/js/brim/interop.js
@@ -1,7 +1,8 @@
 /* @flow */
-import type {$Record, RecordData} from "../types/records"
-import brim, {type Ts} from "./"
+import type {$Record} from "./record"
+import type {RecordData} from "../types/records"
 import Log from "../models/Log"
+import brim, {type Ts} from "./"
 
 export default {
   recordToLog(record: $Record) {

--- a/src/js/brim/record.js
+++ b/src/js/brim/record.js
@@ -7,8 +7,8 @@ export type $Record = {|
   columns: () => Column[],
   values: () => FieldValue[],
   data: () => RecordData,
-  find: (string) => ?$Field,
-  get: (string) => $Field
+  get: (string) => ?$Field,
+  mustGet: (string) => $Field
 |}
 
 export default function record(data: RecordData): $Record {
@@ -22,12 +22,12 @@ export default function record(data: RecordData): $Record {
     data() {
       return data
     },
-    find(name: string) {
+    get(name: string) {
       let fieldData = data.find((field) => field.name === name)
       return fieldData ? brim.field(fieldData) : null
     },
-    get(name: string) {
-      const f = this.find(name)
+    mustGet(name: string) {
+      const f = this.get(name)
       if (f) return f
       else throw new Error(`Missing field: ${name}`)
     }

--- a/src/js/brim/record.js
+++ b/src/js/brim/record.js
@@ -7,7 +7,8 @@ export type $Record = {|
   columns: () => Column[],
   values: () => FieldValue[],
   data: () => RecordData,
-  find: (string) => ?$Field
+  find: (string) => ?$Field,
+  get: (string) => $Field
 |}
 
 export default function record(data: RecordData): $Record {
@@ -24,6 +25,11 @@ export default function record(data: RecordData): $Record {
     find(name: string) {
       let fieldData = data.find((field) => field.name === name)
       return fieldData ? brim.field(fieldData) : null
+    },
+    get(name: string) {
+      const f = this.find(name)
+      if (f) return f
+      else throw new Error(`Missing Field: ${name}`)
     }
   }
 }

--- a/src/js/brim/record.js
+++ b/src/js/brim/record.js
@@ -29,7 +29,7 @@ export default function record(data: RecordData): $Record {
     get(name: string) {
       const f = this.find(name)
       if (f) return f
-      else throw new Error(`Missing Field: ${name}`)
+      else throw new Error(`Missing field: ${name}`)
     }
   }
 }

--- a/src/js/brim/record.js
+++ b/src/js/brim/record.js
@@ -1,7 +1,14 @@
 /* @flow */
-import type {$Record, FieldValue, RecordData} from "../types/records"
 import type {Column} from "../types"
-import brim from "./"
+import type {FieldValue, RecordData} from "../types/records"
+import brim, {type $Field} from "./"
+
+export type $Record = {|
+  columns: () => Column[],
+  values: () => FieldValue[],
+  data: () => RecordData,
+  find: (string) => ?$Field
+|}
 
 export default function record(data: RecordData): $Record {
   return {
@@ -14,7 +21,7 @@ export default function record(data: RecordData): $Record {
     data() {
       return data
     },
-    field(name: string) {
+    find(name: string) {
       let fieldData = data.find((field) => field.name === name)
       return fieldData ? brim.field(fieldData) : null
     }

--- a/src/js/flows/createSubspace.js
+++ b/src/js/flows/createSubspace.js
@@ -1,8 +1,8 @@
 /* @flow */
 import type {Thunk} from "../state/types"
 import {getUniqName} from "../lib/uniqName"
+import Current from "../state/Current"
 import Spaces from "../state/Spaces"
-import Tab from "../state/Tab"
 import Tabs from "../state/Tabs"
 import Viewer from "../state/Viewer"
 import brim from "../brim"
@@ -11,9 +11,9 @@ import refreshSpaceNames from "./refreshSpaceNames"
 class CreateSubspaceError extends Error {}
 
 export default (): Thunk => (dispatch, getState, {zealot}) => {
-  const spaceId = Tab.getSpaceId(getState())
-  const clusterId = Tab.clusterId(getState())
-  const names = Spaces.getSpaces(clusterId)(getState()).map((s) => s.name)
+  const spaceId = Current.getSpaceId(getState())
+  const connectionId = Current.getConnectionId(getState())
+  const names = Spaces.getSpaces(connectionId)(getState()).map((s) => s.name)
   const records = Viewer.getSelectedRecords(getState()).map(brim.record)
   if (!records.length)
     return Promise.reject(new CreateSubspaceError("No selected logs"))

--- a/src/js/flows/createSubspace.js
+++ b/src/js/flows/createSubspace.js
@@ -1,0 +1,33 @@
+/* @flow */
+import type {Thunk} from "../state/types"
+import {getUniqName} from "../lib/uniqName"
+import Spaces from "../state/Spaces"
+import Tab from "../state/Tab"
+import Tabs from "../state/Tabs"
+import Viewer from "../state/Viewer"
+import brim from "../brim"
+import refreshSpaceNames from "./refreshSpaceNames"
+
+class CreateSubspaceError extends Error {}
+
+export default (): Thunk => (dispatch, getState, {zealot}) => {
+  const spaceId = Tab.getSpaceId(getState())
+  const clusterId = Tab.clusterId(getState())
+  const names = Spaces.getSpaces(clusterId)(getState()).map((s) => s.name)
+  const records = Viewer.getSelectedRecords(getState()).map(brim.record)
+  if (!records.length)
+    return Promise.reject(new CreateSubspaceError("No selected logs"))
+
+  try {
+    const logs = records.map((r) => r.get("_log").stringValue())
+    const keys = records.map((r) => r.get("key").stringValue())
+    const name = getUniqName(keys[0], names)
+    return zealot.subspaces
+      .create({name, spaceId, logs})
+      .then((space) =>
+        dispatch(refreshSpaceNames()).then(() => dispatch(Tabs.new(space.id)))
+      )
+  } catch (e) {
+    return Promise.reject(new CreateSubspaceError(e.message))
+  }
+}

--- a/src/js/flows/createSubspace.js
+++ b/src/js/flows/createSubspace.js
@@ -19,8 +19,8 @@ export default (): Thunk => (dispatch, getState, {zealot}) => {
     return Promise.reject(new CreateSubspaceError("No selected logs"))
 
   try {
-    const logs = records.map((r) => r.get("_log").stringValue())
-    const keys = records.map((r) => r.get("key").stringValue())
+    const logs = records.map((r) => r.mustGet("_log").stringValue())
+    const keys = records.map((r) => r.mustGet("key").stringValue())
     const name = getUniqName(keys[0], names)
     return zealot.subspaces
       .create({name, spaceId, logs})

--- a/src/js/flows/createSubspace.test.js
+++ b/src/js/flows/createSubspace.test.js
@@ -1,0 +1,118 @@
+/* @flow */
+
+import {createZealotMock} from "zealot"
+
+import Clusters from "../state/Clusters"
+import Search from "../state/Search"
+import Spaces from "../state/Spaces"
+import Tab from "../state/Tab"
+import Tabs from "../state/Tabs"
+import Viewer from "../state/Viewer"
+import createSubspace from "./createSubspace"
+import fixtures from "../test/fixtures"
+import initTestStore from "../test/initTestStore"
+
+let store, zealot
+const select = (selector) => selector(store.getState())
+const conn = fixtures("cluster1")
+const space = fixtures("space1")
+const subspace = {...space, id: "2", parent_id: 1, name: "subspace"}
+const records = [
+  [
+    {name: "key", type: "string", value: "10.10.10.10"},
+    {name: "_log", type: "string", value: "/log.zng"}
+  ],
+  [
+    {name: "key", type: "string", value: "10.10.10.10"},
+    {name: "_log", type: "string", value: "/log-2.zng"}
+  ]
+]
+
+beforeEach(() => {
+  zealot = createZealotMock()
+    .stubPromise("subspaces.create", subspace)
+    .stubPromise("spaces.list", [space, subspace])
+  store = initTestStore(zealot)
+  store.dispatchAll([
+    Clusters.add(conn),
+    Spaces.setDetail(conn.id, space),
+    Search.setCluster(conn.id),
+    Search.setSpace(space.id),
+    Viewer.appendRecords(undefined, records),
+    Viewer.select(0)
+  ])
+})
+
+test("Makes a new tab", async () => {
+  expect(select(Tabs.getCount)).toBe(1)
+  await store.dispatch(createSubspace())
+  expect(select(Tabs.getCount)).toBe(2)
+})
+
+test("The new tab is active", async () => {
+  const before = select(Tabs.getActive)
+  await store.dispatch(createSubspace())
+  expect(select(Tabs.getActive)).not.toBe(before)
+})
+
+test("The subspace is the current space", async () => {
+  await store.dispatch(createSubspace())
+  expect(select(Tab.getSpaceId)).toBe("2")
+})
+
+test("The subspace is named the first key of the records", async () => {
+  await store.dispatch(createSubspace())
+  expect(zealot.calls("subspaces.create")[0].args.name).toEqual("10.10.10.10")
+})
+
+test("Sends the array of selected logs", async () => {
+  store.dispatch(Viewer.selectRange(1))
+  await store.dispatch(createSubspace())
+  expect(zealot.calls("subspaces.create")[0].args.logs).toEqual([
+    "/log.zng",
+    "/log-2.zng"
+  ])
+})
+
+test("The list of spaces is updated", async () => {
+  // $FlowFixMe
+  const count = () => select(Spaces.getSpaces(conn.id)).length
+  expect(count()).toBe(1)
+  await store.dispatch(createSubspace())
+  expect(count()).toBe(2)
+})
+
+test("Error if there is no selected records", () => {
+  store.dispatch(Viewer.selectMulti(0))
+  return expect(store.dispatch(createSubspace())).rejects.toThrow(
+    "No selected logs"
+  )
+})
+
+test("Error if there is no _log fields", () => {
+  store.dispatchAll([
+    Viewer.clear(),
+    Viewer.appendRecords(undefined, [
+      [{name: "fun", type: "string", value: "time"}]
+    ]),
+    Viewer.select(0)
+  ])
+
+  return expect(store.dispatch(createSubspace())).rejects.toThrow(
+    "Missing field: _log"
+  )
+})
+
+test("Error if there is no key fields", () => {
+  store.dispatchAll([
+    Viewer.clear(),
+    Viewer.appendRecords(undefined, [
+      [{name: "_log", type: "string", value: "time"}]
+    ]),
+    Viewer.select(0)
+  ])
+
+  return expect(store.dispatch(createSubspace())).rejects.toThrow(
+    "Missing field: key"
+  )
+})

--- a/src/js/flows/createSubspace.test.js
+++ b/src/js/flows/createSubspace.test.js
@@ -3,9 +3,8 @@
 import {createZealotMock} from "zealot"
 
 import Clusters from "../state/Clusters"
-import Search from "../state/Search"
+import Current from "../state/Current"
 import Spaces from "../state/Spaces"
-import Tab from "../state/Tab"
 import Tabs from "../state/Tabs"
 import Viewer from "../state/Viewer"
 import createSubspace from "./createSubspace"
@@ -36,8 +35,8 @@ beforeEach(() => {
   store.dispatchAll([
     Clusters.add(conn),
     Spaces.setDetail(conn.id, space),
-    Search.setCluster(conn.id),
-    Search.setSpace(space.id),
+    Current.setConnectionId(conn.id),
+    Current.setSpaceId(space.id),
     Viewer.appendRecords(undefined, records),
     Viewer.select(0)
   ])
@@ -57,7 +56,7 @@ test("The new tab is active", async () => {
 
 test("The subspace is the current space", async () => {
   await store.dispatch(createSubspace())
-  expect(select(Tab.getSpaceId)).toBe("2")
+  expect(select(Current.getSpaceId)).toBe("2")
 })
 
 test("The subspace is named the first key of the records", async () => {

--- a/src/js/flows/refreshSpaceNames.js
+++ b/src/js/flows/refreshSpaceNames.js
@@ -1,11 +1,10 @@
 /* @flow */
 import type {Thunk} from "../state/types"
-import {globalDispatch} from "../state/GlobalContext"
 import Current from "../state/Current"
 import Spaces from "../state/Spaces"
 
 export default function refreshSpaceNames(): Thunk {
-  return (dispatch, getState, {zealot}) => {
+  return (dispatch, getState, {zealot, globalDispatch}) => {
     return zealot.spaces.list().then((spaces) => {
       spaces = spaces || []
       let id = Current.getConnectionId(getState())

--- a/src/js/initializers/initStore.js
+++ b/src/js/initializers/initStore.js
@@ -2,10 +2,11 @@
 
 import {composeWithDevTools} from "redux-devtools-extension"
 import {createStore, applyMiddleware} from "redux"
+import {createZealot} from "zealot"
 import reduxThunk from "redux-thunk"
 
 import type {Action, Dispatch, State} from "../state/types"
-import {createZealot} from "zealot"
+import {globalDispatch} from "../state/GlobalContext"
 import getUrlSearchParams from "../lib/getUrlSearchParams"
 import invoke from "../electron/ipc/invoke"
 import ipc from "../electron/ipc"
@@ -27,7 +28,10 @@ export default async () => {
     initialState,
     composeWithDevTools(
       applyMiddleware(
-        reduxThunk.withExtraArgument({zealot: createZealot("localhost:9867")})
+        reduxThunk.withExtraArgument({
+          zealot: createZealot("localhost:9867"),
+          globalDispatch
+        })
       )
     )
   )

--- a/src/js/state/Spaces/types.js
+++ b/src/js/state/Spaces/types.js
@@ -27,7 +27,8 @@ export type Space = {
   max_time: Ts,
   pcap_support: boolean,
   storage_kind: "filestore" | "archivestore",
-  ingest: SpaceIngest
+  ingest: SpaceIngest,
+  parent_id?: string
 }
 
 type SpaceIngest = {

--- a/src/js/state/Tabs/flows.js
+++ b/src/js/state/Tabs/flows.js
@@ -6,7 +6,7 @@ import Tabs from "./"
 import brim from "../../brim"
 
 export default {
-  new: (spaceId?: string): Thunk => (dispatch, getState) => {
+  new: (spaceId?: string | null = null): Thunk => (dispatch, getState) => {
     const {
       current: {connectionId}
     } = Tabs.getActiveTab(getState())

--- a/src/js/state/Tabs/flows.js
+++ b/src/js/state/Tabs/flows.js
@@ -6,12 +6,12 @@ import Tabs from "./"
 import brim from "../../brim"
 
 export default {
-  new: (): Thunk => (dispatch, getState) => {
-    let {
+  new: (spaceId?: string): Thunk => (dispatch, getState) => {
+    const {
       current: {connectionId}
     } = Tabs.getActiveTab(getState())
-    let id = brim.randomHash()
-    dispatch(Tabs.add(id, {connectionId}))
+    const id = brim.randomHash()
+    dispatch(Tabs.add(id, {connectionId, spaceId}))
     dispatch(Tabs.activate(id))
     let el = document.getElementById("main-search-input")
     if (el) el.focus()

--- a/src/js/state/Tabs/reducer.js
+++ b/src/js/state/Tabs/reducer.js
@@ -62,7 +62,10 @@ function addTabData(stateData, {id, data}) {
   let initialState = tabReducer(undefined, {type: "INIT"})
   const tab = produce(initialState, (draft) => {
     draft.id = id
-    if (data) draft.current.connectionId = data.connectionId
+    if (data) {
+      draft.current.connectionId = data.connectionId
+      draft.current.spaceId = data.spaceId
+    }
   })
   return [...stateData, tab]
 }

--- a/src/js/state/Tabs/test.js
+++ b/src/js/state/Tabs/test.js
@@ -20,7 +20,7 @@ test("add tab with no data", () => {
 
 test("add tab with data and activate", () => {
   let state = store.dispatchAll([
-    Tabs.add("1", {connectionId: "a"}),
+    Tabs.add("1", {connectionId: "a", spaceId: null}),
     Tabs.activate("1")
   ])
   let tab = Tabs.getActiveTab(state)

--- a/src/js/state/Tabs/types.js
+++ b/src/js/state/Tabs/types.js
@@ -11,7 +11,8 @@ export type TabActions =
   | TABS_ACTIVE_CLEAR
 
 export type AddTabData = {
-  connectionId: string | null
+  connectionId: string | null,
+  spaceId: string | null
 }
 
 export type TABS_ADD = {

--- a/src/js/state/Viewer/actions.js
+++ b/src/js/state/Viewer/actions.js
@@ -25,7 +25,7 @@ import type {
   ViewerStatus
 } from "./types"
 
-export const clear = (tabId: string): VIEWER_CLEAR => {
+export const clear = (tabId?: string): VIEWER_CLEAR => {
   return {type: "VIEWER_CLEAR", tabId}
 }
 
@@ -48,7 +48,7 @@ export const setEndStatus = (
 }
 
 export const appendRecords = (
-  tabId: string,
+  tabId: ?string,
   records: RecordData[]
 ): VIEWER_RECORDS => {
   return {type: "VIEWER_RECORDS", records, tabId}

--- a/src/js/state/Viewer/selectors.js
+++ b/src/js/state/Viewer/selectors.js
@@ -60,3 +60,13 @@ export const getSelection = createSelector<
   ViewerSelection,
   ViewerSelectionData
 >(getSelectionData, (data) => createSelection(data))
+
+export const getSelectedRecords = createSelector<
+  State,
+  void,
+  RecordData[],
+  ViewerSelection,
+  RecordData[]
+>(getSelection, getViewerRecords, (selection, records) =>
+  selection.getIndices().map((index) => records[index])
+)

--- a/src/js/state/Viewer/types.js
+++ b/src/js/state/Viewer/types.js
@@ -42,7 +42,7 @@ export type ViewerAction =
 export type VIEWER_RECORDS = {
   type: "VIEWER_RECORDS",
   records: RecordData[],
-  tabId: string
+  tabId: ?string
 }
 
 export type VIEWER_SET_RECORDS = {
@@ -53,7 +53,7 @@ export type VIEWER_SET_RECORDS = {
 
 export type VIEWER_CLEAR = {
   type: "VIEWER_CLEAR",
-  tabId: string
+  tabId?: string
 }
 
 export type VIEWER_SPLICE = {

--- a/src/js/state/types.js
+++ b/src/js/state/types.js
@@ -15,7 +15,11 @@ import type {TabsState} from "./Tabs/types"
 import type {ViewState} from "./View/types"
 
 export type GetState = () => State
-export type Thunk = (Dispatch, GetState, {zealot: *}) => any
+export type Thunk = (
+  Dispatch,
+  GetState,
+  {zealot: *, globalDispatch: Dispatch}
+) => any
 export type Dispatch = Function
 export type Action = Object
 export type DispatchProps = {|dispatch: Dispatch|}

--- a/src/js/test/initTestStore.js
+++ b/src/js/test/initTestStore.js
@@ -17,16 +17,23 @@ type TestStore = {
 }
 
 export default (zealot: * = createZealotMock()): TestStore => {
-  // $FlowFixMe
-  return createStore(
+  let store
+
+  // This is so that tests can use globalDispatch without actually making
+  // electron ipc calls. In the tests, globalDispatch is an alias for dispatch.
+  const globalDispatch = (...args) => store.dispatch(...args)
+
+  store = createStore(
     rootReducer,
     undefined,
     compose(
       applyDispatchAll(),
-      applyMiddleware(reduxThunk.withExtraArgument({zealot})),
+      applyMiddleware(reduxThunk.withExtraArgument({zealot, globalDispatch})),
       applyActionHistory()
     )
   )
+  // $FlowFixMe
+  return store
 }
 
 function applyDispatchAll() {

--- a/src/js/types/records.js
+++ b/src/js/types/records.js
@@ -1,8 +1,5 @@
 /* @flow */
 
-import type {$Field} from "../brim"
-import type {Column} from "./"
-
 export type FieldValue = string | null | FieldValue[]
 
 export type FieldData = {
@@ -12,10 +9,3 @@ export type FieldData = {
 }
 
 export type RecordData = FieldData[]
-
-export type $Record = {|
-  columns: () => Column[],
-  values: () => FieldValue[],
-  data: () => RecordData,
-  field: (string) => ?$Field
-|}


### PR DESCRIPTION
This PR adds a new thunk called `createSubspace()`. It grabs the selected records from the viewer and issues the api call to zqd with the expected parameters. It doesn't add any UI, just preps the app with the new function and corresponding tests.

This PR also puts the `globalDispatch` method in the third parameter of the Thunk function signature. This makes it much easier to stub out in tests. Thunks now look like:

```js
type Thunk = (dispatch, getState, {zealot, globalDispatch}) => any
```

In the tests, we mock `globalDispatch` with the normal `dispatch` function so that it does not make any ipc calls to electron. The testing framework doesn't know about the electron APIs.