### PR TITLE
Update log post endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20483,8 +20483,8 @@
       }
     },
     "zq": {
-      "version": "git+https://github.com/brimsec/zq.git#067eb47e508bc90466ab6136d5e13ffd18bbe9f9",
-      "from": "git+https://github.com/brimsec/zq.git#067eb47e508bc90466ab6136d5e13ffd18bbe9f9"
+      "version": "git+https://github.com/brimsec/zq.git#80150da05b769d205d8a9ab3a637f24cd7d54ed1",
+      "from": "git+https://github.com/brimsec/zq.git#80150da05b769d205d8a9ab3a637f24cd7d54ed1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "styled-components": "^5.1.1",
     "valid-url": "^1.0.9",
     "zealot": "file:zealot",
-    "zq": "git+https://github.com/brimsec/zq.git#067eb47e508bc90466ab6136d5e13ffd18bbe9f9"
+    "zq": "git+https://github.com/brimsec/zq.git#80150da05b769d205d8a9ab3a637f24cd7d54ed1"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",

--- a/zealot/src/api/logs.ts
+++ b/zealot/src/api/logs.ts
@@ -5,7 +5,7 @@ export default {
   post({spaceId, paths, types}: LogsPostArgs) {
     return {
       method: "POST",
-      path: `/space/${encodeURIComponent(spaceId)}/log`,
+      path: `/space/${encodeURIComponent(spaceId)}/log/paths`,
       body: getBody(paths, types)
     }
   }


### PR DESCRIPTION
In brimsec/zq#1336, the uri for posting paths for log ingest changes from
/space/:spaceid/logs to /space/:spaceid/logs/paths.

The previous uri will now serve and endpoint that allows for logs to streamed
over the network using http multipart forms.