### PR TITLE
Fix value of max X and max Y

### DIFF
--- a/src/js/electron/window/dimens.test.ts
+++ b/src/js/electron/window/dimens.test.ts
@@ -215,3 +215,14 @@ test("when window is bigger than screen", () => {
     height: 800
   })
 })
+
+test("moving to current display", () => {
+  const _screen1 = {x: 0, y: 0, width: 1920, height: 1160}
+  const screen2 = {x: 1920, y: 77, width: 1600, height: 860}
+  const window = {width: 1250, height: 750}
+
+  const {width, height} = window
+  const {x, y} = screen2
+  const next = stack({x, y, width, height}, screen2, 25)
+  expect(next).toEqual({x: 1920 + 25, y: 77 + 25, width: 1250, height: 750})
+})

--- a/src/js/electron/window/dimens.ts
+++ b/src/js/electron/window/dimens.ts
@@ -79,10 +79,9 @@ export function stack(prev: Rectangle, screen: Rectangle, distance: number) {
 
   const width = Math.min(prev.width, screen.width)
   const height = Math.min(prev.height, screen.height)
-
   return {
-    x: boundedLine(prev.x + distance, width, screen.width),
-    y: boundedLine(prev.y + distance, height, screen.height),
+    x: boundedLine(prev.x + distance, width, screen.x + screen.width),
+    y: boundedLine(prev.y + distance, height, screen.y + screen.height),
     width,
     height
   }


### PR DESCRIPTION
In my math for position the windows on an external display, I didn't add the screen.x to the screen.width when determining what the "max" value an x can be. (Same with y).

Test added from @philrz debug logs. Thanks!

Fixes #1041 