### PR TITLE
ZQL docs links & better link for opening issues

### DIFF
--- a/src/js/components/SearchInput.js
+++ b/src/js/components/SearchInput.js
@@ -93,7 +93,7 @@ function Menu() {
     {label: "Copy for curl", click: () => dispatch(Modal.show("curl"))},
     {label: "Copy for zq", click: () => dispatch(Modal.show("zq"))},
     {
-      label: "Syntax docs",
+      label: "ZQL syntax docs",
       click: () =>
         shell.openExternal("https://github.com/brimsec/zq/tree/master/zql/docs")
     },

--- a/src/js/electron/menu/__snapshots__/appMenu.test.js.snap
+++ b/src/js/electron/menu/__snapshots__/appMenu.test.js.snap
@@ -225,7 +225,7 @@ Array [
     "submenu": Array [
       Object {
         "click": [Function],
-        "label": "Query Syntax Docs",
+        "label": "ZQL Syntax Docs",
       },
       Object {
         "click": [Function],
@@ -413,7 +413,7 @@ Array [
     "submenu": Array [
       Object {
         "click": [Function],
-        "label": "Query Syntax Docs",
+        "label": "ZQL Syntax Docs",
       },
       Object {
         "click": [Function],

--- a/src/js/electron/menu/appMenu.js
+++ b/src/js/electron/menu/appMenu.js
@@ -218,7 +218,9 @@ export default function appMenu(
       {
         label: "Submit Issue...",
         click() {
-          shell.openExternal("https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue")
+          shell.openExternal(
+            "https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue"
+          )
         }
       }
     ]

--- a/src/js/electron/menu/appMenu.js
+++ b/src/js/electron/menu/appMenu.js
@@ -218,7 +218,7 @@ export default function appMenu(
       {
         label: "Submit Issue...",
         click() {
-          shell.openExternal("https://github.com/brimsec/brim/issues/new")
+          shell.openExternal("https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue")
         }
       }
     ]

--- a/src/js/electron/menu/appMenu.js
+++ b/src/js/electron/menu/appMenu.js
@@ -194,7 +194,7 @@ export default function appMenu(
   function helpSubmenu() {
     let submenu = [
       {
-        label: "Query Syntax Docs",
+        label: "ZQL Syntax Docs",
         click() {
           shell.openExternal(
             "https://github.com/brimsec/zq/tree/master/zql/docs"


### PR DESCRIPTION
While verifying #982 I was confronted with how the wording of the current option "Syntax docs" in the "..." menu is a bit vague and also out of sync with the equivalent in the **Help** pull-down that said "Query Syntax Docs". Since we now have no shame in calling the query language by its official name "ZQL", here I'm proposing going ahead and changing both to say "ZQL Syntax Docs". To maintain style with what's already in each menu, I maintained the "all caps" appearance that was in the pull-down menu and the "capitalize first word" approach that was in the "..." menu.

Once I did _that_ I also noticed how the "Submit Issue..." link was going straight to open an issue on GitHub, but we now have a more helpful wiki article that would help a user gather info and better craft their issues, so I changed that link as well.

Disclaimer: I'm no JavaScript developer, but I found these by doing searches against the code base, replacing in what appeared to be the correct places, and tested the fixes locally. Hopefully that suffices. 😄 