### PR TITLE
add autoupdate restrictions

### DIFF
--- a/src/js/electron/autoUpdater.ts
+++ b/src/js/electron/autoUpdater.ts
@@ -14,10 +14,12 @@ const autoUpdateLinux = async () => {
   const url = getFeedURLForPlatform("darwin-x64")
   try {
     const currentVersion = app.getVersion()
+    log.info({currentVersion})
     if (!semver.valid(currentVersion))
       throw "Invalid current version format: " + currentVersion
 
     const resp = await got(url).json()
+    log.info({resp})
 
     const latestVersion = get(resp, "name", "")
     if (!semver.valid(latestVersion))

--- a/src/js/electron/main.ts
+++ b/src/js/electron/main.ts
@@ -48,11 +48,9 @@ async function main() {
 
   // autoUpdater should not run in dev, and will fail if the code has not been signed
   if (!electronIsDev) {
-    try {
-      await setupAutoUpdater()
-    } catch (err) {
+    setupAutoUpdater().catch((err) => {
       log.error("Failed to initiate autoUpdater: " + err)
-    }
+    })
   }
 
   app.on("second-instance", (e, argv) => {

--- a/src/js/electron/main.ts
+++ b/src/js/electron/main.ts
@@ -49,7 +49,7 @@ async function main() {
   // autoUpdater should not run in dev, and will fail if the code has not been signed
   if (!electronIsDev) {
     try {
-      setupAutoUpdater()
+      await setupAutoUpdater()
     } catch (err) {
       log.error("Failed to initiate autoUpdater: " + err)
     }


### PR DESCRIPTION
fixes #1219 

Adds the same version check mechanism that we do for linux: if the latest version is *ahead* of the current version then don't update. This is not currently the default behavior of MacOS and Windows, and it is useful for building and sharing beta releases.

The other fix in here has to do with the autoupdate server: if the current version, which we encode in the server url, is the *same* as the latest version that we have in our github releases, then the server returns a 204 status. In my initial probing of the server I had mistakenly thought that the server still returned a body in this case (and contradicted its status) but the server actually does behaves restfully and does not return anything with that 204 code. This is why we were seeing the empty string in the error for the fixes ticket referenced above. 

Signed-off-by: Mason Fish <mason@looky.cloud>