### PR TITLE
Include pcap, zapi, and zar in zdeps/

### DIFF
--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -14,16 +14,25 @@ const platformDefs = {
   darwin: {
     zqdBin: "zqd",
     zqBin: "zq",
+    pcapBin: "pcap",
+    zapiBin: "zapi",
+    zarBin: "zar",
     osarch: "darwin-amd64"
   },
   linux: {
     zqdBin: "zqd",
     zqBin: "zq",
+    pcapBin: "pcap",
+    zapiBin: "zapi",
+    zarBin: "zar",
     osarch: "linux-amd64"
   },
   win32: {
     zqdBin: "zqd.exe",
     zqBin: "zq.exe",
+    pcapBin: "pcap.exe",
+    zapiBin: "zapi.exe",
+    zarBin: "zar.exe",
     osarch: "windows-amd64"
   }
 }
@@ -86,7 +95,7 @@ async function zqArtifactsDownload(version, destPath) {
 
     fs.mkdirpSync(destPath)
 
-    for (let f of [plat.zqdBin, plat.zqBin]) {
+    for (let f of [plat.zqdBin, plat.zqBin, plat.pcapBin, plat.zapiBin, plat.zarBin]) {
       fs.moveSync(
         path.join(tmpdir.name, paths.internalTopDir, f),
         path.join(destPath, f),
@@ -134,7 +143,7 @@ async function zqDevBuild(destPath) {
 
   const zqPackageDir = path.join(__dirname, "..", "..", "node_modules", "zq")
 
-  for (let f of [plat.zqdBin, plat.zqBin]) {
+  for (let f of [plat.zqdBin, plat.zqBin, plat.pcapBin, plat.zapiBin, plat.zarBin]) {
     fs.copyFileSync(path.join(zqPackageDir, "dist", f), path.join(destPath, f))
   }
 }

--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -95,7 +95,13 @@ async function zqArtifactsDownload(version, destPath) {
 
     fs.mkdirpSync(destPath)
 
-    for (let f of [plat.zqdBin, plat.zqBin, plat.pcapBin, plat.zapiBin, plat.zarBin]) {
+    for (let f of [
+      plat.zqdBin,
+      plat.zqBin,
+      plat.pcapBin,
+      plat.zapiBin,
+      plat.zarBin
+    ]) {
       fs.moveSync(
         path.join(tmpdir.name, paths.internalTopDir, f),
         path.join(destPath, f),
@@ -143,7 +149,13 @@ async function zqDevBuild(destPath) {
 
   const zqPackageDir = path.join(__dirname, "..", "..", "node_modules", "zq")
 
-  for (let f of [plat.zqdBin, plat.zqBin, plat.pcapBin, plat.zapiBin, plat.zarBin]) {
+  for (let f of [
+    plat.zqdBin,
+    plat.zqBin,
+    plat.pcapBin,
+    plat.zapiBin,
+    plat.zarBin
+  ]) {
     fs.copyFileSync(path.join(zqPackageDir, "dist", f), path.join(destPath, f))
   }
 }


### PR DESCRIPTION
This does increase the size of the Brim release artifact by 7-11%, but the times users have had to download `zq` separately to get these tools for debug/functionality it creates hassle as well as possible hazard, should they pick an incompatible version. Therefore I think it's worth the tradeoff.

Here's validation that the `zdeps/` gets populated in my local Dev environment after doing `npm install` with this branch:

```
$ ls -l brim/zdeps
total 225808
-rwxr-xr-x  1 phil  staff  18349360 Sep 27 11:11 pcap
-rwxr-xr-x  1 phil  staff  23451128 Sep 27 11:11 zapi
-rwxr-xr-x  1 phil  staff  21796624 Sep 27 11:11 zar
drwxr-xr-x  5 phil  staff       160 Sep 27 11:11 zeek
-rwxr-xr-x  1 phil  staff  21306408 Sep 27 11:11 zq
-rwxr-xr-x  1 phil  staff  30701240 Sep 27 11:11 zqd
```

Here's similar validation on each platform using an RC build.

Mac:

```
$ ls -l /Applications/Brim.app/Contents/Resources/app/zdeps
total 228864
-rwxr-xr-x  1 phil  admin  18601312 Sep 27 11:18 pcap
-rwxr-xr-x  1 phil  admin  23767872 Sep 27 11:18 zapi
-rwxr-xr-x  1 phil  admin  22092352 Sep 27 11:18 zar
drwxr-xr-x  5 phil  admin       160 Sep 27 11:18 zeek
-rwxr-xr-x  1 phil  admin  21595904 Sep 27 11:18 zq
-rwxr-xr-x  1 phil  admin  31110032 Sep 27 11:18 zqd
```

Ubuntu:

```
$ ls -l /usr/lib/brim/resources/app/zdeps
total 85860
-rwxr-xr-x 1 root root 14053376 Sep 27 11:16 pcap
-rwxr-xr-x 1 root root 17862656 Sep 27 11:16 zapi
-rwxr-xr-x 1 root root 16617472 Sep 27 11:16 zar
drwxr-xr-x 4 root root     4096 Sep 27 11:41 zeek
-rwxr-xr-x 1 root root 16257024 Sep 27 11:16 zq
-rwxr-xr-x 1 root root 23126016 Sep 27 11:16 zqd
```

Fedora (Red Hat):

```
$ ls -l /usr/lib/brim/resources/app/zdeps
total 85868
-rwxr-xr-x. 1 root root 14052376 Sep 27 11:20 pcap
-rwxr-xr-x. 1 root root 17861048 Sep 27 11:20 zapi
-rwxr-xr-x. 1 root root 16618776 Sep 27 11:20 zar
drwxr-xr-x. 4 root root     4096 Sep 27 11:47 zeek
-rwxr-xr-x. 1 root root 16258904 Sep 27 11:20 zq
-rwxr-xr-x. 1 root root 23124760 Sep 27 11:20 zqd
```

Windows:

```
C:\>dir "%LOCALAPPDATA%\Brim\app-0.18.0\resources\app\zdeps"
 Volume in drive C has no label.
 Volume Serial Number is 0C07-A419
 Directory of C:\Users\Phil\AppData\Local\Brim\app-0.18.0\resources\app\zdeps
09/27/2020  11:50 AM    <DIR>          .
09/27/2020  11:50 AM    <DIR>          ..
09/27/2020  11:50 AM        14,086,232 pcap.exe
09/27/2020  11:50 AM        17,841,752 zapi.exe
09/27/2020  11:50 AM        16,670,808 zar.exe
09/27/2020  11:50 AM    <DIR>          zeek
09/27/2020  11:50 AM        16,310,872 zq.exe
09/27/2020  11:50 AM        23,117,400 zqd.exe
               5 File(s)     88,027,064 bytes
               3 Dir(s)  17,168,822,272 bytes free
```

Closes #1038.