### PR TITLE
Column chooser sorting and searching

### DIFF
--- a/src/css/_column-chooser.scss
+++ b/src/css/_column-chooser.scss
@@ -63,6 +63,15 @@
     padding-bottom: 12px;
     height: 100%;
   }
+
+  .search-input {
+    width: 100%;
+  }
+
+  #column-search {
+    width: 100%;
+  }
+
 }
 
 .slide-in-right-appear {
@@ -73,3 +82,4 @@
   transition: transform 150ms;
   transform: translate(0, 0);
 }
+

--- a/src/css/_column-chooser.scss
+++ b/src/css/_column-chooser.scss
@@ -77,7 +77,6 @@
     right: -2px;
     top: -2px;
   }
-
 }
 
 .slide-in-right-appear {
@@ -88,4 +87,3 @@
   transition: transform 150ms;
   transform: translate(0, 0);
 }
-

--- a/src/css/_column-chooser.scss
+++ b/src/css/_column-chooser.scss
@@ -67,6 +67,7 @@
   .search-input {
     width: 100%;
     align-content: center;
+    margin-bottom: 12px;
   }
 
   #column-search {

--- a/src/css/_column-chooser.scss
+++ b/src/css/_column-chooser.scss
@@ -66,10 +66,16 @@
 
   .search-input {
     width: 100%;
+    align-content: center;
   }
 
   #column-search {
     width: 100%;
+  }
+  #column-search-clear {
+    position: absolute;
+    right: -2px;
+    top: -2px;
   }
 
 }

--- a/src/css/_column-chooser.scss
+++ b/src/css/_column-chooser.scss
@@ -70,14 +70,6 @@
     margin-bottom: 12px;
   }
 
-  #column-search {
-    width: 100%;
-  }
-  #column-search-clear {
-    position: absolute;
-    right: -2px;
-    top: -2px;
-  }
 }
 
 .slide-in-right-appear {

--- a/src/css/_column-chooser.scss
+++ b/src/css/_column-chooser.scss
@@ -69,7 +69,6 @@
     align-content: center;
     margin-bottom: 12px;
   }
