### PR TITLE
Stack windows correctly on non-zero x,y screens

### DIFF
--- a/src/js/electron/window/dimens.test.ts
+++ b/src/js/electron/window/dimens.test.ts
@@ -226,3 +226,38 @@ test("moving to current display", () => {
   const next = stack({x, y, width, height}, screen2, 25)
   expect(next).toEqual({x: 1920 + 25, y: 77 + 25, width: 1250, height: 750})
 })
+
+test("moving to current display when display is smaller", () => {
+  const _screen1 = {x: 0, y: 0, width: 1920, height: 1160}
+  const screen2 = {x: 1920, y: 77, width: 1600, height: 860}
+  const window = {width: 1920, height: 1160}
+
+  const {width, height} = window
+  const {x, y} = screen2
+  const next = stack({x, y, width, height}, screen2, 25)
+  expect(next).toEqual({x: 1920, y: 77, width: 1600, height: 860})
+})
+
+test("stacking windows that overflow in positive space", () => {
+  const screen = {x: 1000, y: 1000, width: 1000, height: 1000}
+  const prev = {width: 800, height: 800, x: 1200, y: 1200}
+
+  expect(stack(prev, screen, 25)).toEqual({
+    x: 1025,
+    y: 1025,
+    width: 800,
+    height: 800
+  })
+})
+
+test("stacking windows that overflow in negative space", () => {
+  const screen = {x: -1000, y: -1000, width: 1000, height: 1000}
+  const prev = {width: 800, height: 800, x: -800, y: -800}
+
+  expect(stack(prev, screen, 25)).toEqual({
+    x: -975,
+    y: -975,
+    width: 800,
+    height: 800
+  })
+})

--- a/src/js/electron/window/dimens.ts
+++ b/src/js/electron/window/dimens.ts
@@ -71,17 +71,18 @@ export function center(inner: Rectangle, outer: Rectangle): Rectangle {
 }
 
 export function stack(prev: Rectangle, screen: Rectangle, distance: number) {
-  const boundedLine = (point, length, max) => {
-    if (length >= max) return 0
-    if (point + length < max) return point
-    return (point + length) % max
-  }
-
   const width = Math.min(prev.width, screen.width)
   const height = Math.min(prev.height, screen.height)
+
+  const moveCoord = (point, length, max) => {
+    if (length === max) return 0
+    if (point + distance + length < max) return point + distance
+    return (point + distance + length) % max
+  }
+
   return {
-    x: boundedLine(prev.x + distance, width, screen.x + screen.width),
-    y: boundedLine(prev.y + distance, height, screen.y + screen.height),
+    x: moveCoord(prev.x - screen.x, width, screen.width) + screen.x,
+    y: moveCoord(prev.y - screen.y, height, screen.height) + screen.y,
     width,
     height
   }


### PR DESCRIPTION
Third try fix #1041 

If a screen had an x or y that was not zero, some parts of the code broke. So we subtract the screen.x from the desired window.x, to effectively make the screen x and y both 0. Then all the math is easier. Then we add back the screen.x at the end.

Added more tests to fix the bugs in the comments of the ticket.