### PR TITLE
The proper appRoot in dev mode

### DIFF
--- a/src/js/electron/userTasks.ts
+++ b/src/js/electron/userTasks.ts
@@ -26,7 +26,7 @@ export default function(app: any) {
 
 function getArguments(arg) {
   if (electronIsDev) {
-    // This is not exactly relyable. Each time the directory changes, this will change.
+    // This is not exactly reliable. Each time the directory changes, this will change.
     // Thankfully, it's only run in dev mode.
     const appRoot = path.join(__dirname, "..", "..", "..", "..")
     return [appRoot, arg].join(" ")

--- a/src/js/electron/userTasks.ts
+++ b/src/js/electron/userTasks.ts
@@ -26,7 +26,9 @@ export default function(app: any) {
 
 function getArguments(arg) {
   if (electronIsDev) {
-    const appRoot = path.join(__dirname, "..", "..", "..")
+    // This is not exactly relyable. Each time the directory changes, this will change.
+    // Thankfully, it's only run in dev mode.
+    const appRoot = path.join(__dirname, "..", "..", "..", "..")
     return [appRoot, arg].join(" ")
   } else {
     return arg


### PR DESCRIPTION
Since we changed the directory structure, the user tasks on windows were broken in dev mode. However they worked just fine on release builds.