### PR TITLE
ensure contextMenu itest uses sorted data

### DIFF
--- a/itest/tests/contextMenu.test.ts
+++ b/itest/tests/contextMenu.test.ts
@@ -71,7 +71,7 @@ describe("type-wise Filter = value searches", () => {
         stdTest(`FilterEq${testId}: ${path} ${fieldName}="${s}"`, (done) => {
           runSearch(
             app,
-            `_path=${path} ${fieldName}!=null | cut id, ${fieldName}`
+            `_path=${path} ${fieldName}!=null | cut id, ${fieldName} | sort id`
           )
             .then(async () => {
               await appStep.rightClick(


### PR DESCRIPTION
When using archive store by default, this test failed as it the data file it uses as the same timestamp for all its records.