### PR TITLE
Electron on windows, instanceof bugs

### DIFF
--- a/src/js/brim/cell.ts
+++ b/src/js/brim/cell.ts
@@ -13,7 +13,7 @@ export interface Cell {
 }
 
 export function createCell({name, data}: zng.Field): Cell {
-  if (data instanceof zng.Primitive) {
+  if (data.constructor && data.constructor.name === "Primitive") {
     return createPrimitiveCell({name, data})
   } else {
     return createComplexCell({name, data})

--- a/src/js/components/LogCell/index.tsx
+++ b/src/js/components/LogCell/index.tsx
@@ -52,7 +52,7 @@ type FieldSwitchProps = {
 }
 
 function FieldSwitch({field, log, menuBuilder}: FieldSwitchProps) {
-  if (field.data instanceof zng.Primitive) {
+  if (field.data.constructor && field.data.constructor.name === "Primitive") {
     const menu = menuBuilder(field, log, false)
     return <SingleField field={field} menu={menu} />
   } else {

--- a/src/js/components/LogRow.tsx
+++ b/src/js/components/LogRow.tsx
@@ -38,7 +38,12 @@ const LogRow = (props: Props) => {
     const field = log.tryField(column.name)
     const key = `${index}-${colIndex}`
 
-    if (field && field.data && !(field.data instanceof zng.Record)) {
+    if (
+      field &&
+      field.data &&
+      field.data.constructor &&
+      field.data.constructor.name !== "Record"
+    ) {
       return (
         <LogCell
           rightClick={rightClick}

--- a/src/js/correlation/models/Correlation.ts
+++ b/src/js/correlation/models/Correlation.ts
@@ -24,18 +24,20 @@ export class Correlation {
   }
 
   getUid() {
+    console.log("r is: ", this.r)
     if (this.r.has("_path")) {
       const path = this.r.get("_path").toString()
       const name = get(specialUids, path, "uid")
+      console.log("name is: ", this.r)
       if (this.r.has(name)) {
         const data = this.r.get(name)
+        console.log("data is: ", data)
         if (data instanceof zng.Primitive) {
           return data.toString()
         } else {
-          return data
-            .getValue()
-            .map((v) => v.toString())
-            .join(" ")
+          const value = data.getValue()
+          if (!value) return null
+          return value.map((v) => v.toString()).join(" ")
         }
       }
     }

--- a/src/js/correlation/models/Correlation.ts
+++ b/src/js/correlation/models/Correlation.ts
@@ -31,6 +31,7 @@ export class Correlation {
       if (this.r.has(name)) {
         const data = this.r.get(name)
         console.log("data is: ", data)
+        console.log("is primitive instance? ", data instanceof zng.Primitive)
         if (data instanceof zng.Primitive) {
           return data.toString()
         } else {

--- a/src/js/correlation/models/Correlation.ts
+++ b/src/js/correlation/models/Correlation.ts
@@ -24,7 +24,6 @@ export class Correlation {
   }
 
   getUid() {
-    console.log("r is: ", this.r)
     if (this.r.has("_path")) {
       const path = this.r.get("_path").toString()
       const name = get(specialUids, path, "uid")
@@ -36,6 +35,7 @@ export class Correlation {
           return data.toString()
         } else {
           const value = data.getValue()
+          console.log("value is: ", value)
           if (!value) return null
           return value.map((v) => v.toString()).join(" ")
         }

--- a/src/js/correlation/models/Correlation.ts
+++ b/src/js/correlation/models/Correlation.ts
@@ -29,10 +29,6 @@ export class Correlation {
       const name = get(specialUids, path, "uid")
       if (this.r.has(name)) {
         const data = this.r.get(name)
-        console.log(
-          "is primitive instance? ",
-          data.constructor && data.constructor.name === "Primitive"
-        )
         if (data.constructor && data.constructor.name === "Primitive") {
           return data.toString()
         } else {

--- a/src/js/correlation/models/Correlation.ts
+++ b/src/js/correlation/models/Correlation.ts
@@ -1,4 +1,4 @@
-import {get} from "lodash"
+import {get, isString} from "lodash"
 import {zng} from "../../../../zealot/dist"
 
 const specialUids = {
@@ -27,17 +27,18 @@ export class Correlation {
     if (this.r.has("_path")) {
       const path = this.r.get("_path").toString()
       const name = get(specialUids, path, "uid")
-      console.log("name is: ", this.r)
       if (this.r.has(name)) {
         const data = this.r.get(name)
-        console.log("data is: ", data)
-        console.log("is primitive instance? ", data instanceof zng.Primitive)
-        if (data instanceof zng.Primitive) {
+        console.log(
+          "is primitive instance? ",
+          data.constructor && data.constructor.name === "Primitive"
+        )
+        if (data.constructor && data.constructor.name === "Primitive") {
           return data.toString()
         } else {
           const value = data.getValue()
-          console.log("value is: ", value)
           if (!value) return null
+          if (isString(value)) return value
           return value.map((v) => v.toString()).join(" ")
         }
       }

--- a/src/js/electron/menu/actions/searchActions.ts
+++ b/src/js/electron/menu/actions/searchActions.ts
@@ -203,7 +203,11 @@ function buildSearchActions() {
       label: "VirusTotal Lookup",
       listener(dispatch, data: zng.SerializedField) {
         const field = zng.Field.deserialize(data)
-        if (field.data instanceof zng.Primitive && field.data.isSet()) {
+        if (
+          field.data.constructor &&
+          field.data.constructor.name === "Primitive" &&
+          field.data.isSet()
+        ) {
           open(virusTotal.url(field.data.getValue() as string))
         }
       }

--- a/src/js/zql/toZql.ts
+++ b/src/js/zql/toZql.ts
@@ -3,7 +3,8 @@ import isString from "lodash/isString"
 
 export function toZql(object: unknown): string {
   // TODO: remove me
-  console.log(`Can't convert object to ZQL: ${object}`)
+  console.log("object is: ")
+  console.log(object)
   if (object instanceof zng.Primitive) return toZqlZngPrimitive(object)
   if (isString(object)) return toZqlString(object)
   if (object instanceof Date) return toZqlDate(object)

--- a/src/js/zql/toZql.ts
+++ b/src/js/zql/toZql.ts
@@ -1,8 +1,11 @@
 import {zng} from "../../../zealot/dist"
+import isString from "lodash/isString"
 
 export function toZql(object: unknown): string {
+  // TODO: remove me
+  console.log(`Can't convert object to ZQL: ${object}`)
   if (object instanceof zng.Primitive) return toZqlZngPrimitive(object)
-  if (typeof object === "string") return toZqlString(object)
+  if (isString(object)) return toZqlString(object)
   if (object instanceof Date) return toZqlDate(object)
   if (typeof object === "boolean") return toZqlBool(object)
 
@@ -29,6 +32,8 @@ function toZqlBool(bool: boolean) {
 }
 
 function toZqlZngPrimitive(data: zng.Primitive) {
+  // TODO: remove me
+  console.log({data})
   if (data.getType() === "string") return toZqlString(data.getValue())
   throw new Error(`Can't convert Zng Type: ${data.getType()} to zql`)
 }

--- a/src/js/zql/toZql.ts
+++ b/src/js/zql/toZql.ts
@@ -2,7 +2,8 @@ import {zng} from "../../../zealot/dist"
 import isString from "lodash/isString"
 
 export function toZql(object: unknown): string {
-  if (object instanceof zng.Primitive) return toZqlZngPrimitive(object)
+  if (object.constructor && object.constructor.name === "Primitive")
+    return toZqlZngPrimitive(object as zng.Primitive)
   if (isString(object)) return toZqlString(object)
   if (object instanceof Date) return toZqlDate(object)
   if (typeof object === "boolean") return toZqlBool(object)

--- a/src/js/zql/toZql.ts
+++ b/src/js/zql/toZql.ts
@@ -2,9 +2,6 @@ import {zng} from "../../../zealot/dist"
 import isString from "lodash/isString"
 
 export function toZql(object: unknown): string {
-  // TODO: remove me
-  console.log("object is: ")
-  console.log(object)
   if (object instanceof zng.Primitive) return toZqlZngPrimitive(object)
   if (isString(object)) return toZqlString(object)
   if (object instanceof Date) return toZqlDate(object)
@@ -33,8 +30,6 @@ function toZqlBool(bool: boolean) {
 }
 
 function toZqlZngPrimitive(data: zng.Primitive) {
-  // TODO: remove me
-  console.log({data})
   if (data.getType() === "string") return toZqlString(data.getValue())
   throw new Error(`Can't convert Zng Type: ${data.getType()} to zql`)
 }


### PR DESCRIPTION
fixes #1280 

The way we type check using `instanceof` has different results on windows electron than it does in other platforms. The cause of this is still something to chase down, and could be related to the way our import paths get transpiled by babel, but for now this is a fix that will get us by. Here are some of the related tickets I found on the topic:

https://github.com/xOPERATIONS/maestro/issues/121
https://github.com/electron/electron/issues/1586
https://github.com/electron/electron/issues/1289