### PR TITLE
Log endpoint uses multipart form

### DIFF
--- a/src/js/brim/ingest/detectFileTypes.test.ts
+++ b/src/js/brim/ingest/detectFileTypes.test.ts
@@ -1,5 +1,5 @@
 import ingest from "./"
-import itestFile from "../../test/itestFile"
+import {itestFile} from "../../test/itestFile"
 
 const json = itestFile("sample.ndjson")
 const pcap = itestFile("sample.pcap")
@@ -8,14 +8,14 @@ const unknown = itestFile("plain.txt")
 const zeek = itestFile("sample.tsv")
 
 test("add file types", async () => {
-  const paths = [pcap, pcapng, zeek, json, unknown]
-  const types = await ingest.detectFileTypes(paths)
+  const files = [pcap, pcapng, zeek, json, unknown]
+  const types = await ingest.detectFileTypes(files)
 
   expect(types).toEqual([
-    {type: "pcap", path: pcap},
-    {type: "pcap", path: pcapng},
-    {type: "log", path: zeek},
-    {type: "log", path: json},
-    {type: "log", path: unknown}
+    {type: "pcap", file: pcap},
+    {type: "pcap", file: pcapng},
+    {type: "log", file: zeek},
+    {type: "log", file: json},
+    {type: "log", file: unknown}
   ])
 })

--- a/src/js/brim/ingest/detectFileTypes.ts
+++ b/src/js/brim/ingest/detectFileTypes.ts
@@ -1,11 +1,11 @@
 import {FileListData} from "./fileList"
 import detectFileType from "./detectFileType"
 
