### PR TITLE
fixes for brim integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,16 +164,18 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
       - run: npm install --no-audit
       - run: npm run build
-      - name: Build and Install MacOS DMG
-        if: runner.os == 'macOS'
-        run: |
-          set -x
-          source scripts/lib/common.bash
-          node scripts/release --darwin
-          hdiutil attach dist/installers/Brim.dmg
-          cp -R /Volumes/Brim/Brim.app /Applications
-          retry_until_success 60 1 umount_macos_ci_dimg /Volumes/Brim
-        shell: bash
+# Disabling using built & installed app for now;
+# see brim#1145
+#      - name: Build and Install MacOS DMG
+#        if: runner.os == 'macOS'
+#        run: |
+#          set -x
+#          source scripts/lib/common.bash
+#          node scripts/release --darwin
+#          hdiutil attach dist/installers/Brim.dmg
+#          cp -R /Volumes/Brim/Brim.app /Applications
+#          retry_until_success 60 1 umount_macos_ci_dimg /Volumes/Brim
+#        shell: bash
       - name: Download Linux packages
         if: runner.os == 'Linux'
         uses: actions/download-artifact@v1

--- a/docs/Code-Base-Walkthrough.md
+++ b/docs/Code-Base-Walkthrough.md
@@ -36,7 +36,7 @@ All React components used within the app.
 
 **/electron**
 
-Code intended to run in [Electron's main process](https://www.electronjs.org/docs/tutorial/application-architecture). Also contains the app's entry point, `src/js/electron/main.js`.
+Code intended to run in [Electron's main process](https://www.electronjs.org/docs/tutorial/quick-start#main-and-renderer-processes). Also contains the app's entry point, `src/js/electron/main.js`.
 
 **/errors**
 
@@ -92,7 +92,7 @@ Code that runs the backend zqd process on localhost.
 
 ## Libraries
 
-We are an Electron app, so [electron](https://www.electronjs.org/docs) is the core library we use. For those unfamiliar, it's helpful to understand the [main vs renderer processes](https://www.electronjs.org/docs/tutorial/application-architecture) in an Electron app.
+We are an Electron app, so [electron](https://www.electronjs.org/docs) is the core library we use. For those unfamiliar, it's helpful to understand the [main vs renderer processes](https://www.electronjs.org/docs/tutorial/quick-start#main-and-renderer-processes) in an Electron app.
 
 Additionally, we rely heavily on the node modules listed here:
 

--- a/zealot/test_api/subspace_test.ts
+++ b/zealot/test_api/subspace_test.ts
@@ -19,6 +19,6 @@ testApi("creating a subspace", async (zealot) => {
         spaceId: parent.id
       }),
     Error,
-    "log filter id1 not a data filename"
+    "log filter id1 not a chunk file name"
   )
 })


### PR DESCRIPTION
This Brim tests looks for an error message that changed in brimsec/zq#1461. 

While we should update this test to work differently, this change should allow tests to pass against the zq master after #1137 lands. I'll update this PR then to point zq at zq master.




