### PR TITLE
Update zq to v0.27.1 and prep v0.22.0 (redux)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 * Allow the export of query results in NDJSON and CSV formats (#1302, #1328)
 * Add a correlation visualization in the Log Detail view for pivoting from a Suricata alert back to related Zeek `conn` events (#1310)
 * Re-style the Log Detail panel and window (#1310)
-* Update zq to [v0.27.0](https://github.com/brimsec/zq/releases/tag/v0.27.0) (follow that link for details of additional changes that may affect Brim)
+* Ensure Suricta `event_type` field is displayed directly to the right of the `ts` timestamp field (#1339)
+* Pull-down menu option **Window > Reset State** now clears app state after user confirmation (#1338)
+* Update zq to [v0.27.1](https://github.com/brimsec/zq/releases/tag/v0.27.1) (follow that link for details of additional changes that may affect Brim)
 
 ## v0.21.1
 * Update zq to [v0.26.0](https://github.com/brimsec/zq/releases/tag/v0.26.0), which fixes an issue that was causing pcap import failures, and also delivers other enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Allow the export of query results in NDJSON and CSV formats (#1302, #1328)
 * Add a correlation visualization in the Log Detail view for pivoting from a Suricata alert back to related Zeek `conn` events (#1310)
 * Re-style the Log Detail panel and window (#1310)
-* Ensure Suricta `event_type` field is displayed directly to the right of the `ts` timestamp field (#1339)
+* Ensure `_path` and `event_type` fields are always displayed directly to the right of the `ts` timestamp field (#1339)
 * Pull-down menu option **Window > Reset State** now clears app state after user confirmation (#1338)
 * Update zq to [v0.27.1](https://github.com/brimsec/zq/releases/tag/v0.27.1) (follow that link for details of additional changes that may affect Brim)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24163,7 +24163,7 @@
     },
     "zq": {
       "version": "git+https://github.com/brimsec/zq.git#e5a8cf5988956a2709fc9fc43569f55ec3eab74b",
-      "from": "git+https://github.com/brimsec/zq.git#e5a8cf5988956a2709fc9fc43569f55ec3eab74b"
+      "from": "git+https://github.com/brimsec/zq.git#v0.27.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "styled-components": "^5.1.1",
     "tree-model": "^1.0.7",
     "valid-url": "^1.0.9",
-    "zq": "git+https://github.com/brimsec/zq.git#e5a8cf5988956a2709fc9fc43569f55ec3eab74b"
+    "zq": "git+https://github.com/brimsec/zq.git#v0.27.1"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",


### PR DESCRIPTION
A previous attempt had been made to prepare a GA v0.22.0 release, but it was aborted during smoke testing due to a last-minute zq bug that has since been fixed.

The changes since that last attempt:

https://github.com/brimsec/brim/compare/2b45a97...af91d29

All changes since the last tagged GA release v0.21.1:

https://github.com/brimsec/brim/compare/v0.21.1...af91d29