### PR TITLE
No cancel on closing detail

### DIFF
--- a/src/js/electron/tron/window.js
+++ b/src/js/electron/tron/window.js
@@ -17,7 +17,7 @@ export default function window(name: WindowName, params: WindowParams) {
     case "about":
       return aboutWindow()
     case "detail":
-      return detailWindow({name, ...params})
+      return detailWindow({...params, name})
     default:
       throw new Error(`Unknown window name: ${name}`)
   }

--- a/src/js/electron/tron/window.js
+++ b/src/js/electron/tron/window.js
@@ -17,7 +17,7 @@ export default function window(name: WindowName, params: WindowParams) {
     case "about":
       return aboutWindow()
     case "detail":
-      return detailWindow({...params})
+      return detailWindow(params)
     default:
       throw new Error(`Unknown window name: ${name}`)
   }
@@ -80,7 +80,6 @@ function detailWindow(params) {
       nodeIntegration: true
     }
   })
-
   if (size) {
     win.setSize(...size)
   }

--- a/src/js/electron/tron/window.js
+++ b/src/js/electron/tron/window.js
@@ -17,7 +17,7 @@ export default function window(name: WindowName, params: WindowParams) {
     case "about":
       return aboutWindow()
     case "detail":
-      return detailWindow({...params, name})
+      return detailWindow({...params})
     default:
       throw new Error(`Unknown window name: ${name}`)
   }
@@ -71,7 +71,7 @@ function aboutWindow() {
 }
 
 function detailWindow(params) {
-  let {size, position, query, id, name} = params
+  let {size, position, query, id} = params
   let win = new BrowserWindow({
     resizable: true,
     width: 360,
@@ -90,7 +90,7 @@ function detailWindow(params) {
     win.center()
   }
 
-  win.loadFile("detail.html", {query: {...query, id, name}})
+  win.loadFile("detail.html", {query: {...query, id}})
 
   return win
 }

--- a/src/js/electron/tron/window.js
+++ b/src/js/electron/tron/window.js
@@ -17,7 +17,7 @@ export default function window(name: WindowName, params: WindowParams) {
     case "about":
       return aboutWindow()
     case "detail":
-      return detailWindow(params)
+      return detailWindow({name, ...params})
     default:
       throw new Error(`Unknown window name: ${name}`)
   }
@@ -71,7 +71,7 @@ function aboutWindow() {
 }
 
 function detailWindow(params) {
-  let {size, position, query, id} = params
+  let {size, position, query, id, name} = params
   let win = new BrowserWindow({
     resizable: true,
     width: 360,
@@ -80,6 +80,7 @@ function detailWindow(params) {
       nodeIntegration: true
     }
   })
+
   if (size) {
     win.setSize(...size)
   }
@@ -89,7 +90,7 @@ function detailWindow(params) {
     win.center()
   }
 
-  win.loadFile("detail.html", {query: {...query, id}})
+  win.loadFile("detail.html", {query: {...query, id, name}})
 
   return win
 }

--- a/src/js/initializers/initCleanup.js
+++ b/src/js/initializers/initCleanup.js
@@ -3,14 +3,7 @@ import {ipcRenderer} from "electron"
 
 import type {Store} from "../state/types"
 import closeWindow from "../flows/closeWindow"
-import refreshWindow from "../flows/refreshWindow"
-import getUrlSearchParams from "../lib/getUrlSearchParams"
 
 export default function(store: Store) {
   ipcRenderer.on("close", () => store.dispatch(closeWindow()))
-  global.onbeforeunload = () => {
-    const {name} = getUrlSearchParams()
-    if (name === "detail") return
-    store.dispatch(refreshWindow())
-  }
 }

--- a/src/js/initializers/initCleanup.js
+++ b/src/js/initializers/initCleanup.js
@@ -4,8 +4,13 @@ import {ipcRenderer} from "electron"
 import type {Store} from "../state/types"
 import closeWindow from "../flows/closeWindow"
 import refreshWindow from "../flows/refreshWindow"
+import getUrlSearchParams from "../lib/getUrlSearchParams"
 
 export default function(store: Store) {
   ipcRenderer.on("close", () => store.dispatch(closeWindow()))
-  global.onbeforeunload = () => store.dispatch(refreshWindow())
+  global.onbeforeunload = () => {
+    const {name} = getUrlSearchParams()
+    if (name === "detail") return
+    store.dispatch(refreshWindow())
+  }
 }

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -11,8 +11,12 @@ import initialize from "./initializers/initialize"
 import lib from "./lib"
 import theme from "./style-theme"
 import {ThemeProvider} from "styled-components"
+import refreshWindow from "./flows/refreshWindow"
 
 initialize().then((store) => {
+  global.onbeforeunload = () => {
+    store.dispatch(refreshWindow())
+  }
   ReactDOM.render(
     <AppErrorBoundary dispatch={store.dispatch}>
       <Provider store={store}>


### PR DESCRIPTION
closes #994 

Storing the "detail" window name in the search query params allows us conditionally decide if it is appropriate to delete partial spaces.

This was also occurring upon refresh of the detail page since the same event gets fired.


![brim](https://user-images.githubusercontent.com/14865533/90809800-e325b780-e2d6-11ea-9157-f2e810f27b4c.gif)
