### PR TITLE
use connectionStatuses reducer

### DIFF
--- a/src/js/components/ConnectionModals/ConnectionForm.tsx
+++ b/src/js/components/ConnectionModals/ConnectionForm.tsx
@@ -106,8 +106,7 @@ const ConnectionForm = ({onClose, conn}: Props) => {
       id: hostPort,
       name: name,
       username: undefined,
-      password: undefined,
-      status: "initial"
+      password: undefined
     }
   }
 

--- a/src/js/components/ConnectionModals/StatusLight.tsx
+++ b/src/js/components/ConnectionModals/StatusLight.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import styled from "styled-components"
-import {ClusterStatus} from "../../state/Clusters/types"
+import {ConnectionStatus} from "../../state/ConnectionStatuses/types"
 
 const StatusLight = ({...props}: any) => {
   return (
@@ -15,7 +15,7 @@ const StatusLight = ({...props}: any) => {
   )
 }
 
-export default styled(StatusLight)<{status: ClusterStatus}>`
+export default styled(StatusLight)<{status: ConnectionStatus | void}>`
   fill: ${(p) => {
     switch (p.status) {
       case "connected":

--- a/src/js/components/ConnectionModals/ViewConnectionModal.tsx
+++ b/src/js/components/ConnectionModals/ViewConnectionModal.tsx
@@ -9,6 +9,7 @@ import styled from "styled-components"
 import StatusLight from "./StatusLight"
 import EditConnectionModal from "./EditConnectionModal"
 import useEnterKey from "../hooks/useEnterKey"
+import ConnectionStatuses from "../../state/ConnectionStatuses"
 
 const StyledContent = styled(Content)`
   padding-top: 24px;
@@ -107,18 +108,18 @@ const Field = ({label, value}: FieldProps) => {
 const ViewConnectionModalContents = ({onClose, onEdit}) => {
   const conn = useSelector(Current.getConnection)
   const spaceIds = useSelector(Spaces.ids(conn.id))
+  const {name, host, port, version = "unknown", id} = conn
+  const connStatus = useSelector(ConnectionStatuses.get(id))
   const spaceCount = spaceIds.length
   useEnterKey(onClose)
-
-  const {name, host, port, status, version = "unknown"} = conn
 
   return (
     <StyledContent>
       <StyledConnectionDetail>
         <Title>{name}</Title>
         <Status>
-          <StatusLight status={status} />
-          <p>{status}</p>
+          <StatusLight status={connStatus} />
+          <p>{connStatus || "unknown"}</p>
         </Status>
         <ConnectionFields>
           <Field label="Host" value={[host, port].join(":")} />

--- a/src/js/components/LeftPane.tsx
+++ b/src/js/components/LeftPane.tsx
@@ -15,6 +15,7 @@ import SavedSpacesList from "./SavedSpacesList"
 import Spaces from "../state/Spaces"
 import useDrag from "./hooks/useDrag"
 import usePopupMenu from "./hooks/usePopupMenu"
+import ConnectionStatuses from "../state/ConnectionStatuses"
 
 const Arrow = (props) => {
   return (
@@ -168,13 +169,13 @@ export function LeftPane() {
   const isOpen = useSelector(Layout.getLeftSidebarIsOpen)
   const width = useSelector(Layout.getLeftSidebarWidth)
   const id = useSelector(Current.getConnectionId)
+  const connStatus = useSelector(ConnectionStatuses.get(id))
   const spaces = useSelector(Spaces.getSpaces(id))
 
   const showHistory = useSelector(Layout.getHistoryIsOpen)
   const showSpaces = useSelector(Layout.getSpacesIsOpen)
   const historyHeight = useSelector(Layout.getHistoryHeight)
   const spacesHeight = useSelector(Layout.getSpacesHeight)
-  const conn = useSelector(Current.getConnection)
 
   const paneRef = useRef<HTMLDivElement>()
   const paneHeight = useRef(0)
@@ -229,7 +230,7 @@ export function LeftPane() {
           <AddSpaceButton />
         </SectionHeader>
         <SectionContents show={showSpaces}>
-          <SavedSpacesList spaces={spaces} connStatus={conn.status} />
+          <SavedSpacesList spaces={spaces} connStatus={connStatus} />
         </SectionContents>
         {showSpaces && <DragAnchor {...dragFunc()} />}
       </StyledSection>

--- a/src/js/components/SavedSpacesList.tsx
+++ b/src/js/components/SavedSpacesList.tsx
@@ -20,11 +20,11 @@ import Spaces from "../state/Spaces"
 import deleteSpaces from "../flows/deleteSpaces"
 import {popNotice} from "./PopNotice"
 import {AppDispatch} from "../state/types"
-import {ClusterStatus} from "../state/Clusters/types"
+import {ConnectionStatus} from "../state/ConnectionStatuses/types"
 
 type Props = {
   spaces: Space[]
-  connStatus: ClusterStatus
+  connStatus: ConnectionStatus | void
 }
 
 const NameWrap = styled.div`

--- a/src/js/components/TabContent.tsx
+++ b/src/js/components/TabContent.tsx
@@ -26,7 +26,6 @@ export default function TabContent() {
   const conn = useSelector(Current.getConnection)
   const connStatus = useSelector(ConnectionStatuses.get(conn.id))
 
-  console.log("connStatus is: ", connStatus)
   useEffect(() => {
     if (!connStatus) {
       dispatch(initCurrentTab())

--- a/src/js/components/TabContent.tsx
+++ b/src/js/components/TabContent.tsx
@@ -10,6 +10,7 @@ import MacSpinner from "./MacSpinner"
 import styled from "styled-components"
 import ConnectionError from "./ConnectionError"
 import {initCurrentTab} from "../flows/initCurrentTab"
+import ConnectionStatuses from "../state/ConnectionStatuses"
 
 const SpinnerWrap = styled.div`
   width: 100%;
@@ -23,19 +24,23 @@ export default function TabContent() {
   const dispatch = useDispatch()
   const space = useSelector(Current.getSpace)
   const conn = useSelector(Current.getConnection)
+  const connStatus = useSelector(ConnectionStatuses.get(conn.id))
 
+  console.log("connStatus is: ", connStatus)
   useEffect(() => {
-    if (conn.status === "initial") dispatch(initCurrentTab())
-  }, [])
+    if (!connStatus) {
+      dispatch(initCurrentTab())
+    }
+  }, [connStatus])
 
-  if (conn.status === "initial")
+  if (!connStatus)
     return (
       <SpinnerWrap>
         <MacSpinner />
       </SpinnerWrap>
     )
 
-  if (conn.status === "disconnected") return <ConnectionError conn={conn} />
+  if (connStatus === "disconnected") return <ConnectionError conn={conn} />
 
   if (!space) {
     return <TabWelcome />

--- a/src/js/electron/ipc/windows/messages.ts
+++ b/src/js/electron/ipc/windows/messages.ts
@@ -10,6 +10,9 @@ import {
 } from "../types"
 
 export type NewTabSearchParams = {
+  host: string
+  port: string
+  connId: string
   program: string
   span: SpanArgs
   spaceId: string

--- a/src/js/electron/tron/windowManager.ts
+++ b/src/js/electron/tron/windowManager.ts
@@ -124,7 +124,9 @@ export default function windowManager() {
       winParams: Partial<WindowParams> = {},
       initialState: any = undefined
     ): BrimWindow {
-      const lastWin = last<BrimWindow>(this.getWindows())
+      const lastWin = last<BrimWindow>(
+        this.getWindows().filter((w) => w.name === name)
+      )
       const params = defaultWindowParams(winParams, lastWin && lastWin.ref)
       const id = params.id
 

--- a/src/js/electron/tron/windowManager.ts
+++ b/src/js/electron/tron/windowManager.ts
@@ -97,7 +97,7 @@ export default function windowManager() {
     openSearchTab(searchParams: NewTabSearchParams) {
       let isNewWin = true
       const existingWin = this.getWindows()
-        .sort((a, b) => a.lastFocused - b.lastFocused)
+        .sort((a, b) => b.lastFocused - a.lastFocused)
         .find((w) => w.name === "search")
       if (existingWin) {
         isNewWin = false
@@ -109,7 +109,8 @@ export default function windowManager() {
         return
       }
 
-      const {win} = this.openWindow("search", {})
+      const {host, port} = searchParams
+      const win = this.openWindow("search", {query: {host, port}})
       win.ref.webContents.once("did-finish-load", () => {
         sendTo(
           win.ref.webContents,
@@ -190,10 +191,10 @@ export default function windowManager() {
       if (win) {
         win.ref.webContents.send("showPreferences")
       } else {
-        const {win} = this.openWindow("search", {})
+        const newWin = this.openWindow("search", {})
 
-        win.ref.webContents.once("did-finish-load", () => {
-          win.ref.webContents.send("showPreferences")
+        newWin.ref.webContents.once("did-finish-load", () => {
+          newWin.ref.webContents.send("showPreferences")
         })
       }
     },

--- a/src/js/flows/initConnection.ts
+++ b/src/js/flows/initConnection.ts
@@ -3,6 +3,7 @@ import Clusters from "../state/Clusters"
 import {Cluster} from "../state/Clusters/types"
 import refreshSpaceNames from "./refreshSpaceNames"
 import {globalDispatch} from "../state/GlobalContext"
+import ConnectionStatuses from "../state/ConnectionStatuses"
 
 export const initConnection = (cluster: Cluster) => (
   dispatch,
@@ -15,17 +16,17 @@ export const initConnection = (cluster: Cluster) => (
     .then(({version}) => {
       const connectedCluster: Cluster = {
         ...cluster,
-        status: "connected",
         version
       }
       dispatch(Clusters.add(connectedCluster))
+      dispatch(ConnectionStatuses.set(cluster.id, "connected"))
       globalDispatch(Clusters.add(connectedCluster)).then(() => {
         dispatch(Current.setConnectionId(cluster.id))
         dispatch(refreshSpaceNames())
       })
     })
     .catch((e) => {
-      dispatch(Clusters.setStatus(cluster.id, "disconnected"))
+      dispatch(ConnectionStatuses.set(cluster.id, "disconnected"))
       throw e
     })
 }

--- a/src/js/flows/initCurrentTab.ts
+++ b/src/js/flows/initCurrentTab.ts
@@ -1,14 +1,9 @@
 import Current from "../state/Current"
 import {initSpace} from "./initSpace"
-import Clusters from "../state/Clusters"
 import {Thunk} from "../state/types"
 import {initConnection} from "./initConnection"
 
-export const initCurrentTab = (): Thunk => async (
-  dispatch,
-  getState,
-  {globalDispatch}
-) => {
+export const initCurrentTab = (): Thunk => async (dispatch, getState) => {
   const state = getState()
   const conn = Current.getConnection(state)
   const spaceId = Current.getSpaceId(state)
@@ -18,9 +13,7 @@ export const initCurrentTab = (): Thunk => async (
     if (spaceId) {
       dispatch(initSpace(spaceId))
     }
-    globalDispatch(Clusters.setStatus(conn.id, "connected"))
   } catch (e) {
     console.error("Connection failed: ", e)
-    globalDispatch(Clusters.setStatus(conn.id, "disconnected"))
   }
 }

--- a/src/js/flows/openLogDetailsWindow.ts
+++ b/src/js/flows/openLogDetailsWindow.ts
@@ -11,6 +11,9 @@ export const openLogDetailsWindow = (): Thunk => (dispatch, getState) => {
       delete tab.columns
       delete tab.viewer
     }
+
+    // handlers cannot be serialized to plain js objects
+    delete draft.handlers
   })
   invoke(
     ipc.windows.open("detail", {size: [700, 600], query: {host, port}}, state)

--- a/src/js/flows/openNewSearchWindow.ts
+++ b/src/js/flows/openNewSearchWindow.ts
@@ -8,7 +8,13 @@ import {Thunk} from "../state/types"
 export const openNewSearchTab = (): Thunk => (dispatch, getState) => {
   const state = getState()
 
+  const conn = Current.getConnection(state)
+  const {host, port, id} = conn
+
   const params = {
+    host,
+    port,
+    connId: id,
     spaceId: Current.getSpaceId(state),
     span: Tab.getSpan(state),
     program: SearchBar.getSearchBarInputValue(state)

--- a/src/js/initializers/initConnectionParams.ts
+++ b/src/js/initializers/initConnectionParams.ts
@@ -12,8 +12,7 @@ const setupConnection = (host, port) => (dispatch, _, {globalDispatch}) => {
     id: hostPort,
     name: hostPort,
     username: "",
-    password: "",
-    status: "initial"
+    password: ""
   }
   dispatch(Clusters.add(cluster))
   globalDispatch(Clusters.add(cluster))

--- a/src/js/initializers/initConnectionStatuses.ts
+++ b/src/js/initializers/initConnectionStatuses.ts
@@ -1,9 +1,0 @@
-import Clusters from "../state/Clusters"
-import {Store} from "../state/types"
-
-export const initConnectionStatuses = (store: Store) => {
-  const clusters = Clusters.all(store.getState())
-  clusters.forEach(({id}) => {
-    store.dispatch(Clusters.setStatus(id, "initial"))
-  })
-}

--- a/src/js/initializers/initNewSearchTab.ts
+++ b/src/js/initializers/initNewSearchTab.ts
@@ -7,12 +7,13 @@ import SearchBar from "../state/SearchBar"
 import Tabs from "../state/Tabs"
 
 export default function(store: Store, params: NewTabSearchParams) {
-  const {spaceId, span, program, isNewWin} = params
+  const {connId, spaceId, span, program, isNewWin} = params
 
   if (!isNewWin) {
-    store.dispatch(Tabs.new())
+    store.dispatch(Tabs.new(spaceId, connId))
   }
 
+  store.dispatch(Current.setConnectionId(connId))
   store.dispatch(Current.setSpaceId(spaceId))
   store.dispatch(Search.setSpanArgs(span))
   store.dispatch(SearchBar.removeAllSearchBarPins())

--- a/src/js/initializers/initNewSearchTab.ts
+++ b/src/js/initializers/initNewSearchTab.ts
@@ -10,7 +10,7 @@ export default function(store: Store, params: NewTabSearchParams) {
   const {connId, spaceId, span, program, isNewWin} = params
 
   if (!isNewWin) {
-    store.dispatch(Tabs.new(spaceId, connId))
+    store.dispatch(Tabs.new())
   }
 
   store.dispatch(Current.setConnectionId(connId))

--- a/src/js/initializers/initialize.ts
+++ b/src/js/initializers/initialize.ts
@@ -4,11 +4,9 @@ import initIpcListeners from "./initIpcListeners"
 import initMenuActionListeners from "./initMenuActionListeners"
 import initStore from "./initStore"
 import initConnectionParams from "./initConnectionParams"
-import {initConnectionStatuses} from "./initConnectionStatuses"
 
 export default async function initialize() {
   const store = await initStore()
-  initConnectionStatuses(store)
   initDOM()
   initGlobals(store)
   initIpcListeners(store)

--- a/src/js/state/Clusters/actions.ts
+++ b/src/js/state/Clusters/actions.ts
@@ -1,4 +1,4 @@
-import {CLUSTER_ADD, CLUSTER_REMOVE, Cluster, ClusterStatus} from "./types"
+import {CLUSTER_ADD, CLUSTER_REMOVE, Cluster} from "./types"
 
 export default {
   add(cluster: Cluster): CLUSTER_ADD {
@@ -6,8 +6,5 @@ export default {
   },
   remove(id: string): CLUSTER_REMOVE {
     return {type: "CLUSTER_REMOVE", id}
-  },
-  setStatus(id: string, status: ClusterStatus) {
-    return {type: "CLUSTER_SET_STATUS", id, status}
   }
 }

--- a/src/js/state/Clusters/reducer.ts
+++ b/src/js/state/Clusters/reducer.ts
@@ -13,9 +13,5 @@ export default produce((draft: ClustersState, action: ClusterAction) => {
     case "CLUSTER_REMOVE":
       delete draft[action.id]
       return
-    case "CLUSTER_SET_STATUS":
-      if (!draft[action.id]) return
-      draft[action.id].status = action.status
-      return
   }
 }, init())

--- a/src/js/state/Clusters/test.ts
+++ b/src/js/state/Clusters/test.ts
@@ -13,8 +13,7 @@ const cluster: Cluster = {
   host: "boom.com",
   port: "9867",
   username: "kerr",
-  password: "123",
-  status: "initial"
+  password: "123"
 }
 
 test("addCluster", () => {

--- a/src/js/state/Clusters/types.ts
+++ b/src/js/state/Clusters/types.ts
@@ -5,17 +5,14 @@ export type Cluster = {
   port: string
   username: string
   password: string
-  status: ClusterStatus
   version?: string
 }
-
-export type ClusterStatus = "initial" | "connected" | "disconnected"
 
 export type ClustersState = {
   [key: string]: Cluster
 }
 
-export type ClusterAction = CLUSTER_REMOVE | CLUSTER_ADD | CLUSTER_SET_STATUS
+export type ClusterAction = CLUSTER_REMOVE | CLUSTER_ADD
 
 export type CLUSTER_REMOVE = {
   type: "CLUSTER_REMOVE"
@@ -25,10 +22,4 @@ export type CLUSTER_REMOVE = {
 export type CLUSTER_ADD = {
   type: "CLUSTER_ADD"
   cluster: Cluster
-}
-
-export type CLUSTER_SET_STATUS = {
-  type: "CLUSTER_SET_STATUS"
-  id: string
-  status: ClusterStatus
 }

--- a/src/js/state/ConnectionStatuses/actions.ts
+++ b/src/js/state/ConnectionStatuses/actions.ts
@@ -1,0 +1,10 @@
+import {ConnectionStatus} from "./types"
+
+export default {
+  set(connId: string, status: ConnectionStatus) {
+    return {type: "CONNECTION_STATUSES_SET", connId, status}
+  },
+  remove(connId: string) {
+    return {type: "CONNECTION_STATUSES_REMOVE", connId}
+  }
+}

--- a/src/js/state/ConnectionStatuses/index.ts
+++ b/src/js/state/ConnectionStatuses/index.ts
@@ -1,0 +1,9 @@
+import actions from "./actions"
+import reducer from "./reducer"
+import selectors from "./selectors"
+
+export default {
+  ...actions,
+  ...selectors,
+  reducer
+}

--- a/src/js/state/ConnectionStatuses/reducer.ts
+++ b/src/js/state/ConnectionStatuses/reducer.ts
@@ -1,0 +1,20 @@
+import {ConnectionStatusesAction, ConnectionStatusesState} from "./types"
+import produce from "immer"
+
+const init = (): ConnectionStatusesState => {
+  return {}
+}
+
+export default produce(
+  (draft: ConnectionStatusesState, action: ConnectionStatusesAction) => {
+    switch (action.type) {
+      case "CONNECTION_STATUSES_SET":
+        draft[action.connId] = action.status
+        return
+      case "CONNECTION_STATUSES_REMOVE":
+        delete draft[action.connId]
+        return
+    }
+  },
+  init()
+)

--- a/src/js/state/ConnectionStatuses/selectors.ts
+++ b/src/js/state/ConnectionStatuses/selectors.ts
@@ -1,0 +1,8 @@
+import {State} from "../types"
+import {ConnectionStatus} from "./types"
+
+export default {
+  get: (connId: string) => (state: State): ConnectionStatus | void => {
+    return state.connectionStatuses[connId]
+  }
+}

--- a/src/js/state/ConnectionStatuses/test.ts
+++ b/src/js/state/ConnectionStatuses/test.ts
@@ -1,0 +1,18 @@
+import initTestStore from "../../test/initTestStore"
+import ConnectionStatuses from "./"
+
+let store
+beforeEach(() => {
+  store = initTestStore()
+})
+
+test("set/remove connection status", () => {
+  expect(ConnectionStatuses.get("123")(store.getState())).toBeUndefined()
+
+  let state = store.dispatchAll([ConnectionStatuses.set("123", "connected")])
+
+  expect(ConnectionStatuses.get("123")(state)).toBe("connected")
+
+  state = store.dispatchAll([ConnectionStatuses.remove("123")])
+  expect(ConnectionStatuses.get("123")(state)).toBeUndefined()
+})

--- a/src/js/state/ConnectionStatuses/types.ts
+++ b/src/js/state/ConnectionStatuses/types.ts
@@ -1,0 +1,20 @@
+export type ConnectionStatusesState = {
+  [clusterId: string]: ConnectionStatus
+}
+
+export type ConnectionStatus = "connected" | "disconnected"
+
+export type ConnectionStatusesAction =
+  | CONNECTION_STATUSES_SET
+  | CONNECTION_STATUSES_REMOVE
+
+export type CONNECTION_STATUSES_SET = {
+  type: "CONNECTION_STATUSES_SET"
+  connId: string
+  status: ConnectionStatus
+}
+
+export type CONNECTION_STATUSES_REMOVE = {
+  type: "CONNECTION_STATUSES_REMOVE"
+  connId: string
+}

--- a/src/js/state/Current/test.ts
+++ b/src/js/state/Current/test.ts
@@ -30,8 +30,7 @@ test("getting the actual connection", () => {
     host: "www.myconn.com",
     port: "123",
     username: "",
-    password: "",
-    status: "connected"
+    password: ""
   }
   const state = store.dispatchAll([
     Clusters.add(conn),
@@ -49,8 +48,7 @@ test("getting the actual space", () => {
     host: "www.myconn.com",
     port: "123",
     username: "",
-    password: "",
-    status: "connected"
+    password: ""
   }
   const state = store.dispatchAll([
     Clusters.add(conn),

--- a/src/js/state/Tabs/flows.ts
+++ b/src/js/state/Tabs/flows.ts
@@ -3,14 +3,12 @@ import {ipcRenderer} from "electron"
 import {Thunk} from "../types"
 import Tabs from "./"
 import brim from "../../brim"
-import Current from "../Current"
 
 export default {
-  new: (spaceId: string | null = null, connId?: string): Thunk => (
-    dispatch,
-    getState
-  ) => {
-    const connectionId = connId || Current.getConnectionId(getState())
+  new: (spaceId: string | null = null): Thunk => (dispatch, getState) => {
+    const {
+      current: {connectionId}
+    } = Tabs.getActiveTab(getState())
     const id = brim.randomHash()
     dispatch(Tabs.add(id, {connectionId, spaceId}))
     dispatch(Tabs.activate(id))

--- a/src/js/state/Tabs/flows.ts
+++ b/src/js/state/Tabs/flows.ts
@@ -3,12 +3,14 @@ import {ipcRenderer} from "electron"
 import {Thunk} from "../types"
 import Tabs from "./"
 import brim from "../../brim"
+import Current from "../Current"
 
 export default {
-  new: (spaceId: string | null = null): Thunk => (dispatch, getState) => {
-    const {
-      current: {connectionId}
-    } = Tabs.getActiveTab(getState())
+  new: (spaceId: string | null = null, connId?: string): Thunk => (
+    dispatch,
+    getState
+  ) => {
+    const connectionId = connId || Current.getConnectionId(getState())
     const id = brim.randomHash()
     dispatch(Tabs.add(id, {connectionId, spaceId}))
     dispatch(Tabs.activate(id))

--- a/src/js/state/getPersistable.ts
+++ b/src/js/state/getPersistable.ts
@@ -5,6 +5,7 @@ export default function getPersistable(state: any) {
     delete draft.errors
     delete draft.notice
     delete draft.handlers
+    delete draft.connectionStatuses
 
     for (const tab of draft.tabs.data) {
       delete tab.viewer

--- a/src/js/state/migrations/202011060944_removeClustersStatus.test.ts
+++ b/src/js/state/migrations/202011060944_removeClustersStatus.test.ts
@@ -1,0 +1,16 @@
+import getTestState from "../../test/helpers/getTestState"
+import migrate from "./202011060944_removeClustersStatus"
+
+test("migrating 202011060944_removeClustersStatus", () => {
+  const {data} = getTestState("v0.17.0")
+  const next = migrate(data)
+
+  const windows = Object.values(next.windows)
+
+  // @ts-ignore
+  for (const {state} of windows) {
+    Object.values(state.clusters).forEach((c) => {
+      expect(c).not.toHaveProperty("status")
+    })
+  }
+})

--- a/src/js/state/migrations/202011060944_removeClustersStatus.ts
+++ b/src/js/state/migrations/202011060944_removeClustersStatus.ts
@@ -1,0 +1,14 @@
+import {getAllStates} from "../../test/helpers/getTestState"
+import {Cluster} from "../Clusters/types"
+
+export default function removeClustersStatus(state: any) {
+  for (const s of getAllStates(state)) {
+    if (!s.clusters) continue
+    Object.values(s.clusters).forEach((c: Cluster) => {
+      // @ts-ignore
+      delete c.status
+    })
+  }
+
+  return state
+}

--- a/src/js/state/rootReducer.ts
+++ b/src/js/state/rootReducer.ts
@@ -1,6 +1,7 @@
 import {combineReducers} from "redux"
 
 import Clusters from "./Clusters"
+import ConnectionStatuses from "./ConnectionStatuses"
 import Errors from "./Errors"
 import Handlers from "./Handlers"
 import Investigation from "./Investigation"
@@ -23,5 +24,6 @@ export default combineReducers<any, any>({
   view: View.reducer,
   spaces: Spaces.reducer,
   packets: Packets.reducer,
-  prefs: Prefs.reducer
+  prefs: Prefs.reducer,
+  connectionStatuses: ConnectionStatuses.reducer
 })

--- a/src/js/state/types.ts
+++ b/src/js/state/types.ts
@@ -12,6 +12,7 @@ import {SpacesState} from "./Spaces/types"
 import {TabsState} from "./Tabs/types"
 import {ViewState} from "./View/types"
 import {createZealot, Zealot} from "zealot"
+import {ConnectionStatusesState} from "./ConnectionStatuses/types"
 
 export type GetState = () => State
 export type ThunkExtraArg = {
@@ -39,4 +40,5 @@ export type State = {
   tabs: TabsState
   packets: PacketsState
   prefs: PrefsState
+  connectionStatuses: ConnectionStatusesState
 }

--- a/src/js/test/fixtures/index.ts
+++ b/src/js/test/fixtures/index.ts
@@ -24,8 +24,7 @@ const cluster1 = (): Cluster => ({
   host: "test",
   port: "9867",
   username: "",
-  password: "",
-  status: "connected"
+  password: ""
 })
 
 const cluster2 = (): Cluster => ({
@@ -34,8 +33,7 @@ const cluster2 = (): Cluster => ({
   host: "test",
   port: "9868",
   username: "",
-  password: "",
-  status: "connected"
+  password: ""
 })
 
 const fixtures = () => ({

--- a/src/js/test/helpers/loginTo.ts
+++ b/src/js/test/helpers/loginTo.ts
@@ -14,6 +14,7 @@ export default async function loginTo(
 ): Promise<{store: TestStore; cluster: Cluster; zealot: ZealotMock}> {
   const mock = createZealotMock()
   mock
+    .stubPromise("version", {version: "1"}, "always")
     .stubPromise("spaces.list", [{name: "dataSpace", id: "1"}], "always")
     .stubPromise("spaces.get", {name: "dataSpace", id: "1"}, "always")
     .stubStream(


### PR DESCRIPTION
fixes #1183 

Refactors the way we store statuses to be in it's own piece of non-persisting window-level state.

I also noticed a couple of other smaller bugs which I fixed along the way, I'll leave comments next to the corresponding code for those.

![brim](https://user-images.githubusercontent.com/14865533/98408920-d0459800-2026-11eb-8fda-f6ede8c5970f.gif)
