### PR TITLE
Make notice banner above tabs

### DIFF
--- a/src/css/_notice-banner.scss
+++ b/src/css/_notice-banner.scss
@@ -34,7 +34,7 @@
 
   &.fixed {
     position: absolute;
-    z-index: 1;
+    z-index: 5;
     top: 22px;
     left: 50%;
     max-width: 90%;


### PR DESCRIPTION
Fixes #1181 

The z-index of the tab bar changed from 1 to 2, so I've set the z-index of the yellow notice to 5. 