### PR TITLE
Wait For Windows to Close

### DIFF
--- a/src/js/electron/quitter.ts
+++ b/src/js/electron/quitter.ts
@@ -22,7 +22,12 @@ export function handleQuit(manager: $WindowManager, store, session, zqd) {
     }
   })
 
-  app.on("window-all-closed", () => {
-    if (process.platform !== "darwin") app.quit()
+  app.on("window-all-closed", async () => {
+    if (process.platform === "darwin") return
+    // Strangely, this event fires before the "closed" event on the window is fired,
+    // where we dereference the window. Here we check to make sure all the windows
+    // have indeed been dereferenced before we quit the app.
+    await manager.whenAllClosed()
+    app.quit()
   })
 }

--- a/src/js/electron/tron/windowManager.test.ts
+++ b/src/js/electron/tron/windowManager.test.ts
@@ -54,3 +54,24 @@ test("confirm quit is true", async () => {
   const ok = await manager.confirmQuit()
   expect(ok).toBe(true)
 })
+
+test("when all closed resolves", (done) => {
+  const manager = tron.windowManager()
+  let pending = true
+  manager.whenAllClosed().then(() => (pending = false))
+  setTimeout(() => {
+    expect(pending).toBe(false)
+    done()
+  })
+})
+
+test("when all closed waits until windows are done", (done) => {
+  const manager = tron.windowManager()
+  manager.openWindow("search")
+  let pending = true
+  manager.whenAllClosed().then(() => (pending = false))
+  setTimeout(() => {
+    expect(pending).toBe(true)
+    done()
+  })
+})


### PR DESCRIPTION
fixes #1204 

When you close the last open Brim window, we automatically quit the app (unless you're on a Mac).

We are notified that the last window has closed using electron's event `app.on("window-all-closed")` [docs](https://www.electronjs.org/docs/api/app#event-window-all-closed).

When a window closes, it fires a "closed" event [docs](https://www.electronjs.org/docs/api/browser-window#event-closed). We use this event to dereference the window.

Strangely, electron fires these events in this order:

1. app => "window-all-closed"
2. browserWindow => "closed"

This led to calling a method on a browser window that was destroyed, but had not yet fired "closed" which would have caused us to dereference it.

To fix, I added a `windowManager.whenAllClosed()` method that will resolve when all windows have dereferenced.