### PR TITLE
Precise error message zqd pcap not found error

### DIFF
--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -144,4 +144,19 @@ describe("error case", () => {
       "Some pcap warning"
     ])
   })
+
+  test("pcap post file not found", async () => {
+    zealot.stubError("pcaps.post", {
+      type: "Error",
+      kind: "item does not exist",
+      error: "file:///Users/phil/pcap/hello.pcapng"
+    })
+    await expect(
+      store.dispatch(ingestFiles([itestFile("sample.pcap")]))
+    ).rejects.toThrow(
+      new RegExp(
+        "File file:///Users/phil/pcap/hello.pcapng does not exist on testName1"
+      )
+    )
+  })
 })

--- a/zealot/src/fetcher/fetcher.ts
+++ b/zealot/src/fetcher/fetcher.ts
@@ -24,6 +24,10 @@ export function createFetcher(host: string) {
     async stream(args: FetchArgs) {
       const {path, method, body, signal} = args
       const resp = await fetch(url(host, path), {method, body, signal})
+      if (!resp.ok) {
+        const content = await parseContentType(resp)
+        return Promise.reject(createError(content))
+      }
       const iterator = createIterator(resp, args)
       return createStream(iterator, resp)
     }

--- a/zealot/src/fetcher/iterator.ts
+++ b/zealot/src/fetcher/iterator.ts
@@ -9,12 +9,6 @@ export async function* createIterator(
   resp: Response,
   args: FetchArgs
 ): ZIterator {
-  if (!resp.ok) {
-    let contents = await parseContentType(resp)
-    if (isObject(contents)) throw contents
-    else throw new Error(contents)
-  }
-
   const enhancers = (args.enhancers || []).map((fn: Enhancer) => fn())
 
   for await (let json of eachLine(resp.body)) {

--- a/zealot/src/zealot_mock.ts
+++ b/zealot/src/zealot_mock.ts
@@ -4,6 +4,7 @@ import {createStream} from "./fetcher/stream"
 import * as zqd from "./zqd"
 import {zjson} from "./index"
 import {Zealot} from "./types"
+import {createError} from "./util/error"
 import {zngToZeek} from "./enhancers/mod"
 
 type StubMode = "always" | "once"
@@ -42,6 +43,7 @@ export interface ZealotMock {
     mode?: StubMode
   ) => ZealotMock
   stubPromise: (method: string, output: any, mode?: StubMode) => ZealotMock
+  stubError: (method: string, err: any, mode?: StubMode) => ZealotMock
   calls: (method: string) => {method: string; args: any}[]
   zealot: Zealot
 }
@@ -92,6 +94,10 @@ export function createZealotMock(): ZealotMock {
     },
     stubPromise(method: string, output: any, mode: StubMode = "once") {
       stub(method, output, promise, mode)
+      return this
+    },
+    stubError(method: string, err: any, mode: StubMode = "once") {
+      override(method, () => { throw createError(err) })
       return this
     },
     calls(method: string) {


### PR DESCRIPTION
If a pcap file is posted to a remote server the remote server will return 404
not found. The current error message was just name of the file. Update the
error message in this case to reflect that the server does not have to access
the file.

Related change:

- The zealot fetcher was not throwing an error if a stream request response was
a 404. Change so it does if the response is not ok.

Closes #1221