### PR TITLE
Change bucket directory hierarchy for build artifacts

### DIFF
--- a/.github/workflows/linux-release-candidate.yml
+++ b/.github/workflows/linux-release-candidate.yml
@@ -54,5 +54,5 @@ jobs:
         service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
     - name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/linux/${{ steps.extract_branch.outputs.branch }} || true
-        gsutil mv dist/installers gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/linux/${{ steps.extract_branch.outputs.branch }}
+        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/linux || true
+        gsutil mv dist/installers gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/linux

--- a/.github/workflows/linux-release-promotion.yml
+++ b/.github/workflows/linux-release-promotion.yml
@@ -19,12 +19,12 @@ jobs:
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
         service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
     - name: Copy artifacts from Google Cloud Storage bucket to GitHub Release page
-      run: gsutil cp -r gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/linux/rc-${{ steps.extract_tag.outputs.tag }} .
+      run: gsutil cp -r gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/rc-${{ steps.extract_tag.outputs.tag }}/linux .
     - name: Upload release candidate artifacts to GitHub Releases
       uses: svenstaro/upload-release-action@1.1.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: rc-${{ steps.extract_tag.outputs.tag }}/*
+        file: linux/*
         file_glob: true
         overwrite: true

--- a/.github/workflows/macos-release-candidate.yml
+++ b/.github/workflows/macos-release-candidate.yml
@@ -74,5 +74,5 @@ jobs:
         service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
     - name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/macos/${{ steps.extract_branch.outputs.branch }} || true
-        gsutil mv dist/installers gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/macos/${{ steps.extract_branch.outputs.branch }}
+        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/macos || true
+        gsutil mv dist/installers gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/macos

--- a/.github/workflows/macos-release-promotion.yml
+++ b/.github/workflows/macos-release-promotion.yml
@@ -19,12 +19,12 @@ jobs:
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
         service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
     - name: Copy artifacts from Google Cloud Storage bucket to GitHub Release page
-      run: gsutil cp -r gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/macos/rc-${{ steps.extract_tag.outputs.tag }} .
+      run: gsutil cp -r gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/rc-${{ steps.extract_tag.outputs.tag }}/macos .
     - name: Upload release candidate artifacts to GitHub Releases
       uses: svenstaro/upload-release-action@1.1.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: rc-${{ steps.extract_tag.outputs.tag }}/*
+        file: macos/*
         file_glob: true
         overwrite: true

--- a/.github/workflows/win-release-candidate.yml
+++ b/.github/workflows/win-release-candidate.yml
@@ -77,5 +77,5 @@ jobs:
       env:
         CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
       run: |
-        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/windows/${{ steps.extract_branch.outputs.branch }} || true
-        gsutil mv dist\installers\ gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/windows/${{ steps.extract_branch.outputs.branch }}
+        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/windows || true
+        gsutil mv dist\installers\ gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/windows

--- a/.github/workflows/win-release-promotion.yml
+++ b/.github/workflows/win-release-promotion.yml
@@ -28,12 +28,12 @@ jobs:
     - name: Copy artifacts from Google Cloud Storage bucket to GitHub Release page
       env:
         CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
-      run: gsutil cp -r gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/windows/rc-${{ steps.extract_tag.outputs.tag }} .
+      run: gsutil cp -r gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/rc-${{ steps.extract_tag.outputs.tag }}/windows .
     - name: Upload release candidate artifacts to GitHub Releases
       uses: svenstaro/upload-release-action@1.1.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: rc-${{ steps.extract_tag.outputs.tag }}\*
+        file: windows\*
         file_glob: true
         overwrite: true


### PR DESCRIPTION
I'm hoping to make some improvements to our build system in the near future. As a prerequisite to that, I've been wanting to address a mistake I made in a prior enhancement, hence this PR.

 On the Google Cloud Storage bucket where release candidates first get staged, I chose a directory hierarchy `{platform}/{tag}/{artifact}`, e.g.:

```
$ gsutil ls -lR gs://brimsec-releases | grep "/rc-v0.22.0/"
gs://brimsec-releases/brim/linux/rc-v0.22.0/:
 232745868  2021-01-07T00:08:16Z  gs://brimsec-releases/brim/linux/rc-v0.22.0/brim_amd64.deb
 255494972  2021-01-07T00:08:14Z  gs://brimsec-releases/brim/linux/rc-v0.22.0/brim_x86_64.rpm
gs://brimsec-releases/brim/macos/rc-v0.22.0/:
 373078075  2021-01-07T00:16:32Z  gs://brimsec-releases/brim/macos/rc-v0.22.0/Brim-darwin-autoupdater.zip
 364312640  2021-01-07T00:16:37Z  gs://brimsec-releases/brim/macos/rc-v0.22.0/Brim.dmg
gs://brimsec-releases/brim/windows/rc-v0.22.0/:
 303899772  2021-01-07T00:12:34Z  gs://brimsec-releases/brim/windows/rc-v0.22.0/Brim-0.22.0-full.nupkg
 299167832  2021-01-07T00:12:38Z  gs://brimsec-releases/brim/windows/rc-v0.22.0/Brim-Setup.exe
        76  2021-01-07T00:12:39Z  gs://brimsec-releases/brim/windows/rc-v0.22.0/RELEASES
```

Having had some time to use it in this form, I can see its shortcomings. For instance, if a build fails smoke testing and I want to get rid of it, the approach above means having to delete _three_ folders, or script up something that zaps the individual files one by one. I realize now that it makes more sense to just go with the approach `{tag}/{platform}/{artifact}` as I'm doing in this PR here.

I've created a personal fork of Brim to test this out along with my other upcoming enhancements, so the proof of a successful rc+promote cycle can be seen at https://github.com/philrz/brim/releases/tag/v0.25.0. All I had to do was plug in the same secrets that we use in the main Brim repo with the one delta being a different destination bucket.