### PR TITLE
GET /space returns partial spaces

### DIFF
--- a/src/js/state/Spaces/actions.ts
+++ b/src/js/state/Spaces/actions.ts
@@ -11,7 +11,7 @@ import {
 } from "./types"
 
 export default {
-  setSpaces: (clusterId: string, spaces: Space[]): SPACES_SET => ({
+  setSpaces: (clusterId: string, spaces: Partial<Space>[]): SPACES_SET => ({
     type: "SPACES_SET",
     clusterId,
     spaces: spaces || []

--- a/src/js/state/Spaces/reducer.ts
+++ b/src/js/state/Spaces/reducer.ts
@@ -5,10 +5,12 @@ import brim from "../../brim"
 
 const init: SpacesState = {}
 
-const spacesReducer = produce((draft, action: SpacesAction) => {
+const spacesReducer = produce((draft, action: SpacesAction): {
+  [id: string]: Space
+} => {
   switch (action.type) {
     case "SPACES_SET":
-      return action.spaces.reduce((next, space) => {
+      return action.spaces.reduce<{[id: string]: Space}>((next, space) => {
         next[space.id] = defaults(space, draft[space.id])
         return next
       }, {})
@@ -65,7 +67,7 @@ export default function reducer(
   }
 }
 
-function defaults(next: Space, prev: Space): Space {
+function defaults(next: Partial<Space>, prev: Space): Space {
   // It would be nice to not need to keep this ingest state in the space
   // object. An separate ingest reducer would be good.
   const space = brim.interop.spacePayloadToSpace(next)
@@ -74,6 +76,7 @@ function defaults(next: Space, prev: Space): Space {
   const prevIngest = prev && prev.ingest
   return {
     ...defaults,
+    ...prev,
     ...space,
     ingest: {
       ...defaultIngest,

--- a/src/js/state/Spaces/test.ts
+++ b/src/js/state/Spaces/test.ts
@@ -49,10 +49,13 @@ const testSpace2: Space = {
 
 const testSpaces: Space[] = [testSpace1, testSpace2]
 
-test("setting the spaces", () => {
-  const state = store.dispatchAll([Spaces.setSpaces("cluster1", testSpaces)])
+test("setting the spaces merges with previous data", () => {
+  const state = store.dispatchAll([
+    Spaces.setDetail("cluster1", testSpace1),
+    Spaces.setSpaces("cluster1", [{id: "testId1", name: "testName1"}])
+  ])
 
-  expect(Spaces.ids("cluster1")(state)).toEqual(["testId1", "testId2"])
+  expect(Spaces.get("cluster1", "testId1")(state)).toEqual(testSpace1)
 })
 
 test("space names removing", () => {

--- a/src/js/state/Spaces/types.ts
+++ b/src/js/state/Spaces/types.ts
@@ -39,7 +39,7 @@ type SpaceIngest = {
 export type SPACES_SET = {
   type: "SPACES_SET"
   clusterId: string
-  spaces: Space[]
+  spaces: Partial<Space>[]
 }
 
 export type SPACES_DETAIL = {


### PR DESCRIPTION
Fixes more of #1281 

The zqd spaces endpoint now returns partial `Space` objects for the list view, where it was previously returning full `Space` objects.

The code was replacing all the state with the returned Partial Space objects creating this NAN - UNDEFINED bug.

To fix, we now treat the spaces as partial, and merge them with whatever was there before.