### PR TITLE
Uncomment Suricata Test

### DIFF
--- a/itest/tests/__snapshots__/ingest.test.ts.snap
+++ b/itest/tests/__snapshots__/ingest.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Ingest tests ingest of alerts.pcap (suricata) 1`] = `
+Array [
+  "ts",
+  "count",
+  "2015-03-05T15:07:13.000",
+  "13",
+  "2015-03-05T15:04:28.000",
+  "2",
+]
+`;
+
 exports[`Ingest tests ingest of sample.azng 1`] = `
 Array [
   "ts",

--- a/itest/tests/ingest.test.ts
+++ b/itest/tests/ingest.test.ts
@@ -44,20 +44,19 @@ describe("Ingest tests", () => {
     })
   })
 
-  // Skip for now since it consistently fails in CI
-  // stdTest(`ingest of alerts.pcap (suricata)`, (done) => {
-  //   appStep
-  //     .ingestFile(app, "alerts.pcap")
-  //     .then(async () => {
-  //       const results = await appStep.search(
-  //         app,
-  //         "event_type = alert | every 1s count()"
-  //       )
-  //       expect(results).toMatchSnapshot()
-  //       done()
-  //     })
-  //     .catch((err) => {
-  //       handleError(app, err, done)
-  //     })
-  // })
+  stdTest(`ingest of alerts.pcap (suricata)`, (done) => {
+    appStep
+      .ingestFile(app, "alerts.pcap")
+      .then(async () => {
+        const results = await appStep.search(
+          app,
+          "event_type = alert | every 1s count()"
+        )
+        expect(results).toMatchSnapshot()
+        done()
+      })
+      .catch((err) => {
+        handleError(app, err, done)
+      })
+  })
 })


### PR DESCRIPTION
Let's see how reliable these new integration hooks really are.

Re-run this after #1339 is merged. It contains a fix that will allow each ingest up to 2 minutes to complete before failing. In this branch, the limit is 25 seconds.