### PR TITLE
Better Slack URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Thank you for contributing to Brim!
 
-Per [common practice](https://www.thinkful.com/learn/github-pull-request-tutorial/Feel-Free-to-Ask#Feel-Free-to-Ask), please [open an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue) before sending a pull request. If you think your ideas might benefit from some refinement via Q&A, come talk to us on [Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg) as well.
+Per [common practice](https://www.thinkful.com/learn/github-pull-request-tutorial/Feel-Free-to-Ask#Feel-Free-to-Ask), please [open an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue) before sending a pull request. If you think your ideas might benefit from some refinement via Q&A, come talk to us on [Slack](https://www.brimsecurity.com/join-slack/) as well.
 
 Brim is early in its life cycle and will be expanding quickly. Please star and/or watch the repo so you can follow and track our progress.
 

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ development information like building and testing Brim.
 
 ## Join the Community
 
-Join our [Public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg) workspace for announcements, Q&A, and to trade tips!
+Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for announcements, Q&A, and to trade tips!

--- a/docs/Code-Base-Walkthrough.md
+++ b/docs/Code-Base-Walkthrough.md
@@ -202,4 +202,4 @@ See the [[Adding Migrations]] page for a more detailed guide.
 
 ## Questions?
 
-We appreciate your interest in improving Brim. If you've got questions that aren't answered here or in the [video](#video), please join our [public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg) workspace and ask!
+We appreciate your interest in improving Brim. If you've got questions that aren't answered here or in the [video](#video), please join our [public Slack](https://www.brimsecurity.com/join-slack/) workspace and ask!

--- a/docs/Geolocation.md
+++ b/docs/Geolocation.md
@@ -39,4 +39,4 @@ The following issues are currently being held open to gather interest:
 If you're interested in additional geolocation features, please follow the links to review these issues and click :+1: below the
 description on any of these features you'd like to see added. If you have additional feedback or ideas on this functionality,
 feel free to add a comment to the issues, or join our
-[public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg) and talk to us. Thanks!
+[public Slack](https://www.brimsecurity.com/join-slack/) and talk to us. Thanks!

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -152,7 +152,7 @@ differences:
 |[zeek/864](https://github.com/zeek/zeek/issues/864)|Multi-section pcapng with overlapping timestamps creates excess `conn` events|
 
 If you find yourself running into these issues or others of a similar nature,
-please reach out to us on our [public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg)
+please reach out to us on our [public Slack](https://www.brimsecurity.com/join-slack/)
 or [open an issue](#opening-an-issue) and we'll try to help.
 
 ## Brim seems unable to restart normally, such as after a bad crash
@@ -203,7 +203,7 @@ For all information described in this section, we understand that some of it
 may be of a sensitive nature such that you don't feel you can attach it
 directly to a public GitHub Issue. If you can crop, blur, or otherwise modify
 the information before attaching, please do. If you feel you could share such
-information only privately, please notify us on [public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg)
+information only privately, please notify us on [public Slack](https://www.brimsecurity.com/join-slack/)
 and we can arrange to receive it from you in a private 1-on-1 chat.
 
 ## Screenshots/Videos
@@ -278,7 +278,7 @@ you can help us out by doing the following:
 * Review the [common problems](#common-problems) above see if you're hitting one of those.
 * Browse the existing [open issues](https://github.com/brimsec/brim/issues?q=is%3Aissue+is%3Aopen). If you confirm you're hitting one of those, please add a comment to it rather than opening a new issue.
 * [Gather info](#gathering-info) that that may help in reproducing the issue and testing a fix, and attach it to your issue.
-* Feel free to chat with the team on the [public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg) before/after opening an issue.
+* Feel free to chat with the team on the [public Slack](https://www.brimsecurity.com/join-slack/) before/after opening an issue.
 * When you open a new issue, its initial text will include a template with standard info that will almost always be needed. Please include detail for all areas of the template.
 
 Thanks for helping us support the Brim community!

--- a/docs/Zeek-Customization.md
+++ b/docs/Zeek-Customization.md
@@ -174,6 +174,6 @@ a pcap to confirm it works in the app.
 If you're using a custom Zeek setup with Brim, we'd like to hear from you! Whether you've found an interesting 
 Zeek feature that could be useful to other Brim users, or are generating logs that match your existing Zeek setup, 
 or (especially) if you hit challenges and need help, please join our
-[public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg)
+[public Slack](https://www.brimsecurity.com/join-slack/)
 and tell us about it, or
 [open an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue). Thanks!

--- a/docs/Zeek-JSON-Import.md
+++ b/docs/Zeek-JSON-Import.md
@@ -22,7 +22,7 @@ ideas for ways we might improve it, but we'll have a better sense of priority
 and how to go about it if we've heard from those who have tried it. Whether
 you've used this feature and it "just worked" or if you hit challenges and need
 help, please join our
-[public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg)
+[public Slack](https://www.brimsecurity.com/join-slack/)
 and tell us about it, or
 [open an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue). Thanks!
 

--- a/docs/_Footer.md
+++ b/docs/_Footer.md
@@ -1,1 +1,1 @@
-Join our [Public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg) workspace for announcements, Q&A, and to trade tips!
+Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for announcements, Q&A, and to trade tips!

--- a/src/js/electron/menu/appMenu.ts
+++ b/src/js/electron/menu/appMenu.ts
@@ -208,7 +208,7 @@ export default function appMenu(
         label: "Slack Support Channel",
         click() {
           shell.openExternal(
-            "https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg"
+            "https://www.brimsecurity.com/join-slack/"
           )
         }
       },

--- a/src/js/electron/menu/appMenu.ts
+++ b/src/js/electron/menu/appMenu.ts
@@ -207,9 +207,7 @@ export default function appMenu(
       {
         label: "Slack Support Channel",
         click() {
-          shell.openExternal(
-            "https://www.brimsecurity.com/join-slack/"
-          )
+          shell.openExternal("https://www.brimsecurity.com/join-slack/")
         }
       },
       {


### PR DESCRIPTION
We recently added a redirect layer on the https://www.brimsecurity.com/ web site such that the `#` icon for joining Slack is attached to a permanent URL https://www.brimsecurity.com/join-slack/ which, in turn, redirects to the current "invite yourself" URL, which might change after 2000 users invite themselves or Slack expires it due to some glitch (it's happened before). Here I change all the Slack URL pointers such that if the "invite yourself" URL changes again in the future, we only have to update it in that one place on the web site.