### PR TITLE
A modal dialog experiment

### DIFF
--- a/src/css/_tab-bar.scss
+++ b/src/css/_tab-bar.scss
@@ -12,6 +12,8 @@ $tab-bg-color: $cello;
   overflow: hidden;
   position: relative;
   border-bottom: 3px solid $snow;
+  box-shadow: 0 1px 1px var(--lead);
+  z-index: 2;
 
   .tabs-container {
     width: 100%;

--- a/src/css/_text-content.scss
+++ b/src/css/_text-content.scss
@@ -7,7 +7,6 @@
   }
 
   pre {
-    background: $coconut;
     padding: 12px 24px;
     overflow: hidden;
     font-size: 11px;

--- a/src/js/components/DebugModal.tsx
+++ b/src/js/components/DebugModal.tsx
@@ -9,8 +9,14 @@ import SearchBar from "../state/SearchBar"
 import TextInput from "./common/forms/TextInput"
 import brim from "../brim"
 import Modal from "../state/Modal"
-import {ModalDialog, Pre} from "./ModalDialog/ModalDialog"
-import {Content, Footer, Scrollable, Title} from "./ModalDialog/Content"
+import {
+  ModalDialog,
+  Pre,
+  Content,
+  Footer,
+  Scrollable,
+  Title
+} from "./ModalDialog/ModalDialog"
 import ToolbarButton from "./Toolbar/Button"
 
 export function DebugModal() {

--- a/src/js/components/DebugModal.tsx
+++ b/src/js/components/DebugModal.tsx
@@ -1,36 +1,36 @@
-import {useSelector} from "react-redux"
+import {useDispatch, useSelector} from "react-redux"
 import Prism from "prismjs"
 import React, {useState} from "react"
 
 import {reactElementProps} from "../test/integration"
 import InputField from "./common/forms/InputField"
 import InputLabel from "./common/forms/InputLabel"
-import ModalBox from "./ModalBox/ModalBox"
 import SearchBar from "../state/SearchBar"
-import TextContent from "./TextContent"
 import TextInput from "./common/forms/TextInput"
 import brim from "../brim"
+import Modal from "../state/Modal"
+import {ModalDialog, Pre} from "./ModalDialog/ModalDialog"
+import {Content, Footer, Scrollable, Title} from "./ModalDialog/Content"
+import ToolbarButton from "./Toolbar/Button"
 
 export function DebugModal() {
-  return (
-    <ModalBox
-      name="debug"
-      title="Debug Query"
-      buttons="Done"
-      className="debug-modal"
-      {...reactElementProps("debugModal")}
-    >
-      <DebugModalContents />
-    </ModalBox>
-  )
+  const dispatch = useDispatch()
+  const name = useSelector(Modal.getName)
+  const onClosed = () => dispatch(Modal.hide())
+  if (name === "debug") {
+    return <ModalDialog onClosed={onClosed}>{DebugModalContents}</ModalDialog>
+  } else {
+    return null
+  }
 }
 
-function DebugModalContents() {
+function DebugModalContents({onClose}) {
   const searchProgram = useSelector(SearchBar.getSearchProgram)
   const [program, setProgram] = useState(searchProgram)
 
   return (
-    <TextContent>
+    <Content>
+      <Title>Debug Query</Title>
       <p>
         Type a query in the text box to see the parsed abstract syntax tree
         (AST).
@@ -44,12 +44,17 @@ function DebugModalContents() {
           {...reactElementProps("debugProgram")}
         />
       </InputField>
-      <pre
-        className="language-js"
-        dangerouslySetInnerHTML={{__html: formatAst(program)}}
-        {...reactElementProps("debugAst")}
-      />
-    </TextContent>
+      <Scrollable>
+        <Pre
+          className="language-js"
+          dangerouslySetInnerHTML={{__html: formatAst(program)}}
+          {...reactElementProps("debugAst")}
+        />
+      </Scrollable>
+      <Footer>
+        <ToolbarButton text="Done" onClick={onClose} />
+      </Footer>
+    </Content>
   )
 }
 

--- a/src/js/components/ModalDialog/ModalDialog.tsx
+++ b/src/js/components/ModalDialog/ModalDialog.tsx
@@ -19,8 +19,8 @@ const Overlay = styled.div`
 `
 
 const Background = styled.div`
-  --blur-color: hsla(28, 5%, 85%, 0.5);
-  --blur-shadow: hsla(28, 5%, 20%, 0.5);
+  --blur-color: hsla(32, 5%, 85%, 0.5);
+  --blur-shadow: hsla(32, 5%, 20%, 0.5);
 
   pointer-events: all;
   display: flex;

--- a/src/js/components/ModalDialog/ModalDialog.tsx
+++ b/src/js/components/ModalDialog/ModalDialog.tsx
@@ -19,8 +19,8 @@ const Overlay = styled.div`
 `
 
 const Background = styled.div`
-  --blur-color: rgba(228, 229, 231, 0.65);
-  --blue-shadow: rgba(6, 15, 24, 0.42);
+  --blur-color: hsla(28, 5%, 85%, 0.5);
+  --blur-shadow: hsla(28, 5%, 20%, 0.5);
 
   pointer-events: all;
   display: flex;
@@ -30,8 +30,9 @@ const Background = styled.div`
   max-width: 80%;
   max-height: 80%;
   background: var(--blur-color);
-  backdrop-filter: blur(13px);
-  box-shadow: 0 2px 6px 2px var(--blue-shadow);
+  backdrop-filter: blur(24px);
+  box-shadow: 0 0 1px hsla(28, 5%, 20%, 0.75),
+    0 12px 45px hsla(28, 5%, 20%, 0.6);
   border-radius: 0 0 2px 2px;
   opacity: 1;
 

--- a/src/js/components/ModalDialog/ModalDialog.tsx
+++ b/src/js/components/ModalDialog/ModalDialog.tsx
@@ -1,0 +1,130 @@
+import React, {useEffect, useState} from "react"
+import ReactDOM from "react-dom"
+import {CSSTransition} from "react-transition-group"
+import styled from "styled-components"
+import doc from "../../lib/doc"
+
+const Overlay = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  padding-top: 42px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  z-index: 2;
+  overflow: hidden;
+`
+
+const Background = styled.div`
+  --blur-color: rgba(228, 229, 231, 0.65);
+  --blue-shadow: rgba(6, 15, 24, 0.42);
+
+  pointer-events: all;
+  display: flex;
+  overflow: hidden;
+  min-height: 100px;
+  min-width: 300px;
+  max-width: 80%;
+  max-height: 80%;
+  background: var(--blur-color);
+  backdrop-filter: blur(13px);
+  box-shadow: 0 2px 6px 2px var(--blue-shadow);
+  border-radius: 0 0 2px 2px;
+  opacity: 1;
+
+  &.appear {
+    transform: translateY(-100%);
+  }
+
+  &.appear-active {
+    transition: all 300ms ease-out;
+    transform: translateY(0%);
+  }
+
+  &.exit {
+    transform: translateY(0);
+  }
+
+  &.exit-active {
+    transition: transform 300ms;
+    transform: translateY(-100%);
+  }
+
+  &.exit-done {
+    display: none;
+  }
+`
+
+export const Content = styled.div`
+  ${(p) => p.theme.typography.labelNormal}
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding-top: 24px;
+  & > * {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+`
+
+export const Title = styled.h2`
+  ${(p) => p.theme.typography.headingPage}
+`
+
+export const Scrollable = styled.div`
+  overflow: auto;
+`
+
+export const Footer = styled.footer`
+  background: rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: row-reverse;
+  padding: 6px 12px;
+`
+
+export const Pre = styled.pre`
+  font-size: 11px;
+`
+
+interface ChildProps {
+  onClose: () => any
+}
+
+type Props = {
+  children: (props: ChildProps) => any
+  onClosed: () => any
+}
+
+export function ModalDialog(props: Props) {
+  const [show, setShow] = useState(true)
+  const onClose = () => setShow(false)
+
+  useEffect(() => {
+    if (show) {
+      document.body.style.pointerEvents = "none"
+    } else {
+      document.body.style.pointerEvents = ""
+    }
+    return () => {
+      document.body.style.pointerEvents = ""
+    }
+  }, [show])
+
+  return ReactDOM.createPortal(
+    <Overlay>
+      <CSSTransition
+        in={show}
+        appear
+        classNames=""
+        timeout={310}
+        onExited={() => setTimeout(props.onClosed, 100)}
+      >
+        <Background>{props.children({onClose})}</Background>
+      </CSSTransition>
+    </Overlay>,
+    doc.id("modal-dialog-root")
+  )
+}

--- a/src/js/components/SearchPage.tsx
+++ b/src/js/components/SearchPage.tsx
@@ -25,7 +25,6 @@ const RowLayout = styled.div`
   flex-grow: 1;
   flex-flow: row;
   position: relative;
-  box-shadow: inset 0px 1px 1px ${(props) => props.theme.colors.lead};
   padding-top: 1px;
 `
 
@@ -53,6 +52,7 @@ export default function SearchPage() {
     <SearchPageWrapper>
       <SearchPageMain>
         <ColumnLayout>
+          <div id="modal-dialog-root" />
           <TabBar />
           <RowLayout>
             <LeftPane />


### PR DESCRIPTION
Here is an experiment for a new way to structure our modals. The goal is to give them more flexibility, while making it easy to still look consistent.

As part of the experiment, I re-did the "Debug Query" modal to use this new "ModalDialog" component. It has an enter and exit animation using CSSTransition, it pops down below the tab bar, it has a "Scrollable" container for content that can get very long, it has a footer component for the row of buttons, and it locks the rest of the screen using "pointer-events: none" on the body element when it's opened.


![](http://g.recordit.co/LRfHpSdYjR.gif)
