### PR TITLE
Update zq to v0.23.0 and prep v0.19.0 (redux)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ as usual.
 ---
 
 * Update zq to [v0.23.0](https://github.com/brimsec/zq/releases/tag/v0.23.0)
-* Update Zeek to [v3.2.1-brim3](https://github.com/brimsec/zeek/releases/tag/v3.2.1-brim3) which provides [Community ID](https://github.com/corelight/community-id-spec) generation and the latest [geolocation](https://github.com/brimsec/brim/wiki/Geolocation) data (#1193)
+* Update Zeek to [v3.2.1-brim4](https://github.com/brimsec/zeek/releases/tag/v3.2.1-brim4) which provides [Community ID](https://github.com/corelight/community-id-spec) generation and the latest [geolocation](https://github.com/brimsec/brim/wiki/Geolocation) data (#1202)
 * Binaries for [`pcap`](https://github.com/brimsec/zq/blob/master/cmd/pcap/README.md), [`zapi`](https://github.com/brimsec/zq/blob/master/cmd/zapi/README.md), and [`zar`](https://github.com/brimsec/zq/blob/master/ppl/cmd/zar/README.md) are now bundled with Brim (#1098)
 * Fix an issue where Brim presented a blank white screen when it failed to initialize (#1035)
 * Improve how Brim handles ZJSON responses from `zqd` (#1108)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20483,8 +20483,8 @@
       }
     },
     "zq": {
-      "version": "git+https://github.com/brimsec/zq.git#645d67da728c7229044051307cbc8340d4136975",
-      "from": "git+https://github.com/brimsec/zq.git#645d67da728c7229044051307cbc8340d4136975"
+      "version": "git+https://github.com/brimsec/zq.git#78762bb069a1662eb4b2cf9a0c57740dfc2c59d4",
+      "from": "git+https://github.com/brimsec/zq.git#v0.23.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "styled-components": "^5.1.1",
     "valid-url": "^1.0.9",
     "zealot": "file:zealot",
-    "zq": "git+https://github.com/brimsec/zq.git#645d67da728c7229044051307cbc8340d4136975"
+    "zq": "git+https://github.com/brimsec/zq.git#v0.23.0"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",


### PR DESCRIPTION
https://github.com/brimsec/brim/compare/v0.18.0...05e752f

The first attempt to make a `v0.19.0` release candidate yesterday (#1197) was a failure due to a late-found problem (https://github.com/brimsec/zeek/issues/46) with the Zeek artifact it was pointing at. The Zeek artifact has been repaired, so, giving this another go.