### PR TITLE
Add "source" field to JSON typing config for Zeek "weird" events

### DIFF
--- a/zealot/config/json_types.ts
+++ b/zealot/config/json_types.ts
@@ -3444,8 +3444,8 @@ export function getDefaultJsonTypeConfig() {
           type: "bstring"
         },
         {
-          "name": "source",
-          "type": "bstring"
+          name: "source",
+          type: "bstring"
         },
         {
           name: "_write_ts",

--- a/zealot/config/json_types.ts
+++ b/zealot/config/json_types.ts
@@ -3444,6 +3444,10 @@ export function getDefaultJsonTypeConfig() {
           type: "bstring"
         },
         {
+          "name": "source",
+          "type": "bstring"
+        },
+        {
           name: "_write_ts",
           type: "time"
         }


### PR DESCRIPTION
I compiled Zeek 4.0.0-rc1 and ran [print-types.zeek](https://github.com/brimsec/zeek/blob/master/brim/print-types.zeek) against it and found they've added one additional field beyond what we were covering in Zeek 3.x: A `source` field in `weird` events. While our current JSON typing system is hopefully not long for this earth, since users may start using Zeek 4.x before the new approach is complete, I've added the additional field here.

Incidentally, in the past I'd not really confronted the config duplication that appears to be in play here. I suppose if we were building this from scratch now, we'd extend the "zq as a dependency in `node_modules`" approach to have the contents of https://github.com/brimsec/zq/blob/master/zeek/types.json automatically reflected in the Brim-side config whenever it changes on the zq side. I'm not proposing we do this since we may never need to use this approach again, but noting it for the record.

This is a companion PR to https://github.com/brimsec/zq/pull/1884 on the zq side.