### PR TITLE
Double click bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release": "node scripts/release --darwin",
     "prerelease": "npm run build",
     "prebuild": "npm run clean",
-    "postinstall": "npm-run-all -p deps:*",
+    "postinstall": "npm-run-all -s deps:*",
     "deps:zdeps": "node scripts/download-zdeps",
     "deps:zealot": "cd zealot && make bundle"
   },

--- a/src/js/components/SearchResults/ResultsTable.js
+++ b/src/js/components/SearchResults/ResultsTable.js
@@ -107,7 +107,8 @@ export default function ResultsTable(props: Props) {
         }}
         onDoubleClick={(e) => {
           e && clicked(e, index)
-          props.dispatch(openLogDetailsWindow())
+          dispatch(viewLogDetail(logs[index]))
+          dispatch(openLogDetailsWindow())
         }}
         rightClick={menu.searchFieldContextMenu(
           props.program,

--- a/src/js/flows/viewLogDetail.js
+++ b/src/js/flows/viewLogDetail.js
@@ -7,7 +7,11 @@ import LogDetails from "../state/LogDetails"
 import executeUidSearch from "./executeUidSearch"
 import interop from "../brim/interop"
 
-export const viewLogDetail = (log: Log): Thunk => (dispatch) => {
-  dispatch(executeUidSearch(log))
-  dispatch(LogDetails.push(interop.logToRecordData(log)))
+export const viewLogDetail = (log: Log): Thunk => (dispatch, getState) => {
+  const current = LogDetails.build(getState())
+
+  if (!Log.isSame(log, current)) {
+    dispatch(executeUidSearch(log))
+    dispatch(LogDetails.push(interop.logToRecordData(log)))
+  }
 }


### PR DESCRIPTION
Fixes #1005 

We were opening the log detail window before we were saving the log to the state. This now makes sure we push that log detail into the state before opening the detail window.

It also prevents the log detail state from pushing a duplicate log entry.