### PR TITLE
Point to Zeek v3.2.1-brim1

### DIFF
--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -164,7 +164,7 @@ async function main() {
   try {
     // We encode the zeek version here for now to avoid the unncessary
     // git clone if it were in package.json.
-    const zeekVersion = "v3.2.0-dev-brim10"
+    const zeekVersion = "v3.2.1-brim1"
     await zeekDownload(zeekVersion, zdepsPath)
 
     // The zq dependency should be a git tag or commit. Any tag that


### PR DESCRIPTION
To take advantage of Brim Zeek artifacts now being based on GA Zeek v3.2.1, and also to take advantage of updated [geoip-conn](https://github.com/brimsec/geoip-conn) that includes latest GeoLite2 database.

I started this out as a draft PR to make sure that the integration tests pass, and indeed they do. So if we trust our automation, I guess we're ready to merge and start getting some soak time with this in the days up to building the next GA release.