### PR TITLE
Retry link checks after HTTP 429

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,0 +1,3 @@
+{
+  "retryOn429": true
+}

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: '.github/workflows/markdown-link-check-config.json'


### PR DESCRIPTION
I don't know if GitHub has changed their website configs or if they've just been having a moment lately, but I've noticed some of the Markdown Link Check (MLC) jobs have failed occasionally with a flurry of HTTP 429 (Too Many Requests) errors https://github.com/brimsec links (example: https://github.com/brimsec/brim/actions/runs/430631383). I learned that the Action we use for MLC has a [setting](https://github.com/tcort/markdown-link-check#markdownlinkcheckmarkdown-opts-callback) that can make it react to this by retrying after the duration indicated by a `retry-after` header if one is provided, and if not, waits 60 seconds. This all seems like an improvement over being distracted by a failing job, so I've made the config here to enable that.

I tried to repro this in a personal repo so I could test that the change is effective, but of course it wouldn't repro when I try to _force_ it (🙄 ). So I just went as far as to make other config settings via the same JSON file and confirm they had the intended effect (e.g. `ignorePatterns`). That leaves me hopeful this retry setting will do what we need the next time GitHub is feeling fussy.

If this gets merged, I'll follow up with a similar PR in the zq repo, since we use the same link checker there.