### PR TITLE
Point to Zeek v3.2.0-dev-brim8

### DIFF
--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -143,7 +143,7 @@ async function main() {
   try {
     // We encode the zeek version here for now to avoid the unncessary
     // git clone if it were in package.json.
-    const zeekVersion = "v3.2.0-dev-brim7"
+    const zeekVersion = "v3.2.0-dev-brim8"
     await zeekDownload(zeekVersion, zdepsPath)
 
     // The zq dependency should be a git tag or commit. Any tag that


### PR DESCRIPTION
To take advantage of updated [geoip-conn](https://github.com/brimsec/geoip-conn) that includes latest GeoLite2 database.