### PR TITLE
Activate Bug

### DIFF
--- a/src/js/electron/brim.test.ts
+++ b/src/js/electron/brim.test.ts
@@ -1,0 +1,42 @@
+jest.mock("./extensions", () => ({
+  installExtensions: jest.fn()
+}))
+import {installExtensions} from "./extensions"
+import {Brim} from "./brim"
+
+test("activate when zero windows open", () => {
+  const brim = new Brim()
+  expect(brim.windows.count()).toBe(0)
+  brim.activate()
+  expect(brim.windows.count()).toBe(1)
+})
+
+test("actiate when one or more windows open", () => {
+  const brim = new Brim()
+  brim.activate()
+  expect(brim.windows.count()).toBe(1)
+  brim.activate()
+  expect(brim.windows.count()).toBe(1)
+})
+
+test("start opens a window", () => {
+  const brim = new Brim()
+  brim.start()
+  expect(brim.windows.count()).toBe(1)
+})
+
+test("start installs dev extensions if is dev", () => {
+  const brim = new Brim()
+  jest.spyOn(brim, "isDev").mockImplementation(() => true)
+  brim.start()
+  expect(installExtensions).toHaveBeenCalled()
+  // @ts-ignore
+  installExtensions.mockReset()
+})
+
+test("start does not install dev extensions if not dev", () => {
+  const brim = new Brim()
+  jest.spyOn(brim, "isDev").mockImplementation(() => false)
+  brim.start()
+  expect(installExtensions).not.toHaveBeenCalled()
+})

--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -1,0 +1,27 @@
+import windowManager, {$WindowManager} from "./tron/windowManager"
+import isDev from "./isDev"
+import {installExtensions} from "./extensions"
+import {SessionState} from "./tron/formatSessionState"
+
+export class Brim {
+  readonly windows: $WindowManager
+  readonly data: SessionState | undefined
+
+  constructor(data?: SessionState) {
+    this.data = data
+    this.windows = windowManager()
+  }
+
+  async start() {
+    if (this.isDev()) await installExtensions()
+    this.windows.init(this.data)
+  }
+
+  activate() {
+    if (this.windows.count() === 0) this.windows.init()
+  }
+
+  isDev() {
+    return isDev
+  }
+}

--- a/src/js/electron/main.ts
+++ b/src/js/electron/main.ts
@@ -76,7 +76,7 @@ async function main() {
   else app.on("ready", onReady)
 
   app.on("activate", () => {
-    if (!(winMan.count() === 0)) winMan.init()
+    if (winMan.count() === 0) winMan.init()
   })
 
   app.on("web-contents-created", (event, contents) => {

--- a/src/js/electron/main.ts
+++ b/src/js/electron/main.ts
@@ -17,7 +17,6 @@ import "regenerator-runtime/runtime"
 import {app} from "electron"
 
 import {handleSquirrelEvent} from "./squirrel"
-import {installExtensions} from "./extensions"
 import tron from "./tron"
 import path from "path"
 import {ZQD} from "../zqd/zqd"


### PR DESCRIPTION
Fixes #1118 

Clicking the Brim icon on Mac now does nothing if there is already a window open (it focuses it). But if there are no open windows, it will create a new one when clicked.

The problem was some unnecessary parens that got added when we migrated to typescript. It tried to fix some where syntax. The first commit is the fix. The second commit is a small refactor and tests to ensure it doesn't appear again.