### PR TITLE
zq update through "add warnings channel to pcap-ng reader and report through zqd api (#1178)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19776,8 +19776,8 @@
       }
     },
     "zq": {
-      "version": "git+https://github.com/brimsec/zq.git#38e3832e2e24e2386ee000a1a85e2501ee7282ee",
-      "from": "git+https://github.com/brimsec/zq.git#38e3832e2e24e2386ee000a1a85e2501ee7282ee"
+      "version": "git+https://github.com/brimsec/zq.git#41416357a63be577356f27c7cd1e1cd956a5ca4c",
+      "from": "git+https://github.com/brimsec/zq.git#41416357a63be577356f27c7cd1e1cd956a5ca4c"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "styled-components": "^5.1.1",
     "valid-url": "^1.0.9",
     "zealot": "./zealot",
-    "zq": "git+https://github.com/brimsec/zq.git#38e3832e2e24e2386ee000a1a85e2501ee7282ee"
+    "zq": "git+https://github.com/brimsec/zq.git#41416357a63be577356f27c7cd1e1cd956a5ca4c"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",


### PR DESCRIPTION
It looked like we had one of our timing issues yesterday where two zq PRs merged closed together and stepped on each other's automation to update the zq pointer in Brim. I had high hopes of verifying an issue in Brim `master` that's dependent on one of those merges, and nobody's yet merged other zq PRs, so I got impatient and and putting this one up to confirm if the CI will pass & if so merge this to unblock myself.