### PR TITLE
Add file signature for nanosecond pcap to accepted list

### DIFF
--- a/src/js/brim/ingest/detectFileType.js
+++ b/src/js/brim/ingest/detectFileType.js
@@ -4,7 +4,8 @@ import fs from "fs"
 const PCAP_1_HEX = "d4c3b2a1"
 const PCAP_2_HEX = "a1b2c3d4"
 const PCAPNG_HEX = "0a0d0d0a"
-const PCAP_HEXES = [PCAP_1_HEX, PCAP_2_HEX, PCAPNG_HEX]
+const PCAPNANO_HEX = "4d3cb2a1"
+const PCAP_HEXES = [PCAP_1_HEX, PCAP_2_HEX, PCAPNG_HEX, PCAPNANO_HEX]
 
 export type IngestFileType = "pcap" | "log"
 


### PR DESCRIPTION
Fixes #1068.

Now the (unzipped) [pings.pcapnano.zip](https://github.com/brimsec/brim/files/5209860/pings.pcapnano.zip) can be successfully imported.

[Success.zip](https://github.com/brimsec/brim/files/5209873/Success.zip)

I'll also look at adding an automated test in the zq repo that works with this file format.