### PR TITLE
Update zq to v0.25.0 and prep v0.21.0 (redux)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ incidents of the issues described above.
 * Add a "Sectional" package in the code that allows a view to be split (#1247)
 * Add a "Tree list" package in the code for working with lists (rendering, drag & drop, etc.) (#1254)
 * Fix an issue where Brim would freeze during zoom-in/zoom-out (#1275)
+* Fix an issue where autoupdate would install releases with version numbers "older" than the number of the one currently installed (#1244)
+* Fix an issue where the Space list would come up empty and Space details would show "NAN UNDEFINED" after a Brim restart (#1283, #1288)
+* Fix an issue on Windows where clicking records generated from an imported pcap produced error messages (#1287)
 
 ## v0.20.0
 * Update zq to [v0.24.0](https://github.com/brimsec/zq/releases/tag/v0.24.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20558,8 +20558,8 @@
       }
     },
     "zq": {
-      "version": "git+https://github.com/brimsec/zq.git#8680830c05e6205cf88422242d12e6f850aafcfe",
-      "from": "git+https://github.com/brimsec/zq.git#8680830c05e6205cf88422242d12e6f850aafcfe"
+      "version": "git+https://github.com/brimsec/zq.git#05b6f80f9a4c36fabd1bf5ef29cee3bf903f1cc1",
+      "from": "git+https://github.com/brimsec/zq.git#v0.25.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "styled-components": "^5.1.1",
     "valid-url": "^1.0.9",
     "zealot": "file:zealot",
-    "zq": "git+https://github.com/brimsec/zq.git#8680830c05e6205cf88422242d12e6f850aafcfe"
+    "zq": "git+https://github.com/brimsec/zq.git#v0.25.0"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",


### PR DESCRIPTION
Our last attempt to bundle Brim GA release `v0.21.0` was aborted because of bugs found during smoke testing, which have since been addressed. This PR includes the CHANGELOG updates for the fixes to those bugs so we can make another attempt at tagging that GA release.

https://github.com/brimsec/brim/compare/v0.20.0...d81df63