### PR TITLE
Flatten columns when comparing to table columns

### DIFF
--- a/src/js/electron/menu/searchFieldContextMenu.ts
+++ b/src/js/electron/menu/searchFieldContextMenu.ts
@@ -21,9 +21,9 @@ export default function searchFieldContextMenu(
     const isConn = log.try("_path")?.toString() === "conn"
     const isGroupBy = hasGroupByProc(program)
     const isIp = ["addr", "set[addr]"].includes(field.data.getType())
-
     const hasCol = columns.includes(field.name)
-    const sameCols = isEqual(log.type.map((d) => d.name).sort(), columns.sort())
+    const flatColNames = log.flatten().getColumnNames()
+    const sameCols = isEqual(flatColNames.sort(), columns.sort())
     const hasPackets = space && space.pcap_support
     const virusTotal = [
       "hassh",

--- a/src/js/flows/rightclick/cellMenu.test.ts
+++ b/src/js/flows/rightclick/cellMenu.test.ts
@@ -3,6 +3,7 @@ import {MenuItemConstructorOptions} from "electron"
 import {conn, dns} from "../../test/mockLogs"
 import fixtures from "../../test/fixtures"
 import menu from "../../electron/menu"
+import {zng} from "zealot"
 
 function menuText(menu: MenuItemConstructorOptions[]) {
   return menu
@@ -14,15 +15,18 @@ const space = fixtures("space1")
 
 describe("Log Right Click", () => {
   const program = "*"
+  const columnNames = conn()
+    .flatten()
+    .getColumnNames()
 
   test("conn log with pcap support", () => {
     const log = conn()
     const field = log.getField("id.orig_h")
-    const ctxMenu = menu.searchFieldContextMenu(
-      program,
-      log.getColumnNames(),
-      space
-    )(field, log, false)
+    const ctxMenu = menu.searchFieldContextMenu(program, columnNames, space)(
+      field,
+      log,
+      false
+    )
 
     expect(menuText(ctxMenu)).toMatch(/pcaps/i)
   })
@@ -32,11 +36,11 @@ describe("Log Right Click", () => {
 
     const log = conn()
     const field = log.getField("id.orig_h")
-    const ctxMenu = menu.searchFieldContextMenu(
-      program,
-      log.getColumnNames(),
-      space
-    )(field, log, false)
+    const ctxMenu = menu.searchFieldContextMenu(program, columnNames, space)(
+      field,
+      log,
+      false
+    )
 
     expect(menuText(ctxMenu)).not.toMatch(/pcaps/i)
   })
@@ -44,11 +48,11 @@ describe("Log Right Click", () => {
   test("dns log", () => {
     const log = dns()
     const field = log.getField("query")
-    const ctxMenu = menu.searchFieldContextMenu(
-      program,
-      log.getColumnNames(),
-      space
-    )(field, log, false)
+    const ctxMenu = menu.searchFieldContextMenu(program, columnNames, space)(
+      field,
+      log,
+      false
+    )
 
     expect(menuText(ctxMenu)).toMatch(/virustotal/i)
     expect(menuText(ctxMenu)).toMatch(/count by/i)
@@ -57,11 +61,11 @@ describe("Log Right Click", () => {
   test("time field for conn log", () => {
     const log = conn()
     const field = log.getField("ts")
-    const ctxMenu = menu.searchFieldContextMenu(
-      program,
-      log.getColumnNames(),
-      space
-    )(field, log, false)
+    const ctxMenu = menu.searchFieldContextMenu(program, columnNames, space)(
+      field,
+      log,
+      false
+    )
 
     expect(menuText(ctxMenu)).toMatch(/"start" time/i)
     expect(menuText(ctxMenu)).toMatch(/"end" time/i)
@@ -70,40 +74,41 @@ describe("Log Right Click", () => {
 
 describe("Analysis Right Click", () => {
   const program = "* | count() by id.orig_h"
+  const columnNames = ["count", "id.orig_h"]
 
-  test("address field", () => {
-    const log = conn()
+  test("nested field", () => {
+    const log = new zng.Record(
+      [
+        {name: "count", type: "count"},
+        {name: "id", type: "record", of: [{name: "orig_h", type: "addr"}]}
+      ],
+      ["300", ["192.168.0.51"]]
+    )
     const field = log.getField("id.orig_h")
-    const ctxMenu = menu.searchFieldContextMenu(
-      program,
-      log.getColumnNames(),
-      space
-    )(field, log, false)
+    const ctxMenu = menu.searchFieldContextMenu(program, columnNames, space)(
+      field,
+      log,
+      false
+    )
 
     expect(menuText(ctxMenu)).toMatch(/whois/i)
   })
 
   test("non-address field", () => {
-    const log = conn()
+    const log = new zng.Record(
+      [
+        {name: "count", type: "count"},
+        {name: "proto", type: "string"}
+      ],
+      ["100", "tcp"]
+    )
     const field = log.getField("proto")
     const ctxMenu = menu.searchFieldContextMenu(
       "* | count() by proto",
-      log.getColumnNames(),
+      ["count", "proto"],
       space
     )(field, log, false)
 
     expect(menuText(ctxMenu)).toMatch(/pivot/i)
-  })
-
-  test("group by proc", () => {
-    const log = conn()
-    const field = log.getField("proto")
-    const ctxMenu = menu.searchFieldContextMenu(
-      "* | group by proto",
-      log.getColumnNames(),
-      space
-    )(field, log, false)
-
-    expect(menuText(ctxMenu)).toMatch(/filter/i)
   })
 })


### PR DESCRIPTION
In the ZJSON changes, we retained the nested-ness of the data, but added a "flatten" method to convert all the nested field to be flat with "." separator like Zeek. We use this flatten method for the columns in the results table.

The "pivot to logs" field menu option is only enabled when the columns in the table match the columns in the right-clicked record's. This bug revealed that the records columns were still nested. The fix is to flatten first, then compare.

Bug example:
```
Table columns: ["count", "id.resp_h"]
Record columns: ["count", "id"]
```

Fixes #1141 