### PR TITLE
Update create-pull-request pointer to @v3.4.1

### DIFF
--- a/.github/workflows/advance-zq.yml
+++ b/.github/workflows/advance-zq.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Create Pull Request for Manual Inspection
         if: failure()
-        uses: peter-evans/create-pull-request@v1
+        uses: peter-evans/create-pull-request@v3.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: zq update through "${{ steps.zq_pr.outputs.title }}" by ${{ steps.zq_pr.outputs.user }}


### PR DESCRIPTION
The automation that advances the Brim-side `zq` pointer in `package.json` whenever there's a merge to `master` in zq recently started experiencing errors, as shown in [this job output](https://github.com/brimsec/brim/runs/1408777023?check_suite_focus=true#step:21:35). The root cause is described in the article [GitHub Actions: Deprecating set-env and add-path commands](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).

It's a little tricky to tinker with this automation, since as the comments in [advance-zq.yml](https://github.com/brimsec/brim/blob/master/.github/workflows/advance-zq.yml) say:

> These events only trigger on the Github default branch (usually master).

Therefore I set up a quick personal scratch repo that does a very simple invocation of the `create-pull-request` Action. I first triggered the same symptom we see by using the same `@v1` release that we've been using, then updated the pointer to the latest release `@v3.4.1` and saw the symptom went away. Outputs from the Actions runs are [here](https://github.com/philrz/create-pull/actions).

We can also see in commits like [this one](https://github.com/peter-evans/create-pull-request/commit/c7f493a8000b8aeb17a1332e326ba76b57cb83eb) that they've been actively removing refs to these deprecated commands.