### PR TITLE
Update Supported Platforms article

### DIFF
--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -5,75 +5,158 @@
   * [Windows](#windows)
   * [macOS](#macos)
   * [Linux](#linux)
+- [Establishing Platform Supportability](#establishing-platform-supportability)
+  * [Development Tools](#development-tools)
+  * [Automated Testing](#automated-testing)
+  * [Smoke Testing](#smoke-testing)
+  * [Non-Recommended Platforms](#non-recommended-platforms)
 
 # Summary
 
 [Downloadable packages](https://www.brimsecurity.com/download/) for Brim are
-available that run on Windows, macOS, and Linux. The specific
-versions/distributions of these platforms for which we can set expectations of
-quality are affected by end-of-life cycles and their availability in our
-automated test infrastructure.
+available that run on Windows, macOS, and Linux. Our current platform
+recommendations on which to run Brim:
 
-The sections below describe the details regarding the versions we test with
-continuously as well as occasional ad hoc testing. We welcome you to
-[open an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue) on any problem you
-experience with Brim regardless of platform version, but please understand
-that we may be limited in our ability to provide quick fixes (or any fix at
-all) for some platform versions.
+* Windows
+   * Windows 10 or newer
+   * Windows Server 2019 or newer
+* macOS
+   * macOS Catalina 10.15.7 or newer (Intel-based Mac hardware only)
+* Linux
+  * Ubuntu 18.04 or newer
+  * CentOS 8.0 1905 or newer
+  * Debian 10.0.0 or newer
+  * Fedora 28 or newer
+
+The sections below provide details regarding these guidelines and how they are
+established.
 
 # Per-Platform Details
 
 ## Windows
 
-Our Windows test automation runs on Windows Server 2019, and therefore this is
-the platform on which we are best able to ensure quality and prevent
-regressions. Several Brim developers also run Windows 10 on their desktops
-and regularly perform ad hoc testing with it and attempt to reproduce issues on
-Windows 10.
+Brim's [test automation](#automated-testing) runs on Windows Server
+2019 and therefore this is the platform on which we are best able to ensure
+quality and prevent regressions.
+[Microsoft support statements](https://docs.microsoft.com/en-us/windows/release-information/status-windows-10-20h2)
+simultaneously target both Windows 10 and Windows Server, so our quality
+expectations between Windows 10 and Windows Server 2019 are equivalent. Several
+Brim developers also run Windows 10 desktops and regularly perform ad hoc
+testing with it to reproduce reported issues.
 
-Brim is written using tools that have their own platform limitations. Per the
-supported platform guidance for [Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms)
-and [Go](https://golang.org/doc/install#requirements), Windows versions
-_older_ _than_ Windows 7 or Windows Server 2008R2 are not expected to work at
-all.
-
-We've been informed anecdotally that users are running Brim successfully on
-Windows 7. However, as [Windows 7 is end-of-life](https://support.microsoft.com/en-us/help/4057281/windows-7-support-ended-on-january-14-2020),
-we have no access to this platform to reproduce reported issues or test fixes.
-We will make all attempts to provide  "best effort" support on reported Windows
-7 issues, but please understand that if we're unable to reproduce them on
-Windows Server 2019 or Windows 10, we may not be able to address them.
+Basic [smoke testing](#smoke-testing) has also validated that Brim appears to
+work on Windows 8.1 as well. Similar testing has also confirmed that Brim does
+_not_ work on Windows 7. Therefore we do _not_ recommend attempting to run Brim
+on releases older than Windows 8.1.
 
 ## macOS
 
-Our macOS test automation runs on Catalina 10.15, and therefore this is
-the platform on which we are best able to ensure quality and prevent
-regressions.
+Brim's macOS releases run on the Intel-based hardware that makes up the
+majority of Macs in use today. However, there is currently no support for
+running Brim on the recently-announced
+[M1-based hardware](https://www.apple.com/mac/m1/). Issue
+[brim/1266](https://github.com/brimsec/brim/issues/1266) tracks the addition
+of M1 support.
 
-macOS versions prior to 10.14 will not be able import pcaps, as our builtin Zeek
-bundle for macOS relies on features first available in macOS 10.14.
+Brim's [test automation](#automated-testing) runs on Catalina 10.15 and
+therefore this is the platform on which we are best able to ensure quality and
+prevent regressions. Several Brim developers also run macOS Big Sur 11.0 and
+regularly perform ad hoc testing with it to reproduce reported issues.
 
-Brim is written using tools that have their own platform limitations. Per the
-supported platform guidance for [Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms) 
-and [Go](https://golang.org/doc/install#requirements), macOS versions _older_
-_than_ 10.11 are not expected to work at all.
-
-We've been informed anecdotally that users are running Brim successfully on
-some of these macOS releases older than 10.15. However, we do not have the
-ability to easily "spin up" test environments with arbitrary macOS versions to
-reproduce reported issues or test fixes. We will make all attempts to provide
-"best effort" support on macOS releases other than 10.15, but please understand
-that if we're unable to reproduce them on Catalina 10.15, we may not be able
-to address them.
+Basic [smoke testing](#smoke-testing) has also validated that Brim appears to
+work on macOS Mojave 10.14 as well. Similar testing has also confirmed that
+Brim does _not_ work on macOS High Sierra 10.13. Therefore, we do _not_
+recommend attempting to run Brim on macOS releases older than macOS Mojave
+10.14.
 
 ## Linux
 
-Our Linux test automation runs on Ubuntu 18.04 (`.deb` package) and
-CentOS 8 (`.rpm` package), and therefore these are the platforms on which
-we are best able to ensure quality and prevent regressions.
+Brim's [test automation](#automated-testing) runs on Ubuntu 18.04 (`.deb`
+package) and CentOS 8 (`.rpm` package) and therefore these are the platforms
+on which we are best able to ensure quality and prevent regressions.
 
-Brim is written using tools that have their own platform limitations. Per the
-supported platform guidance for [Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms)
-and [Go](https://golang.org/doc/install#requirements), Linux distributions
-_older_ _than_ Ubuntu 12.04, Fedora 21, or Debian 8 are not expected to work
-at all.
+The [CentOS FAQ](https://wiki.centos.org/FAQ/General) explains that CentOS
+"aims to be functionally compatible with Red Hat Enterprise Linux" ([RHEL](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux)).
+Therefore the CentOS versions listed in this article provide the basis of the
+Brim supportability expectation for the equivalent RHEL version.
+
+Basic [smoke testing](#smoke-testing) has also validated the _oldest_
+release on which Brim appeared to work for each common distribution, as
+follows:
+
+* Ubuntu 10.04
+* CentOS 8 1905
+* Debian 10.0.0
+* Fedora 28
+
+Therefore we do _not_ recommend attempting to run Brim on distributions older
+than those listed above.
+
+# Establishing Platform Supportability
+
+The determination of the specific versions of platforms for which we can set
+expectations of quality are based on multiple factors. These include:
+
+* Support for the platform in dependent [development tools](#development-tools)
+* Availability of the platform for [automated testing](#automated-testing)
+and/or [smoke testing](#smoke-testing)
+
+The following sections provide more detail, along with guidance if you feel
+strongly about trying to get Brim running on a [non-recommended platform](#non-recommended-platforms).
+
+## Development Tools
+
+There are two primary development tools on which Brim depends:
+[Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms)
+and [Go](https://golang.org/doc/install#requirements). Their support
+statements cite older platform releases than the Brim-specific ones cited above.
+Therefore the recommendations in the [Summary](#summary) section above should
+be followed.
+
+## Automated Testing
+
+The most extensive testing of Brim is provided via automation that is run on
+[GitHub Actions](https://github.com/features/actions). Specific platform
+versions of
+[Runners](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners)
+are referenced in the automation for Brim's
+[Continuous Integration tests](https://github.com/brimsec/brim/blob/master/.github/workflows/ci.yml)
+and build workflows for
+[Windows](https://github.com/brimsec/brim/blob/master/.github/workflows/win-release-candidate.yml),
+[macOS](https://github.com/brimsec/brim/blob/master/.github/workflows/macos-release-candidate.yml), and
+[Linux](https://github.com/brimsec/brim/blob/master/.github/workflows/linux-release-candidate.yml).
+
+## Smoke Testing
+
+Due to the large number of permutations of platforms (especially as relates to
+Linux distributions), it is currently infeasible to provide the same exhaustive
+automated coverage on every version of every possible platform. Occasionally,
+manual "smoke testing" has been performed on a wider number of platforms to
+confirm basic functionality. Such a smoke test consists of the following:
+
+* Install the base platform while accepting the defaults on any offered install-time config options
+* Install the Brim app using the standard package install procedure for the platform
+* Import a test pcap into Brim and confirm embedded Zeek and Suricata both produce records from it
+
+This exercise was most recently performed in December, 2020 in preparation for
+the GA release `v0.21.0` that introduces Suricata support. For more details on
+the outcome of this exercise, review [brim/1263](https://github.com/brimsec/brim/issues/1263).
+
+## Non-Recommended Platforms
+
+While we welcome you to
+[open an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue)
+about any problem you experience with Brim regardless of platform version,
+the priority of the core Brim development team is to maintain stability and
+introduce new features on the modern platforms that are most widely used.
+Therefore we may be limited in our ability to provide fixes (or any fix at all)
+for platform versions older/different from those recommended above.
+
+We also understand that certain users may have a strong motivation to make Brim
+work on other platforms. As Brim is open source, community members are welcomed
+to perform their own research regarding such platforms and submit
+[cookbooks](https://github.com/brimsec/brim/wiki#cookbooks) that may be of
+use to other users seeking to run on the same platform. Before embarking on
+such an effort, we recommend
+[opening an issue](https://github.com/brimsec/brim/wiki/Troubleshooting#opening-an-issue)
+to check if we're aware of any existing efforts regarding that platform.


### PR DESCRIPTION
Up until now, our Supported Platforms statement has been primarily expressed in terms of where we run CI as well as the support statements from Go/Electron. However, the work on Suricata reminded us how there can be additional sensitivities in terms of shared libraries that may not be present in some platforms and hence will determine whether Brim can install and operate out-of-the-box on them.

I recently ran through a fairly extensive smoke testing exercise documented in #1263 that confirms where we stand on many platforms at this point-in-time as we're preparing to release Suricata. Therefore this PR attempts to make our support statement more current in line with the findings from #1263.

In terms of target audience and approach, I've tried to lead with a simple summary (e.g. a typical user just wanting to confirm that they're a-ok when running on a current release of a common platform) and build up to an audience of advanced users (e.g. a developer that uses a niche Linux distro that may be willing to invest their own cycles into determining what it takes to make Brim run on it).

In keeping with the theme of the prior article, I've stopped short of saying many things are out-n-out "unsupported", barring the ones we know that are an absolute certainty (e.g. [M1-based Mac hardware](https://github.com/brimsec/brim/issues/1266)). I figure this is a reasonable line to walk since the recent smoke testing exercise indicated that the reasons it didn't work on certain platforms seemed to come down primarily to, 1. existence of libraries, or, 2. packaging, both of which could potentially be overcome with some elbow grease. I pointed toward the "cookbook" format as a potential delivery vehicle for that, since those are presented as experimental/advanced. If such a user did submit a PR for such a cookbook, we could reference it from this article and set expectations that the variation is effectively "community supported". I have my doubts this will happen in practice, but I figure it doesn't hurt to leave the door open to motivated users.

Once this is merged, I plan to link to it from the word "platforms" on https://www.brimsecurity.com/download/ page.

Closes #1263.
