### PR TITLE
refresh all connection spaces

### DIFF
--- a/src/js/flows/refreshConnectionsSpaceNames.ts
+++ b/src/js/flows/refreshConnectionsSpaceNames.ts
@@ -1,0 +1,18 @@
+import {Thunk} from "../state/types"
+import Clusters from "../state/Clusters"
+import Spaces from "../state/Spaces"
+
+export default function refreshConnectionsSpaceNames(): Thunk<Promise<void[]>> {
+  return (dispatch, getState, {globalDispatch, createZealot}) => {
+    const clusters = Clusters.all(getState())
+    return Promise.all(
+      clusters.map((c) => {
+        const zealot = createZealot(`${c.host}:${c.port}`)
+        return zealot.spaces.list().then((spaces) => {
+          const addSpaces = spaces || []
+          if (c.id) globalDispatch(Spaces.setSpaces(c.id, addSpaces))
+        })
+      })
+    )
+  }
+}

--- a/src/js/flows/refreshSpacesForAllConnections.ts
+++ b/src/js/flows/refreshSpacesForAllConnections.ts
@@ -2,7 +2,9 @@ import {Thunk} from "../state/types"
 import Clusters from "../state/Clusters"
 import Spaces from "../state/Spaces"
 
-export default function refreshConnectionsSpaceNames(): Thunk<Promise<void[]>> {
+export default function refreshSpacesForAllConnections(): Thunk<
+  Promise<void[]>
+> {
   return (dispatch, getState, {globalDispatch, createZealot}) => {
     const clusters = Clusters.all(getState())
     return Promise.all(

--- a/src/js/initializers/initIpcListeners.ts
+++ b/src/js/initializers/initIpcListeners.ts
@@ -44,10 +44,6 @@ export default (store: Store) => {
     ipcRenderer.send(channel, getPersistable(store.getState()))
   })
 
-  ipcRenderer.on("getState", (event, channel) => {
-    ipcRenderer.send(channel, getPersistable(store.getState()))
-  })
-
   ipcRenderer.on("showPreferences", () => {
     store.dispatch(Modal.show("settings"))
   })

--- a/src/js/initializers/initZqdConnection.ts
+++ b/src/js/initializers/initZqdConnection.ts
@@ -22,7 +22,9 @@ export default async function(store: Store) {
       username: "",
       password: ""
     }
-    await globalDispatch(Clusters.add(cluster))
+
+    store.dispatch(Clusters.add(cluster))
+    globalDispatch(Clusters.add(cluster))
     store.dispatch(Current.setConnectionId(cluster.id))
   }
 

--- a/src/js/initializers/initZqdConnection.ts
+++ b/src/js/initializers/initZqdConnection.ts
@@ -3,7 +3,7 @@ import {initSpace} from "../flows/initSpace"
 import Clusters from "../state/Clusters"
 import Current from "../state/Current"
 import getUrlSearchParams from "../lib/getUrlSearchParams"
-import refreshConnectionsSpaceNames from "../flows/refreshConnectionsSpaceNames"
+import refreshSpacesForAllConnections from "../flows/refreshSpacesForAllConnections"
 import {globalDispatch} from "../state/GlobalContext"
 
 export default async function(store: Store) {
@@ -28,7 +28,7 @@ export default async function(store: Store) {
     store.dispatch(Current.setConnectionId(cluster.id))
   }
 
-  await store.dispatch(refreshConnectionsSpaceNames())
+  await store.dispatch(refreshSpacesForAllConnections())
 
   const lastId = Current.getSpaceId(store.getState())
   const spaceId = space || lastId

--- a/src/js/initializers/initZqdConnection.ts
+++ b/src/js/initializers/initZqdConnection.ts
@@ -3,26 +3,30 @@ import {initSpace} from "../flows/initSpace"
 import Clusters from "../state/Clusters"
 import Current from "../state/Current"
 import getUrlSearchParams from "../lib/getUrlSearchParams"
-import refreshSpaceNames from "../flows/refreshSpaceNames"
+import refreshConnectionsSpaceNames from "../flows/refreshConnectionsSpaceNames"
+import {globalDispatch} from "../state/GlobalContext"
 
 export default async function(store: Store) {
   const {space, host, port, id} = getUrlSearchParams()
   global.windowId = id
 
-  const clusterHost = host || "localhost"
-  const clusterPort = port || "9867"
-  const clusterId = `${clusterHost}:${clusterPort}`
-  const cluster = {
-    id: clusterId,
-    host: clusterHost,
-    port: clusterPort,
-    username: "",
-    password: ""
+  const lastConn = Current.getConnection(store.getState())
+  if ((port && host) || !lastConn) {
+    const clusterHost = host || "localhost"
+    const clusterPort = port || "9867"
+    const clusterId = `${clusterHost}:${clusterPort}`
+    const cluster = {
+      id: clusterId,
+      host: clusterHost,
+      port: clusterPort,
+      username: "",
+      password: ""
+    }
+    await globalDispatch(Clusters.add(cluster))
+    store.dispatch(Current.setConnectionId(cluster.id))
   }
 
-  store.dispatch(Clusters.add(cluster))
-  store.dispatch(Current.setConnectionId(cluster.id))
-  await store.dispatch(refreshSpaceNames())
+  await store.dispatch(refreshConnectionsSpaceNames())
 
   const lastId = Current.getSpaceId(store.getState())
   const spaceId = space || lastId

--- a/src/js/initializers/initZqdConnection.ts
+++ b/src/js/initializers/initZqdConnection.ts
@@ -4,34 +4,35 @@ import Clusters from "../state/Clusters"
 import Current from "../state/Current"
 import getUrlSearchParams from "../lib/getUrlSearchParams"
 import refreshSpacesForAllConnections from "../flows/refreshSpacesForAllConnections"
-import {globalDispatch} from "../state/GlobalContext"
+
+const setupConnection = (host, port) => (dispatch, _, {globalDispatch}) => {
+  const cluster = {
+    host,
+    port,
+    id: [host, port].join(":"),
+    username: "",
+    password: ""
+  }
+  dispatch(Clusters.add(cluster))
+  globalDispatch(Clusters.add(cluster))
+  dispatch(Current.setConnectionId(cluster.id))
+}
 
 export default async function(store: Store) {
   const {space, host, port, id} = getUrlSearchParams()
   global.windowId = id
 
-  const lastConn = Current.getConnection(store.getState())
-  if ((port && host) || !lastConn) {
-    const clusterHost = host || "localhost"
-    const clusterPort = port || "9867"
-    const clusterId = `${clusterHost}:${clusterPort}`
-    const cluster = {
-      id: clusterId,
-      host: clusterHost,
-      port: clusterPort,
-      username: "",
-      password: ""
-    }
+  const existingConnection = Current.getConnection(store.getState())
 
-    store.dispatch(Clusters.add(cluster))
-    globalDispatch(Clusters.add(cluster))
-    store.dispatch(Current.setConnectionId(cluster.id))
+  if (host && port) {
+    store.dispatch(setupConnection(host, port))
+  } else if (!existingConnection) {
+    store.dispatch(setupConnection("localhost", "9867"))
   }
 
   await store.dispatch(refreshSpacesForAllConnections())
 
-  const lastId = Current.getSpaceId(store.getState())
-  const spaceId = space || lastId
+  const spaceId = space || Current.getSpaceId(store.getState())
 
   if (spaceId) store.dispatch(initSpace(spaceId))
 }

--- a/src/js/state/Clusters/reducer.ts
+++ b/src/js/state/Clusters/reducer.ts
@@ -1,9 +1,11 @@
 import {ClusterAction, ClustersState} from "./types"
 import {deleteKey} from "../../lib/obj"
 
-const init: ClustersState = {}
+const init = (): ClustersState => {
+  return {}
+}
 
-export default function(state: ClustersState = init, action: ClusterAction) {
+export default function(state: ClustersState = init(), action: ClusterAction) {
   switch (action.type) {
     case "CLUSTER_ADD":
       return {


### PR DESCRIPTION
fixes #1079 

When loading up the app from a previously saved state, we have still been assuming that the connection will either default to localhost:9867, or that the app has just created a new connection, but it was not properly handling the case where it had already created a new connection from a previous session. This PR aims to fix that by checking for and using any previously set connectionIds and will also populate spaces for all known connections.