### PR TITLE
No overlapping popups

### DIFF
--- a/src/css/_info-notice.scss
+++ b/src/css/_info-notice.scss
@@ -1,11 +1,13 @@
 .info-notice-wrapper {
-  display: flex;
   position: fixed;
   bottom: 0;
   right: 0;
   left: 0;
+  display: flex;
   justify-content: center;
-  height: 100px;
+  align-items: center;
+  flex-direction: column;
+  padding-bottom: 24px;
 }
 
 .info-notice {
@@ -20,7 +22,7 @@
   display: flex;
   align-items: center;
   @include label-normal;
-  bottom: 48px;
+  margin-bottom: 12px;
   animation: popup 2s;
 
   .x-button {

--- a/src/js/components/Notice.tsx
+++ b/src/js/components/Notice.tsx
@@ -7,13 +7,13 @@ import doc from "../lib/doc"
 import {CircleCloseButton} from "./CircleCloseButton"
 
 const Wrap = styled.div`
-  display: flex;
   position: fixed;
   bottom: 0;
   right: 0;
   left: 0;
+  display: flex;
   justify-content: center;
-  height: 100px;
+  height: 112px;
 `
 
 const bg = cssVar("--wet-cement") as string


### PR DESCRIPTION

<img width="736" alt="Screen Shot 2020-11-02 at 4 26 14 PM" src="https://user-images.githubusercontent.com/3460638/97933944-0c2be500-1d29-11eb-9c86-e91b473072d4.png">

This a temporary fix to make two different ways of doing a "Notice" not overlap. I just moved one version below the other version.

In the future, I think we should change where the "Refresh" button is. I think it should be a different piece of UI with a progress bar and buttons to refresh or cancel or what not.

Fixes #1151  