### PR TITLE
Handle PcapPostWarning in Brim

### DIFF
--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -129,4 +129,19 @@ describe("error case", () => {
     expect(Spaces.getSpaces(cluster)(state)).toEqual([])
     expect(Current.getSpaceId(state)).toEqual(null)
   })
+
+  test("pcap post warning", async () => {
+    zealot.stubStream("pcaps.post", [
+      {type: "PcapPostWarning", warning: "Some pcap warning"}
+    ])
+
+    await store.dispatch(ingestFiles([itestFile("sample.pcap")]))
+
+    const state = store.getState()
+    const connId = Current.getConnectionId(state)
+    const spaceId = Current.getSpaceId(state)
+    expect(Spaces.getIngestWarnings(connId, spaceId)(state)).toEqual([
+      "Some pcap warning"
+    ])
+  })
 })

--- a/src/js/flows/ingestFiles.ts
+++ b/src/js/flows/ingestFiles.ts
@@ -170,6 +170,7 @@ const trackProgress = (client, gDispatch, clusterId) => {
             updateSpaceDetails()
             break
           case "LogPostWarning":
+          case "PcapPostWarning":
             gDispatch(space.appendIngestWarning(status.warning))
             break
           case "TaskEnd":


### PR DESCRIPTION
Fixes #1028 

Based off #1108 (that must go in first, but you can look at the last commit here to see the changes)

The app will now respond to PcapPostWarning the same way that it responds to LogPostWarning. The warning will appear in the bottom right of the page after ingest has finished.

A unit test has been added to avoid regressions.