### PR TITLE
Add required promise annotations

### DIFF
--- a/zealot/test_api/helper/test_api.ts
+++ b/zealot/test_api/helper/test_api.ts
@@ -52,7 +52,7 @@ async function until(
   wait: number,
   msg: string
 ) {
-  return new Promise(async (resolve, reject) => {
+  return new Promise<void>(async (resolve, reject) => {
     const id = setTimeout(() => reject(new Error("Timed out: " + msg)), timeout)
     async function check() {
       try {

--- a/zealot/test_api/search_test.ts
+++ b/zealot/test_api/search_test.ts
@@ -58,7 +58,7 @@ testApi("search#callbacks start and end", async (zealot: any) => {
   const start = spy()
   const end = spy()
 
-  await new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     resp
       .callbacks()
       .start(start)


### PR DESCRIPTION
```
deno 1.6.0 (release, x86_64-apple-darwin)
v8 8.8.278.2
typescript 4.1.2
```

Our CI is using a new version of Deno which requires explicit promise annotations. This PR adds those in.