### PR TITLE
Fix links in wiki for remote zqd article

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -17,7 +17,7 @@ effective use of the Brim desktop application and related tools.
 
 ## Cookbooks
 
-- [[Remote `zqd`]]
+- [[Remote zqd]]
 
 ## Developer Resources
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -12,7 +12,7 @@
 
 **Cookbooks**
 
-- [[Remote `zqd`]]
+- [[Remote zqd]]
 
 **Developer Resources**
 


### PR DESCRIPTION
I made a mistake not realizing the backticks would mess up the linking. I've tested out the fix in a personal repo.