### PR TITLE
Round the pixels before distributing them

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     ],
     "testURL": "http://localhost",
     "roots": [
-      "./src/js"
+      "./src"
     ],
     "collectCoverageFrom": [
       "**/*.js",

--- a/src/pkg/sectional/models/Controller.test.ts
+++ b/src/pkg/sectional/models/Controller.test.ts
@@ -33,6 +33,24 @@ test("distribute positive beyond max", () => {
   expect(views.at(3).size).toBe(700)
 })
 
+test("distribute a fractional amount", () => {
+  const data = {
+    size: 1000.1,
+    sections: [
+      {id: "1", min: 24, max: 100},
+      {id: "2", min: 24, max: 100},
+      {id: "3", min: 24, max: 100},
+      {id: "4", min: 24}
+    ]
+  }
+  const views = Controller.parse(data)
+
+  expect(views.at(0).size).toBe(100)
+  expect(views.at(1).size).toBe(100)
+  expect(views.at(2).size).toBe(100)
+  expect(views.at(3).size).toBe(700)
+})
+
 test("resize", () => {
   const data = {
     size: 800,

--- a/src/pkg/sectional/models/Controller.ts
+++ b/src/pkg/sectional/models/Controller.ts
@@ -54,13 +54,14 @@ export default class Controller {
   }
 
   private distribute(extra: number) {
-    const unit = extra > 0 ? 1 : -1
+    let left = Math.round(extra)
     let prev
-    while (extra !== prev /* no change occurred */) {
-      prev = extra
+    const unitOfChange = left > 0 ? 1 : -1
+    while (prev !== left /* unable to distribute any more */) {
+      prev = left
       for (let child of this.sections) {
-        if (extra === 0) break
-        if (child.resize(unit) === 0) extra += -unit
+        if (left === 0) break
+        if (child.resize(unitOfChange) === 0) left += -unitOfChange
       }
     }
   }


### PR DESCRIPTION
Fixes #1256 

The "sectional" component distributes pixels evenly to all the sections on start up. It does this by adding 1 pixel to each section in a while loop. It stops when each section is at it's max, or when there is are more pixels left to distribute. `if (left === 0) break`

To check if each section is at it's max, it keep the leftover pixels from the previous iteration. If the current amount of pixels to distribute equals the amount from the previous loop, that means each section is at it's max, so break the loop. `while(prev !== left)`

What I didn't realize is that when you zoom in a window, you can have elements with a fractional height (421.365px). Because the distributor adds one whole pixel each loop, the remaining space variable never was exactly zero. Since the sections do not have a "max" size by default, this caused an infinite loop and the screen froze.

I now round the number to the nearest whole number before starting the loop. I've added a test to test for fractional pixels as well.