### PR TITLE
Mention nanosecond timestamp issue in Troubleshooting wiki article

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -150,6 +150,7 @@ differences:
 |[zeek/847](https://github.com/zeek/zeek/issues/847)|Zeek creates many conn records for DNS despite `udp_inactivity_timeout=0`|
 |[zeek/862](https://github.com/zeek/zeek/issues/862)|Retransmissions of unsuccessful close attempt keep getting flagged as new connections|
 |[zeek/864](https://github.com/zeek/zeek/issues/864)|Multi-section pcapng with overlapping timestamps creates excess `conn` events|
+|[zeek/1163](https://github.com/zeek/zeek/issues/1163)|Full precision of nanosecond timestamps is not preserved|
 
 If you find yourself running into these issues or others of a similar nature,
 please reach out to us on our [public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg)


### PR DESCRIPTION
With the fixes in #1069 and https://github.com/brimsec/zq/pull/1243, we're now working around the fact that Zeek doesn't preserve the full precision of nanosecond timestamps when they appear in pcaps. Should users notice this when comparing their timestamps in Brim with the extracted flows in Wireshark, here I'm adding a link to the open Zeek issue so Brim users know that's the root cause of the truncation.