### PR TITLE
Point to Zeek v3.2.1-brim4

### DIFF
--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -164,7 +164,7 @@ async function main() {
   try {
     // We encode the zeek version here for now to avoid the unncessary
     // git clone if it were in package.json.
-    const zeekVersion = "v3.2.1-brim3"
+    const zeekVersion = "v3.2.1-brim4"
     await zeekDownload(zeekVersion, zdepsPath)
 
     // The zq dependency should be a git tag or commit. Any tag that


### PR DESCRIPTION
To take advantage of fixed Community ID plugin and updated [geoip-conn](https://github.com/brimsec/geoip-conn) that includes latest GeoLite2 database.