### PR TITLE
Move link checker to separate Actions Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,9 +203,3 @@ jobs:
         with:
           name: artifacts-${{ matrix.os }}-node-${{ matrix.node-version }}
           path: /var/tmp/brimsec/itest
-
-  markdown-link-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,14 @@
+name: Link checker
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/docs/Microsoft-Windows-beta-limitations.md
+++ b/docs/Microsoft-Windows-beta-limitations.md
@@ -19,4 +19,4 @@ recommend that you click on the "More Info" link in the SmartScreen popup and
 verify that the installer is signed by `Brim Security, Inc.`.
 
 We recommend this blog post if you'd like more info on Windows code signing:
-https://www.digicert.com/blog/ms-smartscreen-application-reputation/
+https://support.sectigo.com/Com_KnowledgeDetailPageFaq?Id=kA01N000000zFJx


### PR DESCRIPTION
The automation for the link checker has been doing its job insofar as it's noticed when external links go bad or act flaky. However, it's also been correctly noted that having it run as a Job in the same Action with the rest of `ci.yml` can be troublesome, since it makes it more difficult to debug when there's link problems at the same time as legit code breakages, or CI infra instability.

To address this, here we break out the link checker to its own separate Actions Workflow.