### PR TITLE
Set max to infinity if its null

### DIFF
--- a/src/js/components/AddSpaceButton.tsx
+++ b/src/js/components/AddSpaceButton.tsx
@@ -1,8 +1,7 @@
 import {useDispatch} from "react-redux"
 import React from "react"
 import styled from "styled-components"
-
-import {resetTab} from "../flows/initNewTab"
+import {setSpaceId} from "../state/Current/actions"
 
 const StyledAnchor = styled.a`
   margin-left: auto;
@@ -21,7 +20,7 @@ const StyledAnchor = styled.a`
 
 export default function AddSpaceButton() {
   const dispatch = useDispatch()
-  const onClick = () => dispatch(resetTab())
+  const onClick = () => dispatch(setSpaceId(null))
 
   return (
     <StyledAnchor className="add-space" onClick={onClick}>

--- a/src/pkg/sectional/models/Section.test.ts
+++ b/src/pkg/sectional/models/Section.test.ts
@@ -12,6 +12,18 @@ test("constructor max size", () => {
   expect(s.size).toBe(200)
 })
 
+test("constructor max size when null", () => {
+  const args = {id: "1", size: 500, min: 50, max: null}
+  const s = Section.parse(args)
+  expect(s.max).toEqual(Infinity)
+})
+
+test("constructor max size when undefined", () => {
+  const args = {id: "1", size: 500, min: 50, max: undefined}
+  const s = Section.parse(args)
+  expect(s.max).toEqual(Infinity)
+})
+
 test("resize -", () => {
   const args = {id: "1", size: 100, min: 50, max: 200}
   const s = Section.parse(args)

--- a/src/pkg/sectional/models/Section.test.ts
+++ b/src/pkg/sectional/models/Section.test.ts
@@ -13,9 +13,16 @@ test("constructor max size", () => {
 })
 
 test("constructor max size when null", () => {
-  const args = {id: "1", size: 500, min: 50, max: null}
+  const args = {id: "1", size: 0, min: 50, max: undefined}
   const s = Section.parse(args)
-  expect(s.max).toEqual(Infinity)
+  expect(s.size).toBe(50)
+})
+
+test("serialize boomarang", () => {
+  const section = new Section("mysection")
+  const data = section.serialize()
+  const section2 = Section.parse(JSON.parse(JSON.stringify(data)))
+  expect(section2.serialize()).toEqual(data)
 })
 
 test("constructor max size when undefined", () => {

--- a/src/pkg/sectional/models/Section.ts
+++ b/src/pkg/sectional/models/Section.ts
@@ -1,3 +1,5 @@
+import {isNumber} from "lodash"
+
 export interface SectionData {
   id: string
   size?: number
@@ -20,7 +22,7 @@ export default class Section {
     public isOpen: boolean = true,
     public closedSize: number = min
   ) {
-    if (!max) this.max = Infinity
+    if (!isNumber(max)) this.max = Infinity
     this.size = this.clamp(size)
   }
 
@@ -67,7 +69,7 @@ export default class Section {
       id: this.id,
       size: this.size,
       min: this.min,
-      max: this.max,
+      max: this.max === Infinity ? undefined : this.max,
       isOpen: this.isOpen,
       closedSize: this.closedSize
     }

--- a/src/pkg/sectional/models/Section.ts
+++ b/src/pkg/sectional/models/Section.ts
@@ -20,6 +20,7 @@ export default class Section {
     public isOpen: boolean = true,
     public closedSize: number = min
   ) {
+    if (!max) this.max = Infinity
     this.size = this.clamp(size)
   }
 


### PR DESCRIPTION
If you pass `undefined` to a function with a default parameter, the default parameter will be used. However if you pass `null` to it, it will use `null` as the value.

The constructor of the Section model has a max parameter with a default value of `Infinity`. But when you serialize an object that contains `Infinity`, it gets converted to null.

```
> let myObject = {max: Infinity}
undefined
> JSON.stringify(myObject)
'{"max":null}'
>
```

So the next time we passed these serialized args to the constructor, the max value was set to `null` instead of `Infinity`. That caused an issue when "clamping" the size of the section, resulting in this bug.

I've added some tests.

fixes: #1281 