-export default function(paths: string[]): Promise<FileListData> {
+export default function(files: File[]): Promise<FileListData> {
   return Promise.all(
-    paths.map(async (path) => {
-      const type = await detectFileType(path)
-      return {type, path}
+    files.map(async (file) => {
+      const type = await detectFileType(file.path)
+      return {type, file}
     })
   )
 }

--- a/src/js/brim/ingest/fileList.ts
+++ b/src/js/brim/ingest/fileList.ts
@@ -1,46 +1,52 @@
 import {IngestFileType} from "./detectFileType"
 import lib from "../../lib"
 
-export type FileListData = {type: IngestFileType; path: string}[]
+export type FileListData = {type: IngestFileType; file: File}[]
 
-export default function fileList(files: FileListData) {
+export default function fileList(list: FileListData) {
   return {
     first() {
-      return files[0]
+      return list[0]
     },
 
     oneFile() {
-      return files.length === 1
+      return list.length === 1
     },
 
     multiple() {
-      return files.length > 1
+      return list.length > 1
     },
 
     paths(): string[] {
-      return files.map((f) => f.path)
+      return list.map((f) => f.file.path)
+    },
+
+    files(): File[] {
+      return list.map((f) => f.file)
     },
 
     any(type: string) {
-      return !!files.find((f) => f.type === type)
+      return !!list.find((f) => f.type === type)
     },
 
     allPcap() {
-      return files.every((f) => f.type === "pcap")
+      return list.every((f) => f.type === "pcap")
     },
 
     mixed() {
-      return !files.every((f) => f.type === files[0].type)
+      return !list.every((f) => f.type === list[0].type)
     },
 
     inSameDir() {
-      return files.every(
-        (f) => lib.file(f.path).dirName() === lib.file(files[0].path).dirName()
+      return list.every(
+        (item) =>
+          lib.file(item.file.path).dirName() ===
+          lib.file(list[0].file.path).dirName()
       )
     },
 
     dirName() {
-      return lib.file(files[0].path).dirName()
+      return lib.file(list[0].file.path).dirName()
     }
   }
 }

--- a/src/js/brim/ingest/getParams.ts
+++ b/src/js/brim/ingest/getParams.ts
@@ -10,7 +10,7 @@ export type IngestParams = {
   name: string
   dataDir: string
   endpoint: IngestFileType
-  paths: string[]
+  files: File[]
 }
 
 export type IngestParamsError = {
@@ -37,7 +37,7 @@ export default function getParams(
 
   function getSpaceName() {
     let name
-    if (files.oneFile()) name = lib.file(files.first().path).fileName()
+    if (files.oneFile()) name = lib.file(files.first().file.path).fileName()
     else if (files.inSameDir()) name = files.dirName()
     else name = generateDirName(now)
 
@@ -48,7 +48,7 @@ export default function getParams(
     name: getSpaceName(),
     dataDir: getDataDir(),
     endpoint: files.first().type,
-    paths: files.paths()
+    files: files.files()
   }
 }
 

--- a/src/js/brim/ingest/test.ts
+++ b/src/js/brim/ingest/test.ts
@@ -1,46 +1,56 @@
 import ingest from "./"
 
+const fakeFile = (path: string): File => {
+  const f = new File([], "fake")
+  f.path = path
+  return f
+}
+
 test("one pcap default", () => {
-  const data = ingest.getParams([{type: "pcap", path: "/work/my.pcap"}])
+  const data = ingest.getParams([
+    {type: "pcap", file: fakeFile("/work/my.pcap")}
+  ])
 
   expect(data).toEqual({
     dataDir: "",
     name: "my.pcap",
     endpoint: "pcap",
-    paths: ["/work/my.pcap"]
+    files: [fakeFile("/work/my.pcap")]
   })
 })
 
 test("one zeek log default", () => {
-  const data = ingest.getParams([{type: "log", path: "/work/zeek.log"}])
+  const data = ingest.getParams([
+    {type: "log", file: fakeFile("/work/zeek.log")}
+  ])
 
   expect(data).toEqual({
     name: "zeek.log",
     dataDir: "",
     endpoint: "log",
-    paths: ["/work/zeek.log"]
+    files: [fakeFile("/work/zeek.log")]
   })
 })
 
 test("two zeek logs in same dir default", () => {
   const data = ingest.getParams([
-    {type: "log", path: "/work/zeek-1.log"},
-    {type: "log", path: "/work/zeek-2.log"}
+    {type: "log", file: fakeFile("/work/zeek-1.log")},
+    {type: "log", file: fakeFile("/work/zeek-2.log")}
   ])
 
   expect(data).toEqual({
     name: "work",
     dataDir: "",
     endpoint: "log",
-    paths: ["/work/zeek-1.log", "/work/zeek-2.log"]
+    files: [fakeFile("/work/zeek-1.log"), fakeFile("/work/zeek-2.log")]
   })
 })
 
 test("two zeek logs in different dir default", () => {
   const data = ingest.getParams(
     [
-      {type: "log", path: "/work/day-1/zeek.log"},
-      {type: "log", path: "/work/day-2/zeek.log"}
+      {type: "log", file: fakeFile("/work/day-1/zeek.log")},
+      {type: "log", file: fakeFile("/work/day-2/zeek.log")}
     ],
     "",
     [],
@@ -51,14 +61,14 @@ test("two zeek logs in different dir default", () => {
     name: "zeek_1969-12-31_16:00:00",
     dataDir: "",
     endpoint: "log",
-    paths: ["/work/day-1/zeek.log", "/work/day-2/zeek.log"]
+    files: [fakeFile("/work/day-1/zeek.log"), fakeFile("/work/day-2/zeek.log")]
   })
 })
 
 test("two pcaps", () => {
   const data = ingest.getParams([
-    {type: "pcap", path: "/pcap-1"},
-    {type: "pcap", path: "/pcap-2"}
+    {type: "pcap", file: fakeFile("/pcap-1")},
+    {type: "pcap", file: fakeFile("/pcap-2")}
   ])
 
   expect(data).toEqual({
@@ -68,8 +78,8 @@ test("two pcaps", () => {
 
 test("1 pcap and 1 zeek", () => {
   const data = ingest.getParams([
-    {type: "pcap", path: "/pcap-1"},
-    {type: "log", path: "/zeek-1"}
+    {type: "pcap", file: fakeFile("/pcap-1")},
+    {type: "log", file: fakeFile("/zeek-1")}
   ])
 
   expect(data).toEqual({

--- a/src/js/components/LoadFilesInput.tsx
+++ b/src/js/components/LoadFilesInput.tsx
@@ -10,20 +10,20 @@ import useCallbackRef from "./hooks/useCallbackRef"
 import useDropzone from "./hooks/useDropzone"
 
 type Props = {
-  onChange: (e, arg1: string[]) => void
+  onChange: (e, files: File[]) => void
 }
 
 export default function LoadFilesInput({onChange}: Props) {
   const [input, setInput] = useCallbackRef()
 
   const [bindDropzone, dragging] = useDropzone((e: DragEvent) => {
-    const paths = Array.from(e.dataTransfer.files).map((f) => f.path)
-    onChange(e, paths)
+    const files = Array.from(e.dataTransfer.files)
+    onChange(e, files)
   })
 
   function _onChange(e: ChangeEvent<HTMLInputElement>) {
-    const paths = Array.from(e.target.files).map((f) => f.path)
-    onChange(e, paths)
+    const files = Array.from(e.target.files)
+    onChange(e, files)
   }
 
   function openDialog(_: MouseEvent) {

--- a/src/js/flows/exportResults.ts
+++ b/src/js/flows/exportResults.ts
@@ -37,5 +37,5 @@ export default (filePath: string): Thunk => (dispatch, getState) => {
       format: "zng",
       controlMessages: false
     })
-    .then((resp) => saveToFile(resp.origResp, filePath))
+    .then((resp) => saveToFile(resp.origResp as Response, filePath))
 }

--- a/src/js/flows/getZealot.ts
+++ b/src/js/flows/getZealot.ts
@@ -6,7 +6,7 @@ import ConnectionStatuses from "../state/ConnectionStatuses"
 
 const createBrimFetcher = (dispatch, getState) => {
   return (hostPort: string) => {
-    const {promise, stream} = createFetcher(hostPort)
+    const {promise, ...rest} = createFetcher(hostPort)
 
     const wrappedPromise = (args: FetchArgs): Promise<any> => {
       return promise(args).catch((e) => {
@@ -22,7 +22,7 @@ const createBrimFetcher = (dispatch, getState) => {
       })
     }
 
-    return {promise: wrappedPromise, stream}
+    return {promise: wrappedPromise, ...rest}
   }
 }
 

--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -9,7 +9,7 @@ import Tab from "../state/Tab"
 import fixtures from "../test/fixtures"
 import ingestFiles from "./ingestFiles"
 import initTestStore from "../test/initTestStore"
-import itestFile from "../test/itestFile"
+import {itestFile, itestFilePath} from "../test/itestFile"
 import lib from "../lib"
 
 let store, zealot
@@ -102,13 +102,13 @@ describe("success case", () => {
   test("a json file with a custom types config", async () => {
     zealot.stubStream("logs.post", [{type: "LogPostStatus"}, {type: "TaskEnd"}])
 
-    const contents = await lib.file(itestFile("sampleTypes.json")).read()
-    store.dispatch(Prefs.setJSONTypeConfig(itestFile("sampleTypes.json")))
+    const contents = await lib.file(itestFilePath("sampleTypes.json")).read()
+    store.dispatch(Prefs.setJSONTypeConfig(itestFilePath("sampleTypes.json")))
 
     await store.dispatch(ingestFiles([itestFile("sample.ndjson")]))
 
     expect(zealot.calls("logs.post")[0].args).toEqual({
-      paths: [itestFile("sample.ndjson")],
+      files: [itestFile("sample.ndjson")],
       spaceId: "spaceId",
       types: JSON.parse(contents)
     })

--- a/src/js/flows/ingestFiles.ts
+++ b/src/js/flows/ingestFiles.ts
@@ -174,9 +174,11 @@ const trackProgress = (client, gDispatch, clusterId) => {
             break
           case "LogPostResponse":
             updateSpaceDetails()
-            status.warnings.forEach((warning) => {
-              gDispatch(space.appendIngestWarning(warning))
-            })
+            if (status.warnings) {
+              status.warnings.forEach((warning) => {
+                gDispatch(space.appendIngestWarning(warning))
+              })
+            }
             break
           case "LogPostWarning":
           case "PcapPostWarning":

--- a/src/js/test/itestFile.ts
+++ b/src/js/test/itestFile.ts
@@ -1,5 +1,14 @@
 import path from "path"
+import fs from "fs"
 
-export default (name: string) => {
+export function itestFilePath(name: string) {
   return path.join(__dirname, "../../../itest/testdata", name)
+}
+
+export function itestFile(name) {
+  const path = itestFilePath(name)
+  const buffer = fs.readFileSync(path)
+  const f = new File([buffer as BlobPart], name)
+  f.path = path
+  return f
 }

--- a/zealot/package.json
+++ b/zealot/package.json
@@ -12,8 +12,13 @@
     "build:js": "rollup -c",
     "test": "npm-run-all test:*",
     "test:api": "cd test_api && deno test --allow-net --allow-run --allow-read --allow-write",
-    "test:unit": "node ../node_modules/jest/bin/jest.js src",
+    "test:unit": "node ../node_modules/jest/bin/jest.js",
     "clean": "rimraf dist"
+  },
+  "jest": {
+    "roots": [
+      "./src"
+    ]
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^6.0.0",

--- a/zealot/src/api/logs.ts
+++ b/zealot/src/api/logs.ts
@@ -2,15 +2,20 @@ import {LogsPostArgs} from "../types"
 import {getDefaultJsonTypeConfig} from "../config/json_types"
 
 export default {
-  post({spaceId, paths, types}: LogsPostArgs) {
+  post({spaceId, files, types}: LogsPostArgs) {
     return {
       method: "POST",
-      path: `/space/${encodeURIComponent(spaceId)}/log/paths`,
-      body: getBody(paths, types)
+      path: `/space/${encodeURIComponent(spaceId)}/log`,
+      body: getBody(files, types)
     }
   }
 }
 
-function getBody(paths: string[], types = getDefaultJsonTypeConfig()) {
-  return JSON.stringify({paths, json_type_config: types})
+function getBody(files: File[] | FileList, types = getDefaultJsonTypeConfig()) {
+  const data = new FormData()
+  data.append("json_config", JSON.stringify(types))
+  for (const file of files) {
+    data.append(file.name, file)
+  }
+  return data
 }

--- a/zealot/src/api/logs.ts
+++ b/zealot/src/api/logs.ts
@@ -1,4 +1,4 @@
-import {LogsPostArgs} from "../types"
+import {LogsPostArgs, LogsPostPathsArgs} from "../types"
 import {getDefaultJsonTypeConfig} from "../config/json_types"
 
 export default {
@@ -7,6 +7,13 @@ export default {
       method: "POST",
       path: `/space/${encodeURIComponent(spaceId)}/log`,
       body: getBody(files, types)
+    }
+  },
+  postPaths({spaceId, paths, types}: LogsPostPathsArgs) {
+    return {
+      method: "POST",
+      path: `/space/${encodeURIComponent(spaceId)}/log/paths`,
+      body: getPathsBody(paths, types)
     }
   }
 }
@@ -18,4 +25,8 @@ function getBody(files: File[] | FileList, types = getDefaultJsonTypeConfig()) {
     data.append(file.name, file)
   }
   return data
+}
+
+function getPathsBody(paths: string[], types = getDefaultJsonTypeConfig()) {
+  return JSON.stringify({paths, json_type_config: types})
 }

--- a/zealot/src/enhancers/zngToZeek.ts
+++ b/zealot/src/enhancers/zngToZeek.ts
@@ -1,5 +1,5 @@
+import {ZealotPayload} from "../types"
 import * as zjson from "../zjson"
-import * as zqd from "../zqd"
 
 function fail(t: any): never {
   throw new Error("Unknown zjson Type: " + JSON.stringify(t))
@@ -64,7 +64,7 @@ function replaceSchema(r: zjson.Item) {
 }
 
 export function zngToZeek() {
-  return (p: zqd.Payload) => {
+  return (p: ZealotPayload) => {
     if (p.type == "SearchRecords") {
       return {...p, records: p.records.map(replaceSchema)}
     } else {

--- a/zealot/src/fetcher/callbacks.ts
+++ b/zealot/src/fetcher/callbacks.ts
@@ -1,3 +1,4 @@
+import {ZealotPayload} from "../types"
 import * as zqd from "../zqd"
 import {createRecordsCallback, RecordsCallbackArgs} from "./records_callback"
 
@@ -8,7 +9,7 @@ export function createCallbacks() {
       callbacks.set(name, cb)
       return this
     },
-    emit: (name: string, payload: zqd.Payload) => {
+    emit: (name: string, payload: ZealotPayload) => {
       const cb = callbacks.get(name)
       if (cb) cb(payload)
     },

--- a/zealot/src/fetcher/fetcher.test.ts
+++ b/zealot/src/fetcher/fetcher.test.ts
@@ -1,7 +1,6 @@
 import "regenerator-runtime/runtime"
 import {createFetcher} from "./fetcher"
 import http from "http"
-import {timeDay} from "d3"
 
 let server: http.Server
 beforeEach(() => {

--- a/zealot/src/fetcher/fetcher.test.ts
+++ b/zealot/src/fetcher/fetcher.test.ts
@@ -1,0 +1,33 @@
+import "regenerator-runtime/runtime"
+import {createFetcher} from "./fetcher"
+import http from "http"
+import {timeDay} from "d3"
+
+let server: http.Server
+beforeEach(() => {
+  server = http
+    .createServer((req, res) => {
+      res.writeHead(200, "OK", {"Access-Control-Allow-Origin": "*"})
+      res.write(`{"LogPostResponse": "Hi James"}`)
+      res.end()
+    })
+    .listen(9988)
+})
+
+afterEach(() => {
+  server.close()
+})
+
+test("upload", async () => {
+  const fetcher = createFetcher("localhost:9988")
+  const file = new File(["x".repeat(1 * 1024 * 1024)], "x-file")
+  const fd = new FormData()
+  fd.append("file", file)
+
+  const upload = await fetcher.upload({
+    path: "/",
+    method: "POST",
+    body: fd
+  })
+  expect(await upload.array()).toEqual([{LogPostResponse: "Hi James"}])
+})

--- a/zealot/src/fetcher/fetcher.ts
+++ b/zealot/src/fetcher/fetcher.ts
@@ -8,7 +8,7 @@ import {createError} from "../util/error"
 export type FetchArgs = {
   path: string
   method: string
-  body?: string
+  body?: string | FormData
   enhancers?: Enhancer[]
   signal?: AbortSignal
 }

--- a/zealot/src/fetcher/fetcher.ts
+++ b/zealot/src/fetcher/fetcher.ts
@@ -1,6 +1,6 @@
 import {url} from "../util/utils"
 import {parseContentType} from "./contentType"
-import {Enhancer} from "../types"
+import {Enhancer, ZealotPayload, ZReponse} from "../types"
 import {createIterator} from "./iterator"
 import {createStream} from "./stream"
 import {createError} from "../util/error"

--- a/zealot/src/fetcher/iterator.ts
+++ b/zealot/src/fetcher/iterator.ts
@@ -1,8 +1,7 @@
 import {isObject} from "../util/utils"
 import {parseContentType} from "./contentType"
-import {Enhancer, ZIterator} from "../types"
+import {Enhancer, ZealotPayload, ZIterator} from "../types"
 import {FetchArgs} from "./fetcher"
-import * as zqd from "../zqd"
 import {eachLine} from "../ndjson/lines"
 
 export async function* createIterator(
@@ -13,7 +12,7 @@ export async function* createIterator(
 
   for await (let json of eachLine(resp.body)) {
     yield enhancers.reduce(
-      (payload: zqd.Payload, fn: (p: zqd.Payload) => any) => fn(payload),
+      (payload: ZealotPayload, fn: (p: ZealotPayload) => any) => fn(payload),
       json
     )
   }

--- a/zealot/src/fetcher/pushable_iterator.ts
+++ b/zealot/src/fetcher/pushable_iterator.ts
@@ -1,0 +1,51 @@
+type IteratorResult<T> =
+  | {value: T; done: false}
+  | {value: undefined; done: true}
+
+type PendingPromise<T> = {
+  resolve: (result: T) => void
+  reject: (error: Error) => void
+}
+
+export const createPushableIterator = <T>() => {
+  const pendingPromises: PendingPromise<IteratorResult<T>>[] = []
+  const pendingResults: IteratorResult<T>[] = []
+
+  let done = false
+  let err: Error | null = null
+
+  const createPendingPromise = (): Promise<IteratorResult<T>> =>
+    new Promise((resolve, reject) => pendingPromises.push({resolve, reject}))
+
+  return {
+    push(result: IteratorResult<T>): void {
+      const p = pendingPromises.shift()
+      p ? p.resolve(result) : pendingResults.push(result)
+    },
+    next(): Promise<IteratorResult<T>> {
+      if (err) return this.throw(err)
+      if (done) return this.return()
+      const result = pendingResults.shift()
+      if (result) {
+        return result.done ? this.return() : Promise.resolve(result)
+      } else {
+        return createPendingPromise()
+      }
+    },
+    throw(e: Error) {
+      err = e
+      const p = pendingPromises.shift()
+      if (p) p.reject(err)
+      return Promise.reject(err)
+    },
+    return(): Promise<IteratorResult<T>> {
+      done = true
+      const p = pendingPromises.shift()
+      if (p) p.resolve({done: true, value: undefined})
+      return Promise.resolve({done: true, value: undefined})
+    },
+    [Symbol.asyncIterator]() {
+      return this
+    }
+  }
+}

--- a/zealot/src/fetcher/stream.ts
+++ b/zealot/src/fetcher/stream.ts
@@ -13,7 +13,10 @@ async function emitCallbacks(iterator: ZIterator, callbacks: ZCallbacks) {
   }
 }
 
-export function createStream(iterator: ZIterator, origResp: Response) {
+export function createStream(
+  iterator: ZIterator,
+  origResp: Response | XMLHttpRequest
+) {
   return {
     origResp,
     [Symbol.asyncIterator]: () => iterator,

--- a/zealot/src/ndjson/lines.ts
+++ b/zealot/src/ndjson/lines.ts
@@ -1,8 +1,13 @@
-import {pipeJson} from "./pipe_json"
+import {parse} from "./parse"
+import {NEW_LINE, pipeJson} from "./pipe_json"
 import {pipeText} from "./pipe_text"
 
 export async function* eachLine(readable: ReadableStream<Uint8Array> | null) {
   for await (let json of pipeJson(pipeText(readable))) {
     yield json
   }
+}
+
+export function parseLines(string: string) {
+  return string.split(NEW_LINE).map(parse)
 }

--- a/zealot/src/ndjson/parse.ts
+++ b/zealot/src/ndjson/parse.ts
@@ -1,0 +1,16 @@
+class UnexpectedServerResponse extends Error {
+  constructor(msg: string) {
+    super(msg)
+    this.name = "UnexpectedServerResponse"
+  }
+}
+
+export function parse(string: string) {
+  try {
+    return JSON.parse(string)
+  } catch (e) {
+    throw new UnexpectedServerResponse(
+      `Expected ndjson but received "${string}"`
+    )
+  }
+}

--- a/zealot/src/ndjson/pipe_json.ts
+++ b/zealot/src/ndjson/pipe_json.ts
@@ -1,11 +1,6 @@
-const NEW_LINE = "\n\n\n"
+import {parse} from "./parse"
 
-class UnexpectedServerResponse extends Error {
-  constructor(msg: string) {
-    super(msg)
-    this.name = "UnexpectedServerResponse"
-  }
-}
+export const NEW_LINE = "\n\n\n"
 
 export async function* pipeJson(iterator: AsyncGenerator<string>) {
   let leftover = ""
@@ -24,14 +19,4 @@ export async function* pipeJson(iterator: AsyncGenerator<string>) {
   }
 
   if (leftover) yield parse(leftover)
-}
-
-function parse(string: string) {
-  try {
-    return JSON.parse(string)
-  } catch (e) {
-    throw new UnexpectedServerResponse(
-      `Expected ndjson but received "${string}"`
-    )
-  }
 }

--- a/zealot/src/types.ts
+++ b/zealot/src/types.ts
@@ -70,6 +70,12 @@ export interface LogsPostArgs {
   types?: any
 }
 
+export interface LogsPostPathsArgs {
+  paths: string[]
+  spaceId: string
+  types?: any
+}
+
 export interface Ts {
   sec: number
   ns: number

--- a/zealot/src/types.ts
+++ b/zealot/src/types.ts
@@ -8,9 +8,13 @@ export type Zealot = ReturnType<typeof createZealot>
 export type ZCallbacks = ReturnType<typeof createCallbacks>
 export type ZReponse = ReturnType<typeof createStream>
 export type ZFetcher = ReturnType<typeof createFetcher>
-export type ZIterator = AsyncGenerator<zqd.Payload>
+export type ZIterator = AsyncIterable<ZealotPayload>
 
-export type Enhancer = () => (payload: zqd.Payload) => any
+export type ZealotPayload =
+  | zqd.Payload
+  | {type: "UploadProgress"; progress: number}
+
+export type Enhancer = () => (payload: ZealotPayload) => any
 
 export interface ZealotArgs {
   fetcher: (host: string) => ZFetcher

--- a/zealot/src/types.ts
+++ b/zealot/src/types.ts
@@ -61,7 +61,7 @@ export interface PcapsGetArgs {
 }
 
 export interface LogsPostArgs {
-  paths: string[]
+  files: File[] | FileList
   spaceId: string
   types?: any
 }

--- a/zealot/src/zealot.ts
+++ b/zealot/src/zealot.ts
@@ -18,7 +18,7 @@ export function createZealot(
   args: ZealotArgs = {fetcher: createFetcher}
 ) {
   const host = getHost(hostUrl)
-  const {promise, stream} = args.fetcher(host)
+  const {promise, stream, upload} = args.fetcher(host)
 
   let searchArgs: SearchArgs = getDefaultSearchArgs()
 
@@ -78,7 +78,7 @@ export function createZealot(
     },
     logs: {
       post: (args: LogsPostArgs) => {
-        return stream(logs.post(args))
+        return upload(logs.post(args))
       }
     },
     inspect: {

--- a/zealot/src/zealot.ts
+++ b/zealot/src/zealot.ts
@@ -9,7 +9,8 @@ import {
   PcapsGetArgs,
   LogsPostArgs,
   ZealotArgs,
-  SubspaceCreateArgs
+  SubspaceCreateArgs,
+  LogsPostPathsArgs
 } from "./types"
 import {IndexSearchArgs} from "./api/archive"
 
@@ -79,6 +80,9 @@ export function createZealot(
     logs: {
       post: (args: LogsPostArgs) => {
         return upload(logs.post(args))
+      },
+      postPaths: (args: LogsPostPathsArgs) => {
+        return stream(logs.postPaths(args))
       }
     },
     inspect: {

--- a/zealot/src/zealot_mock.ts
+++ b/zealot/src/zealot_mock.ts
@@ -1,10 +1,8 @@
 import {createZealot} from "./zealot"
 import {FetchArgs} from "./fetcher/fetcher"
 import {createStream} from "./fetcher/stream"
-import * as zqd from "./zqd"
-import {zjson} from "./index"
-import {Zealot} from "./types"
 import {createError} from "./util/error"
+import {Zealot, ZealotPayload} from "./types"
 import {zngToZeek} from "./enhancers/mod"
 
 type StubMode = "always" | "once"
@@ -25,7 +23,7 @@ function promise(response: any) {
   return Promise.resolve(response)
 }
 
-function stream(response: zqd.Payload[]) {
+function stream(response: ZealotPayload[]) {
   const enhance = zngToZeek()
   async function* iterator() {
     if (response) {
@@ -39,7 +37,7 @@ function stream(response: zqd.Payload[]) {
 export interface ZealotMock {
   stubStream: (
     method: string,
-    output: zqd.Payload[],
+    output: ZealotPayload[],
     mode?: StubMode
   ) => ZealotMock
   stubPromise: (method: string, output: any, mode?: StubMode) => ZealotMock
@@ -97,7 +95,9 @@ export function createZealotMock(): ZealotMock {
       return this
     },
     stubError(method: string, err: any, mode: StubMode = "once") {
-      override(method, () => { throw createError(err) })
+      override(method, () => {
+        throw createError(err)
+      })
       return this
     },
     calls(method: string) {

--- a/zealot/src/zealot_mock.ts
+++ b/zealot/src/zealot_mock.ts
@@ -15,6 +15,9 @@ function fakeFetcher() {
     },
     stream: ({method, path}: FetchArgs) => {
       throw new Error(`NoNetwork: You must stub: ${method} ${path}`)
+    },
+    upload: ({method, path}: FetchArgs) => {
+      throw new Error(`NoNetwork: You must stub: ${method} ${path}`)
     }
   }
 }

--- a/zealot/test_api/ingest_test.ts
+++ b/zealot/test_api/ingest_test.ts
@@ -1,17 +1,19 @@
 import {join} from "https://deno.land/std@0.70.0/path/mod.ts"
 import {testApi, assertEquals, uniq} from "./helper/mod.ts"
 
-testApi("ONLY ingest log", async (zealot) => {
+testApi("ingest log", async (zealot) => {
   const space = await zealot.spaces.create({name: "space1"})
   const log = join(Deno.cwd(), "data/sample.tsv")
   const response = await Deno.readTextFile(log)
   const f = new File([response], log)
   const resp = await zealot.logs.post({files: [f], spaceId: space.id})
   const messages = await resp.array()
-  assertEquals(uniq(messages.map((m: any) => m.type)), [
-    "TaskStart",
-    "LogPostStatus",
-    "TaskEnd"
+  assertEquals(messages, [
+    {
+      bytes_read: 9655,
+      type: "LogPostResponse",
+      warnings: null
+    }
   ])
 })
 
@@ -37,9 +39,11 @@ testApi("ingest pcap", async (zealot) => {
 testApi("ingest logs with custom type", async (zealot) => {
   const space = await zealot.spaces.create({name: "space1"})
   const log = join(Deno.cwd(), "data/custom-sample.ndjson")
+  const response = await Deno.readTextFile(log)
+  const f = new File([response], log)
   const typesFile = join(Deno.cwd(), "data/custom-schema.json")
   const types = await Deno.readTextFile(typesFile).then(JSON.parse)
-  const resp = await zealot.logs.post({paths: [log], spaceId: space.id, types})
+  const resp = await zealot.logs.post({files: [f], spaceId: space.id, types})
   await resp.array()
 
   const {span} = await zealot.spaces.get(space.id)

--- a/zealot/test_api/ingest_test.ts
+++ b/zealot/test_api/ingest_test.ts
@@ -1,12 +1,13 @@
 import {join} from "https://deno.land/std@0.70.0/path/mod.ts"
 import {testApi, assertEquals, uniq} from "./helper/mod.ts"
 
-testApi("ingest log", async (zealot) => {
+testApi("ONLY ingest log", async (zealot) => {
   const space = await zealot.spaces.create({name: "space1"})
   const log = join(Deno.cwd(), "data/sample.tsv")
-  const resp = await zealot.logs.post({paths: [log], spaceId: space.id})
+  const response = await Deno.readTextFile(log)
+  const f = new File([response], log)
+  const resp = await zealot.logs.post({files: [f], spaceId: space.id})
   const messages = await resp.array()
-
   assertEquals(uniq(messages.map((m: any) => m.type)), [
     "TaskStart",
     "LogPostStatus",

--- a/zealot/test_api/search_test.ts
+++ b/zealot/test_api/search_test.ts
@@ -10,7 +10,9 @@ import {
 async function setup(zealot: any) {
   const space = await zealot.spaces.create({name: "space1"})
   const log = testFile("sample.tsv")
-  const resp = await zealot.logs.post({paths: [log], spaceId: space.id})
+  const response = await Deno.readTextFile(log)
+  const f = new File([response], log)
+  const resp = await zealot.logs.post({files: [f], spaceId: space.id})
   await resp.array()
 
   zealot.setSearchOptions({

--- a/zealot/test_api/search_test.ts
+++ b/zealot/test_api/search_test.ts
@@ -10,9 +10,7 @@ import {
 async function setup(zealot: any) {
   const space = await zealot.spaces.create({name: "space1"})
   const log = testFile("sample.tsv")
-  const response = await Deno.readTextFile(log)
-  const f = new File([response], log)
-  const resp = await zealot.logs.post({files: [f], spaceId: space.id})
+  const resp = await zealot.logs.postPaths({paths: [log], spaceId: space.id})
   await resp.array()
 
   zealot.setSearchOptions({


### PR DESCRIPTION
UPDATE:

I've added a new method to the fetcher called "upload". It uses XHR to make the request and track progress events. We still return an iterable stream of payloads which now include a message that looks like `{type: "UploadProgress", progress: number}`. This allows us to keep the progress bar unchanged as it was.

Fixes #1094 

This changes the log post method in the zealot client to make a multipart form file upload, instead of sending the paths of the files. The pcaps post endpoint has remained unchanged.

It is not easy to get a progress bar for this type of request (it's impossible ATM using the Fetch API, we'd have to rewrite that method with XHR). I think we didn't have progress for log uploads anyway.



@philrz when you verify this, upload a large log file (or set of log files) over 4 GB. I expect it to work but that would be good to check.

P.S.
@mattnibs I noticed that the key for the warnings was a "nil". That may be a bug, see below:

<img width="1362" alt="image" src="https://user-images.githubusercontent.com/3460638/99590707-910e3400-29a2-11eb-8620-e1e58aeb35e9.png">
