### PR TITLE
Extract contextmenu builder

### DIFF
--- a/src/js/components/SearchResults/ResultsTable.js
+++ b/src/js/components/SearchResults/ResultsTable.js
@@ -15,13 +15,11 @@ import {useRowSelection} from "./selection"
 import {viewLogDetail} from "../../flows/viewLogDetail"
 import Chunker from "../Viewer/Chunker"
 import Columns from "../../state/Columns"
-import Current from "../../state/Current"
 import Layout from "../../state/Layout"
 import Log from "../../models/Log"
 import LogRow from "../LogRow"
 import NoResults from "./NoResults"
 import Prefs from "../../state/Prefs"
-import SearchBar from "../../state/SearchBar"
 import TableColumns from "../../models/TableColumns"
 import View from "../../state/View"
 import Viewer from "../../state/Viewer"
@@ -29,7 +27,6 @@ import ViewerComponent from "../Viewer/Viewer"
 import buildViewerDimens from "../Viewer/buildViewerDimens"
 import dispatchToProps from "../../lib/dispatchToProps"
 import getEndMessage from "./getEndMessage"
-import menu from "../../electron/menu"
 import useDebouncedEffect from "../hooks/useDebouncedEffect"
 
 type StateProps = {|
@@ -48,7 +45,8 @@ type StateProps = {|
 
 type OwnProps = {|
   height: number,
-  width: number
+  width: number,
+  createContextMenu: Function
 |}
 
 type Props = {|...StateProps, ...DispatchProps, ...OwnProps|}
@@ -110,11 +108,7 @@ export default function ResultsTable(props: Props) {
           dispatch(viewLogDetail(logs[index]))
           dispatch(openLogDetailsWindow())
         }}
-        rightClick={menu.searchFieldContextMenu(
-          props.program,
-          props.tableColumns.getColumns().map((c) => c.name),
-          props.space
-        )}
+        rightClick={props.createContextMenu}
       />
     )
   }
@@ -164,10 +158,7 @@ function stateToProps(state: State) {
     timeZone: View.getTimeZone(state),
     timeFormat: Prefs.getTimeFormat(state),
     logs: Viewer.getLogs(state),
-    program: SearchBar.getSearchProgram(state),
-    space: Current.getSpace(state),
-    scrollPos: Viewer.getScrollPos(state),
-    state
+    scrollPos: Viewer.getScrollPos(state)
   }
 }
 

--- a/src/js/components/SearchResults/SearchResults.js
+++ b/src/js/components/SearchResults/SearchResults.js
@@ -1,15 +1,31 @@
 /* @flow */
+import {useSelector} from "react-redux"
 import React from "react"
 
 import {XResultsTable} from "./ResultsTable"
 import {useResizeObserver} from "../hooks/useResizeObserver"
+import Columns from "../../state/Columns"
+import Current from "../../state/Current"
+import SearchBar from "../../state/SearchBar"
+import menu from "../../electron/menu"
 
 export default function SearchResults() {
-  let {ref, rect} = useResizeObserver()
+  const {ref, rect} = useResizeObserver()
+
+  const program = useSelector(SearchBar.getSearchProgram)
+  const space = useSelector(Current.mustGetSpace)
+  const columns = useSelector(Columns.getCurrentTableColumns)
+    .getColumns()
+    .map((c) => c.name)
+  const createContextMenu = menu.searchFieldContextMenu(program, columns, space)
 
   return (
     <div className="search-results" ref={ref}>
-      <XResultsTable width={rect.width} height={rect.height} />
+      <XResultsTable
+        width={rect.width}
+        height={rect.height}
+        createContextMenu={createContextMenu}
+      />
     </div>
   )
 }


### PR DESCRIPTION
This PR just hoists some of the data needed to build the right click menu on the cells of the table into a component higher in the tree. This way, depending on what type of results are rendered, we can use different kinds of right click menus.