### PR TITLE
Separate release candidate creation from promotion to tagged downloadable releases

### DIFF
--- a/.github/workflows/linux-release-candidate.yml
+++ b/.github/workflows/linux-release-candidate.yml
@@ -1,9 +1,9 @@
-name: Brim linux release
+name: Brim linux release candidate creation
 
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - rc-v*
 
 jobs:
   build:
@@ -43,11 +43,16 @@ jobs:
     - run: npm run build
     - name: build packages
       run: node ./scripts/release --linux
-    - name: upload release artifact
-      uses: svenstaro/upload-release-action@1.1.0
+    - name: Extract branch name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+    - name: Setup Google Cloud Platform
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref }}
-        file: dist/installers/*
-        file_glob: true
-        overwrite: true
+        version: '290.0.1'
+        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
+    - name: Upload release artifacts to Google Cloud Storage bucket
+      run: |
+        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/linux/${{ steps.extract_branch.outputs.branch }} || true
+        gsutil mv dist/installers gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/linux/${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/linux-release-promotion.yml
+++ b/.github/workflows/linux-release-promotion.yml
@@ -1,0 +1,30 @@
+name: Brim linux release artifact promote to tagged
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  promote:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Extract tag name
+      run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
+      id: extract_tag
+    - name: Setup Google Cloud Platform
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+        version: '290.0.1'
+        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
+    - name: Copy artifacts from Google Cloud Storage bucket to GitHub Release page
+      run: gsutil cp -r gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/linux/rc-${{ steps.extract_tag.outputs.tag }} .
+    - name: Upload release candidate artifacts to GitHub Releases
+      uses: svenstaro/upload-release-action@1.1.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: rc-${{ steps.extract_tag.outputs.tag }}/*
+        file_glob: true
+        overwrite: true

--- a/.github/workflows/macos-release-candidate.yml
+++ b/.github/workflows/macos-release-candidate.yml
@@ -1,9 +1,9 @@
-name: Brim macOS release
+name: Brim macOS release candidate creation
 
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - rc-v*
 
 jobs:
   build:
@@ -63,19 +63,16 @@ jobs:
         APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
     - name: run gatekeeper assessment on notarized package
       run: spctl --assess --type execute --verbose --ignore-cache --no-cache dist/packages/Brim-darwin-x64/Brim.app
-    - name: upload release dmg
-      uses: svenstaro/upload-release-action@1.1.0
+    - name: Extract branch name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+    - name: Setup Google Cloud Platform
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref }}
-        file: dist/installers/Brim.dmg
-        asset_name: Brim.dmg
-        overwrite: true
-    - name: upload release zip
-      uses: svenstaro/upload-release-action@1.1.0
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref }}
-        file: dist/installers/Brim-darwin-autoupdater.zip
-        asset_name: Brim-darwin-autoupdater.zip
-        overwrite: true
+        version: '290.0.1'
+        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
+    - name: Upload release artifacts to Google Cloud Storage bucket
+      run: |
+        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/macos/${{ steps.extract_branch.outputs.branch }} || true
+        gsutil mv dist/installers gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/macos/${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/macos-release-promotion.yml
+++ b/.github/workflows/macos-release-promotion.yml
@@ -1,0 +1,30 @@
+name: Brim macOS release artifact promote to tagged
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  promote:
+    runs-on: macos-10.15
+    steps:
+    - name: Extract tag name
+      run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
+      id: extract_tag
+    - name: Setup Google Cloud Platform
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+        version: '290.0.1'
+        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
+    - name: Copy artifacts from Google Cloud Storage bucket to GitHub Release page
+      run: gsutil cp -r gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/macos/rc-${{ steps.extract_tag.outputs.tag }} .
+    - name: Upload release candidate artifacts to GitHub Releases
+      uses: svenstaro/upload-release-action@1.1.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: rc-${{ steps.extract_tag.outputs.tag }}/*
+        file_glob: true
+        overwrite: true

--- a/.github/workflows/win-release-candidate.yml
+++ b/.github/workflows/win-release-candidate.yml
@@ -1,9 +1,9 @@
-name: Brim Windows release
+name: Brim Windows release candidate creation
 
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - rc-v*
 
 jobs:
   build:
@@ -57,28 +57,25 @@ jobs:
       env:
         WINDOWS_SIGNING_PASSPHRASE: ${{ secrets.WINDOWS_SIGNING_PASSPHRASE }}
         WINDOWS_SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_SIGNING_PFX_BASE64 }}
-    - name: upload release executable
-      uses: svenstaro/upload-release-action@1.1.0
+    - name: Extract branch name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+      shell: bash
+    - name: Set up Python (needed for Google Cloud Platform)
+      uses: actions/setup-python@v2
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref }}
-        file: dist\installers\Brim-Setup.exe
-        asset_name: Brim-Setup.exe
-        overwrite: true
-    - name: upload RELEASES file
-      uses: svenstaro/upload-release-action@1.1.0
+        python-version: 3.7
+    - name: Setup Google Cloud Platform
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      env:
+        CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref }}
-        file: dist\installers\RELEASES
-        asset_name: RELEASES
-        overwrite: true
-    - name: upload nupkg assets
-      uses: svenstaro/upload-release-action@1.1.0
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref }}
-        file: dist\installers\*.nupkg
-        overwrite: true
-        file_glob: true
-
+        version: '290.0.1'
+        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
+    - name: Upload release artifacts to Google Cloud Storage bucket
+      env:
+        CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
+      run: |
+        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/windows/${{ steps.extract_branch.outputs.branch }} || true
+        gsutil mv dist\installers\ gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/windows/${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/win-release-promotion.yml
+++ b/.github/workflows/win-release-promotion.yml
@@ -1,0 +1,39 @@
+name: Brim Windows release artifacts promote to tagged
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  promote:
+    runs-on: windows-2019
+    steps:
+    - name: Extract tag name
+      run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
+      id: extract_tag
+      shell: bash
+    - name: Set up Python (needed for Google Cloud Platform)
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Setup Google Cloud Platform
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      env:
+        CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
+      with:
+        version: '290.0.1'
+        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
+    - name: Copy artifacts from Google Cloud Storage bucket to GitHub Release page
+      env:
+        CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
+      run: gsutil cp -r gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/windows/rc-${{ steps.extract_tag.outputs.tag }} .
+    - name: Upload release candidate artifacts to GitHub Releases
+      uses: svenstaro/upload-release-action@1.1.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: rc-${{ steps.extract_tag.outputs.tag }}\*
+        file_glob: true
+        overwrite: true


### PR DESCRIPTION
### tl;dr

The changes here create the build artifacts in one Actions Workflow that finishes with putting them on a Google Cloud Storage bucket from which they could be downloaded and smoke tested. If/when a decision is made to "promote" them to GA, a separate Actions Workflow copies the artifacts from the bucket to the GitHub Releases page.

---

### Background & Motivation

Today the only way I know of to make release artifacts come out of our build system is to create a tag named `v*`, which results in not only the creation of the artifacts but also uploads them to the GitHub Release page for the repo. However, we've made dud artifacts in the past, so we always perform smoke tests before wanting external users to start downloading and using them. Exposure from this is limited by marking it as "Pre-Release" when creating the tagged release in GitHub. Brim will not auto-update itself to such releases, and the "Pre-Release" marker is intended as a visual cue for users who go to that page seeking to manually download a release. We also try and direct people to https://www.brimsecurity.com/download/ as much as possible to find downloads because we only update links there after a release has passed smoke testing and is considered truly GA. All that said, I've observed via download count metrics there have been _some_ external users still downloading artifacts marked as "Pre-Release", so I'd like to minimize exposure to this if at all possible, since it may create Support issues and/or poor perception of quality if duds leak out.

In addition to that smoke testing period, another motivation for the work is that I've found I'm no longer able to create Windows release artifacts manually. We've made the build process much more sophisticated recently between compiling the dependent `zq` version, Deno, etc. I'm sure with some focus I could force this to work again, as the build host on GitHub Actions is surely special in that it has more of the right stuff installed. However, rather than burn Dev time figuring that out, I'm just as happy to go with a system that lets me give the work to GitHub Actions but without the exposure cited in the previous paragraph. With the changes in this PR, I could create a release candidate with intent to never actually promote it to GA, and hence use it in my own testing, hand it directly to a user as a hotfix release, etc.

Finally. to keep our download counts as accurate as possible, it'd be handy to have a location besides the GitHub Release page from which to download artifacts.

### Testing

Because I didn't want to pollute our GA Brim "Releases" page with test artifacts, the Workflow scripts in this PR were tested in a separate repo https://github.com/brimsec/brim-release-testing that contains the same code as the official Brim repo. The following example steps include pointers to the results from successful test runs you can see in that repo.

1. Create/push a new branch named `rc-v*` where the `*` is the intended numeric portion of what would be a final GA version string. In this example I used branch name `rc-v1.2.6`. This triggers the Actions Workflow to create the release candidate artifacts.

2. If the Actions Workflow is successful, the artifacts will appear in a folder in the Google Cloud Storage bucket. Example:

```
$ gsutil ls -lR gs://brimsec-releases
gs://brimsec-releases/brim/:
         0  2020-09-12T22:17:43Z  gs://brimsec-releases/brim/

gs://brimsec-releases/brim/linux/:
         0  2020-09-12T22:17:51Z  gs://brimsec-releases/brim/linux/

gs://brimsec-releases/brim/linux/rc-v1.2.6/:
 155504756  2020-09-15T21:43:57Z  gs://brimsec-releases/brim/linux/rc-v1.2.6/brim_amd64.deb
 173971564  2020-09-15T21:43:55Z  gs://brimsec-releases/brim/linux/rc-v1.2.6/brim_x86_64.rpm

gs://brimsec-releases/brim/macos/:
         0  2020-09-15T19:46:22Z  gs://brimsec-releases/brim/macos/

gs://brimsec-releases/brim/macos/rc-v1.2.6/:
 255049816  2020-09-15T21:54:56Z  gs://brimsec-releases/brim/macos/rc-v1.2.6/Brim-darwin-autoupdater.zip
 248791551  2020-09-15T21:55:00Z  gs://brimsec-releases/brim/macos/rc-v1.2.6/Brim.dmg

gs://brimsec-releases/brim/windows/:
         0  2020-09-13T01:51:42Z  gs://brimsec-releases/brim/windows/

gs://brimsec-releases/brim/windows/rc-v1.2.6/:
 205470100  2020-09-15T21:48:59Z  gs://brimsec-releases/brim/windows/rc-v1.2.6/Brim-0.17.0-full.nupkg
 203054680  2020-09-15T21:49:01Z  gs://brimsec-releases/brim/windows/rc-v1.2.6/Brim-Setup.exe
        76  2020-09-15T21:49:01Z  gs://brimsec-releases/brim/windows/rc-v1.2.6/RELEASES
TOTAL: 11 objects, 1241842543 bytes (1.16 GiB)
```

3. If at this point any additional changes are pushed to the release branch (e.g. maybe `master` has already gotten further ahead and we'd like to cherry pick some additional fix) the Actions Workflow will run again and push updated artifacts to the same folders in the bucket. I've done that in our branch in the example here. Notice how the timestamps and byte counts have changed to reflect the updates.

```
$ gsutil ls -lR gs://brimsec-releases
gs://brimsec-releases/brim/:
         0  2020-09-12T22:17:43Z  gs://brimsec-releases/brim/

gs://brimsec-releases/brim/linux/:
         0  2020-09-12T22:17:51Z  gs://brimsec-releases/brim/linux/

gs://brimsec-releases/brim/linux/rc-v1.2.6/:
 155502008  2020-09-15T22:04:45Z  gs://brimsec-releases/brim/linux/rc-v1.2.6/brim_amd64.deb
 173971524  2020-09-15T22:04:43Z  gs://brimsec-releases/brim/linux/rc-v1.2.6/brim_x86_64.rpm

gs://brimsec-releases/brim/macos/:
         0  2020-09-15T19:46:22Z  gs://brimsec-releases/brim/macos/

gs://brimsec-releases/brim/macos/rc-v1.2.6/:
 255049834  2020-09-15T22:11:30Z  gs://brimsec-releases/brim/macos/rc-v1.2.6/Brim-darwin-autoupdater.zip
 248788909  2020-09-15T22:11:34Z  gs://brimsec-releases/brim/macos/rc-v1.2.6/Brim.dmg

gs://brimsec-releases/brim/windows/:
         0  2020-09-13T01:51:42Z  gs://brimsec-releases/brim/windows/

gs://brimsec-releases/brim/windows/rc-v1.2.6/:
 205470102  2020-09-15T22:08:03Z  gs://brimsec-releases/brim/windows/rc-v1.2.6/Brim-0.17.0-full.nupkg
 203049560  2020-09-15T22:08:06Z  gs://brimsec-releases/brim/windows/rc-v1.2.6/Brim-Setup.exe
        76  2020-09-15T22:08:06Z  gs://brimsec-releases/brim/windows/rc-v1.2.6/RELEASES
TOTAL: 11 objects, 1241832013 bytes (1.16 GiB)
```

4. After downloading the artifacts from the bucket and confirming they pass smoke tests, create a release tagged with name `v*` much as we'd done in the past, e.g. `v1.2.6` in this example. When picking settings on the page, I point to the same branch name to make sure the tag is attached to the correct commit. This triggers the Actions Workflow to download the artifacts from the bucket and upload them to the GitHub Release page.

![image](https://user-images.githubusercontent.com/5934157/93270481-1b010d00-f766-11ea-9e63-5267ecb64b48.png)

5. After a successful Actions run, the artifacts appear. Notice we see the same 9 assets we're accustomed to seeing in the GA Brim releases such as for https://github.com/brimsec/brim/releases/tag/v0.17.0.

![image](https://user-images.githubusercontent.com/5934157/93271012-20128c00-f767-11ea-902a-55a678a3c974.png)

At this point the release candidate branch can be deleted.

I've successfully installed the signed Windows artifact and notarized macOS artifacts that came out of this test process.

The secrets needed for building were previously only in the Brim repo. Since I needed those same secrets for the test repo, another part of this change is that we've started using org-level secrets instead of the repo-level ones. If this PR is approved, at the same time I merge it, I'll make the org-level secrets needed for building available to the Brim repo and delete the repo-level secrets that have the same names. This would allow us to easily re-use any of these secrets in other repos that might need them in the future.