### PR TITLE
Fix bug where span was mutating

### DIFF
--- a/src/js/flows/fetchNextPage.js
+++ b/src/js/flows/fetchNextPage.js
@@ -22,17 +22,17 @@ export const fetchNextPage = (): Thunk => (dispatch, getState) => {
 
 function nextPageArgs(logs, span) {
   let spliceIndex = 0
+  let nextSpan = [...span]
   if (!isEmpty(logs)) {
     let index = indexOfLastChange(logs, (log) => log.getString("ts"))
-
     if (index >= 0) {
       const prevTs = logs[index].getField("ts").toDate()
-      span[1] = brim
+      nextSpan[1] = brim
         .time(prevTs)
         .add(1, "ms")
         .toDate()
       spliceIndex = index + 1
     }
   }
-  return [spliceIndex, span]
+  return [spliceIndex, nextSpan]
 }

--- a/src/js/flows/fetchNextPage.test.js
+++ b/src/js/flows/fetchNextPage.test.js
@@ -7,11 +7,11 @@ import Clusters from "../state/Clusters"
 import Current from "../state/Current"
 import Search from "../state/Search"
 import Spaces from "../state/Spaces"
+import Tab from "../state/Tab"
 import Tabs from "../state/Tabs"
 import Viewer from "../state/Viewer"
 import fixtures from "../test/fixtures"
 import initTestStore from "../test/initTestStore"
-import tab from "../state/Tab"
 
 const records = [
   [
@@ -42,7 +42,7 @@ beforeEach(() => {
     Current.setConnectionId(conn.id),
     Current.setSpaceId(space.id),
     Search.setSpanArgsFromDates([new Date(0), new Date(10 * 1000)]),
-    tab.computeSpan(),
+    Tab.computeSpan(),
     Viewer.appendRecords(tabId, records)
   ])
   store.clearActions()
@@ -82,4 +82,12 @@ test("#fetchNextPage when there is only 1 event", () => {
       to: new Date(10 * 1000)
     })
   )
+})
+
+test("#fetchNextPage does not mutate the exisiting span", () => {
+  const before = [...Tab.getSpanAsDates(store.getState())]
+  store.dispatch(fetchNextPage())
+  const after = [...Tab.getSpanAsDates(store.getState())]
+
+  expect(before).toEqual(after)
 })


### PR DESCRIPTION
When fetching the next page, the time span was being mutated causing weird bugs like the packet button not lighting up when clicking on a record. This also explains why it was working fine in the detail view. The span was not mutated there I suppose.

Fixes #979 