-
 }
 
 .slide-in-right-appear {

--- a/src/js/components/ColumnChooserMenu.js
+++ b/src/js/components/ColumnChooserMenu.js
@@ -102,6 +102,10 @@ export default class ColumnChooserMenu extends React.Component<Props, State> {
     this.setState({searchValue: event.target.value})
   }
 
+  clearSearch = () => {
+    this.setState({searchValue: ""})
+  }
+
   render() {
     const {columnHeadersView} = this.props
     const columns = this.props.tableColumns.getColumns()
@@ -154,6 +158,10 @@ export default class ColumnChooserMenu extends React.Component<Props, State> {
                   type="text"
                   value={this.state.searchValue}
                   onChange={this.handleChange}
+                />
+                <CloseButton
+                  id="column-search-clear"
+                  onClick={this.clearSearch}
                 />
               </div>
             </ControlListItem>

--- a/src/js/components/ColumnChooserMenu.js
+++ b/src/js/components/ColumnChooserMenu.js
@@ -16,6 +16,7 @@ import Layout from "../state/Layout"
 import SelectInput from "./common/forms/SelectInput"
 import TableColumns from "../models/TableColumns"
 import dispatchToProps from "../lib/dispatchToProps"
+import SearchInput from "./common/forms/SearchInput"
 
 const ControlListItem = styled.li`
   display: flex;
@@ -66,8 +67,15 @@ type Props = {|
   ...OwnProps
 |}
 
-export default class ColumnChooserMenu extends React.Component<Props, State> {
-  state: State = {
+type LocalState = {
+  searchValue: string
+}
+
+export default class ColumnChooserMenu extends React.Component<
+  Props,
+  LocalState
+> {
+  state: LocalState = {
     searchValue: ""
   }
 
@@ -98,7 +106,7 @@ export default class ColumnChooserMenu extends React.Component<Props, State> {
     }
   }
 
-  handleChange = (event) => {
+  handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
     this.setState({searchValue: event.target.value})
   }
 
@@ -153,15 +161,11 @@ export default class ColumnChooserMenu extends React.Component<Props, State> {
             </ControlListItem>
             <ControlListItem>
               <div className="search-input">
-                <input
+                <SearchInput
                   id="column-search"
                   type="text"
                   value={this.state.searchValue}
                   onChange={this.handleChange}
-                />
-                <CloseButton
-                  id="column-search-clear"
-                  onClick={this.clearSearch}
                 />
               </div>
             </ControlListItem>

--- a/src/js/components/ColumnChooserMenu.js
+++ b/src/js/components/ColumnChooserMenu.js
@@ -139,16 +139,21 @@ export default class ColumnChooserMenu extends React.Component<Props> {
                 Deselect All
               </Paragraph>
             </ControlListItem>
-            {columns.map((c) => (
-              <ColumnListItem key={`${c.name}-${c.type}`}>
-                <Checkbox
-                  label={c.name}
-                  checked={c.isVisible}
-                  onChange={(e) => this.onColumnClick(e, c)}
-                />
-                <Subscript>{c.type}</Subscript>
-              </ColumnListItem>
-            ))}
+            {columns
+              .sort((a, b) => {
+                if (a.name < b.name) return -1
+                else return 1
+              })
+              .map((c) => (
+                <ColumnListItem key={`${c.name}-${c.type}`}>
+                  <Checkbox
+                    label={c.name}
+                    checked={c.isVisible}
+                    onChange={(e) => this.onColumnClick(e, c)}
+                  />
+                  <Subscript>{c.type}</Subscript>
+                </ColumnListItem>
+              ))}
           </ul>
         </div>
       </CSSTransition>

--- a/src/js/components/ColumnChooserMenu.js
+++ b/src/js/components/ColumnChooserMenu.js
@@ -162,7 +162,7 @@ export default class ColumnChooserMenu extends React.Component<
             <ControlListItem>
               <div className="search-input">
                 <SearchInput
-                  id="column-search"
+                  autoFocus
                   type="text"
                   value={this.state.searchValue}
                   onChange={this.handleChange}

--- a/src/js/components/ColumnChooserMenu.js
+++ b/src/js/components/ColumnChooserMenu.js
@@ -66,7 +66,11 @@ type Props = {|
   ...OwnProps
 |}
 
-export default class ColumnChooserMenu extends React.Component<Props> {
+export default class ColumnChooserMenu extends React.Component<Props, State> {
+  state: State = {
+    searchValue: ""
+  }
+
   tableId() {
     return this.props.tableColumns.id
   }
@@ -92,6 +96,10 @@ export default class ColumnChooserMenu extends React.Component<Props> {
     } else {
       this.props.dispatch(Columns.showColumn(this.tableId(), column))
     }
+  }
+
+  handleChange = (event) => {
+    this.setState({searchValue: event.target.value})
   }
 
   render() {
@@ -139,7 +147,25 @@ export default class ColumnChooserMenu extends React.Component<Props> {
                 Deselect All
               </Paragraph>
             </ControlListItem>
+            <ControlListItem>
+              <div className="search-input">
+                <input
+                  id="column-search"
+                  type="text"
+                  value={this.state.searchValue}
+                  onChange={this.handleChange}
+                />
+              </div>
+            </ControlListItem>
             {columns
+              .filter((c) => {
+                if (this.state.searchValue === "") return true
+                return (
+                  c.name
+                    .toLowerCase()
+                    .search(new RegExp(this.state.searchValue, "g")) > -1
+                )
+              })
               .sort((a, b) => {
                 if (a.name < b.name) return -1
                 else return 1

--- a/src/js/components/SearchInput.js
+++ b/src/js/components/SearchInput.js
@@ -18,6 +18,7 @@ import ThreeDotButton from "./ThreeDotButton"
 import submitSearch from "../flows/submitSearch"
 import useDelayedMount from "./hooks/useDelayedMount"
 import usePrevious from "./hooks/usePrevious"
+import {shell} from "electron"
 
 export default function SearchInput() {
   let dispatch = useDispatch()
@@ -93,7 +94,8 @@ function Menu() {
     {label: "Copy for zq", click: () => dispatch(Modal.show("zq"))},
     {
       label: "Syntax docs",
-      click: () => open("https://github.com/brimsec/zq/tree/master/zql/docs")
+      click: () =>
+        shell.openExternal("https://github.com/brimsec/zq/tree/master/zql/docs")
     },
     {
       label: "Kill search",


### PR DESCRIPTION
This PR implements #949 and #975.

I think it still needs a few last touches and discussion. 

I wasn't sure what to do with the styling of the input field. I considered styling it like the main search field, but that takes up a lot of space. So input is appreciated on this.

Second part is the sorting of the column names. From Phil's issues I know there is some discussion on this. So maybe we can continue that discussion here and choose an approach. 

I also think that the top of the column chooser is taking up quite a lot of real estate due to white space as it is right now. 

Maybe we could replace the select all and deselect row with a checkbox above the other check-boxes and before the new search input field. I believe it's done more often that way and compresses the header a bit.

**Example**

```
[ x ]  [ search input field                                ]
[   ]  AA
[ x ]  RA
..... and so on
```

**Demo**

![filter_demo](https://user-images.githubusercontent.com/67417714/90782299-2562ef00-e2ff-11ea-8b95-7613c75fdd25.gif)

**Disclaimer**
Still need to fix some flow errors, but wanted to get the discussion done first.

**Out-of-scope-ninja-fixes** 
#982 is fixed.
