### PR TITLE
Column order:  ts, _path, event_type

### DIFF
--- a/itest/lib/appStep/api/ingestFile.ts
+++ b/itest/lib/appStep/api/ingestFile.ts
@@ -23,5 +23,8 @@ export default async (app: Application, file: string) => {
     await fileInput.addValue(remoteFile)
   })
 
-  await waitForHook(app, "import-complete")
+  await waitForHook(app, "import-complete", {
+    timeout: 120 * 1000, // Give an import up to 2 minutes to complete (slow CI servers)
+    timeoutMsg: `The import-complete hook never appeared during import of: ${file}`
+  })
 }

--- a/itest/lib/appStep/api/waitForHook.ts
+++ b/itest/lib/appStep/api/waitForHook.ts
@@ -1,7 +1,18 @@
+import {Application} from "spectron"
 import {HookName} from "src/js/state/SystemTest"
 import {hookLogLocator} from "src/js/test/locators"
 
-export default async function waitForHook(app, name: HookName) {
+type WaitUntilOptions = {
+  timeout?: number
+  timeoutMsg?: string
+  interval?: number
+}
+
+export default async function waitForHook(
+  app: Application,
+  name: HookName,
+  options?: WaitUntilOptions
+) {
   await app.client.waitUntil(async () => {
     const hooks = await app.client.$$(hookLogLocator.css)
     const lastHook = hooks[hooks.length - 1]
@@ -10,5 +21,5 @@ export default async function waitForHook(app, name: HookName) {
     } else {
       return false
     }
-  })
+  }, options)
 }

--- a/src/js/lib/columnOrder.test.ts
+++ b/src/js/lib/columnOrder.test.ts
@@ -1,0 +1,46 @@
+import columnOrder from "./columnOrder"
+
+const col = (name) => ({name, type: "any", key: name})
+const a = col("a")
+const b = col("b")
+const c = col("c")
+const path = col("_path")
+const event_type = col("event_type")
+const ts = col("ts")
+
+test("ts", () => {
+  expect(columnOrder([a, ts])).toEqual([ts, a])
+})
+
+test("path", () => {
+  expect(columnOrder([b, path])).toEqual([path, b])
+})
+
+test("event_type", () => {
+  expect(columnOrder([b, event_type])).toEqual([event_type, b])
+})
+
+test("ts, path", () => {
+  expect(columnOrder([b, ts, a, path, c])).toEqual([ts, path, b, a, c])
+})
+
+test("ts, event_path", () => {
+  expect(columnOrder([b, event_type, a, ts, c])).toEqual([
+    ts,
+    event_type,
+    b,
+    a,
+    c
+  ])
+})
+
+test("ts, event_path, path", () => {
+  expect(columnOrder([b, event_type, a, ts, c, path])).toEqual([
+    ts,
+    path,
+    event_type,
+    b,
+    a,
+    c
+  ])
+})

--- a/src/js/lib/columnOrder.ts
+++ b/src/js/lib/columnOrder.ts
@@ -1,13 +1,15 @@
 import {$Column} from "../state/Columns/models/column"
 
-const EXCLUDED = ["ts", "_td", "event_type"]
+const EXCLUDED = ["ts", "event_type", "_path"]
 
 export default (cols: $Column[]) => {
   let orderedCols = cols.filter(({name}) => !EXCLUDED.includes(name))
   const ts = cols.find(({name}) => name === "ts")
   const eventType = cols.find(({name}) => name === "event_type")
+  const path = cols.find(({name}) => name === "_path")
 
   if (eventType) orderedCols = [eventType, ...orderedCols]
+  if (path) orderedCols = [path, ...orderedCols]
   if (ts) orderedCols = [ts, ...orderedCols]
   return orderedCols
 }


### PR DESCRIPTION
Actually fixes #1292 

Eventually, I'd like to display the events in the same order they come from the sever, then have a per-schema user preference to move the ordering around in the app. For now, we'll just continue with the less-optimal solution.

The logic is:

1. Gather all the unique columns from the schemas present in the results into an array
2. Grab the event_type column and force it to the front of the array
3. Do the same with the _path column
4. And finally do the same with the ts column

Unit tests have been added that show this is working now.

<img width="758" alt="image" src="https://user-images.githubusercontent.com/3460638/103961189-cca6be00-5108-11eb-862a-4c2f6ea62861.png">
