### PR TITLE
Infinite fix

### DIFF
--- a/src/js/flows/search/handler.ts
+++ b/src/js/flows/search/handler.ts
@@ -1,4 +1,4 @@
-import {createResponse} from "./response"
+import {SearchResponse} from "./response"
 import whenIdle from "../../lib/whenIdle"
 
 function abortError(e) {
@@ -6,9 +6,9 @@ function abortError(e) {
 }
 
 export function handle(request: any) {
-  const response = createResponse()
+  const response = new SearchResponse()
   const channels = new Map<number, any>()
-  const promise = new Promise<any>((resolve, reject) => {
+  const promise = new Promise<void>((resolve, reject) => {
     function flushBuffer() {
       for (const [id, data] of channels) {
         response.emit(id, data.allRecords, data.schemas)

--- a/src/js/flows/search/response.ts
+++ b/src/js/flows/search/response.ts
@@ -10,48 +10,48 @@ type EventNames =
   | "warnings"
   | number
 
-export function createResponse() {
-  // Allow for multiple callbacks on one event
-  const callbacks = new Map<EventNames, Function>()
-  return {
-    chan(num: number, func: (records: any, schemas: any) => void) {
-      callbacks.set(num, func)
-      return this
-    },
-    stats(func: (arg0: SearchStats) => void) {
-      callbacks.set("stats", func)
-      return this
-    },
-    status(func: (arg0: SearchStatus) => void) {
-      callbacks.set("status", func)
-      return this
-    },
-    end(func: (arg0: number) => void) {
-      callbacks.set("end", func)
-      return this
-    },
-    start(func: (arg0: number) => void) {
-      callbacks.set("start", func)
-      return this
-    },
-    error(func: (arg0: string) => void) {
-      callbacks.set("error", func)
-      return this
-    },
-    abort(func: () => void) {
-      callbacks.set("abort", func)
-      return this
-    },
-    warnings(func: (arg0: string) => void) {
-      callbacks.set("warnings", func)
-      return this
-    },
-    emit(event: EventNames, ...data: any) {
-      const func = callbacks.get(event)
-      if (func) func(...data)
-      return this
-    }
+export class SearchResponse {
+  callbacks: Map<EventNames, Function>
+
+  constructor() {
+    this.callbacks = new Map<EventNames, Function>()
+  }
+
+  chan(num: number, func: (records: any, schemas: any) => void) {
+    this.callbacks.set(num, func)
+    return this
+  }
+  stats(func: (arg0: SearchStats) => void) {
+    this.callbacks.set("stats", func)
+    return this
+  }
+  status(func: (arg0: SearchStatus) => void) {
+    this.callbacks.set("status", func)
+    return this
+  }
+  end(func: (id: number) => void) {
+    this.callbacks.set("end", func)
+    return this
+  }
+  start(func: (arg0: number) => void) {
+    this.callbacks.set("start", func)
+    return this
+  }
+  error(func: (arg0: string) => void) {
+    this.callbacks.set("error", func)
+    return this
+  }
+  abort(func: () => void) {
+    this.callbacks.set("abort", func)
+    return this
+  }
+  warnings(func: (arg0: string) => void) {
+    this.callbacks.set("warnings", func)
+    return this
+  }
+  emit(event: EventNames, ...data: any) {
+    const func = this.callbacks.get(event)
+    if (func) func(...data)
+    return this
   }
 }
-
-export type SearchResponse = ReturnType<typeof createResponse>


### PR DESCRIPTION
Fixes: #1347

Thanks for catching this Phil. Geez, I think was with us since the big zjson update 3 months ago: https://github.com/brimsec/brim/pull/1108. The infinite scroll was mistakenly unfinished when the PR went in. Automated testing for this is a bit unclear to me at the moment. We could execute javascript within the spectron driver and set the scrollTop of the element to the max. Then wait until the fetch next page hook fires, then check the contents of the viewer. I want to write these tests now, but I'm feeling pulled to work on the security dashboard.

Thankfully, one of the bug was something typescript could have caught. I've restructured the SearchResponse class in away that typescript understands. After doing that, the compiler revealed the bug:

<img width="697" alt="Screen Shot 2021-01-11 at 10 10 38 AM" src="https://user-images.githubusercontent.com/3460638/104225160-df680e00-53fa-11eb-9aff-e899f65b22d4.png">




I think some better unit tests might be easier.