### PR TITLE
Enable creation of ad hoc builds (on-demand and nightly scheduled)

### DIFF
--- a/.github/workflows/linux-release-candidate.yml
+++ b/.github/workflows/linux-release-candidate.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches:
       - rc-v*
+  schedule:
+    - cron: '5 8 * * *'
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
+    - name: Extract branch name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
     - name: install rpm
       run: sudo apt-get install -y rpm
     - uses: actions/setup-go@v2
@@ -39,20 +45,45 @@ jobs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+    - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
+      name: Set version string for ad hoc builds
+      run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid master-${GITHUB_SHA:0:8})" >> $GITHUB_ENV
     - run: npm install --no-audit
     - run: npm run build
     - name: build packages
       run: node ./scripts/release --linux
-    - name: Extract branch name
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
     - name: Setup Google Cloud Platform
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         version: '290.0.1'
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
         service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
+    - if: ${{ startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
+      name: "Set bucket path (if this is a release candidate)"
+      run: echo "BUCKET_PATH=gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/linux" >> $GITHUB_ENV
+    - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
+      name: "Set bucket path (if this is an ad hoc build)"
+      run: echo "BUCKET_PATH=gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ env.ADHOC_VERSION_STRING }}/linux" >> $GITHUB_ENV
+    - name: "Set publicly-available bucket path"
+      run: echo "PUBLIC_BUCKET_PATH=${BUCKET_PATH/gs:\/\//https://storage.googleapis.com/}" >> $GITHUB_ENV
     - name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/linux || true
-        gsutil mv dist/installers gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/linux
+        gsutil rm -rf ${{ env.BUCKET_PATH }} || true
+        gsutil cp -r dist/installers ${{ env.BUCKET_PATH }}
+    - name: Assemble Slack message that points to multiple artifacts
+      run: |
+        echo "SLACK_TEXT<<EOF" >> $GITHUB_ENV
+        echo "New Linux release available -" >> $GITHUB_ENV
+        for FILENAME in $(find dist/installers -type f -exec basename {} \;)
+        do
+          echo "\n<${{ env.PUBLIC_BUCKET_PATH }}/$FILENAME|${{ env.BUCKET_PATH }}/$FILENAME>" >> $GITHUB_ENV
+        done
+        echo "EOF" >> $GITHUB_ENV
+    - name: Inform Slack users at Brim HQ of the new artifact
+      uses: tiloio/slack-webhook-action@v1.1.2
+      with:
+        slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_RELEASES }}
+        slack_json: '{
+                       "username": "release-automation",
+                       "text": "${{ env.SLACK_TEXT }}"
+                     }'

--- a/.github/workflows/macos-release-candidate.yml
+++ b/.github/workflows/macos-release-candidate.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches:
       - rc-v*
+  schedule:
+    - cron: '5 8 * * *'
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
+    - name: Extract branch name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
     - uses: actions/setup-go@v2
       with:
         go-version: '1.14'
@@ -42,6 +48,9 @@ jobs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+    - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
+      name: Set version string for ad hoc builds
+      run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid master-${GITHUB_SHA:0:8})" >> $GITHUB_ENV
     - run: npm install --no-audit
     - run: npm run build
     - name: create build keychain and import Developer ID certificate into it
@@ -63,16 +72,38 @@ jobs:
         APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
     - name: run gatekeeper assessment on notarized package
       run: spctl --assess --type execute --verbose --ignore-cache --no-cache dist/packages/Brim-darwin-x64/Brim.app
-    - name: Extract branch name
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
     - name: Setup Google Cloud Platform
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         version: '290.0.1'
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
         service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
+    - if: ${{ startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
+      name: "Set bucket path (if this is a release candidate)"
+      run: echo "BUCKET_PATH=gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/macos" >> $GITHUB_ENV
+    - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
+      name: "Set bucket path (if this is an ad hoc build)"
+      run: echo "BUCKET_PATH=gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ env.ADHOC_VERSION_STRING }}/macos" >> $GITHUB_ENV
+    - name: "Set publicly-available bucket path"
+      run: echo "PUBLIC_BUCKET_PATH=${BUCKET_PATH/gs:\/\//https://storage.googleapis.com/}" >> $GITHUB_ENV
     - name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/macos || true
-        gsutil mv dist/installers gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/macos
+        gsutil rm -rf ${{ env.BUCKET_PATH }} || true
+        gsutil cp -r dist/installers ${{ env.BUCKET_PATH }}
+    - name: Assemble Slack message that points to multiple artifacts
+      run: |
+        echo "SLACK_TEXT<<EOF" >> $GITHUB_ENV
+        echo "New macOS release available -" >> $GITHUB_ENV
+        for FILENAME in $(find dist/installers -type f -name \*.dmg -exec basename {} \;)
+        do
+          echo "\n<${{ env.PUBLIC_BUCKET_PATH }}/$FILENAME|${{ env.BUCKET_PATH }}/$FILENAME>" >> $GITHUB_ENV
+        done
+        echo "EOF" >> $GITHUB_ENV
+    - name: Inform Slack users at Brim HQ of the new artifact
+      uses: tiloio/slack-webhook-action@v1.1.2
+      with:
+        slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_RELEASES }}
+        slack_json: '{
+                       "username": "release-automation",
+                       "text": "${{ env.SLACK_TEXT }}"
+                     }'

--- a/.github/workflows/win-release-candidate.yml
+++ b/.github/workflows/win-release-candidate.yml
@@ -4,12 +4,19 @@ on:
   push:
     branches:
       - rc-v*
+  schedule:
+    - cron: '5 8 * * *'
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
+    - name: Extract branch name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+      shell: bash
     - uses: actions/setup-go@v2
       with:
         go-version: '1.14'
@@ -42,6 +49,10 @@ jobs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+    - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
+      name: Set version string for ad hoc builds
+      run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid master-${GITHUB_SHA:0:8})" >> $GITHUB_ENV
+      shell: bash
     - run: npm install --no-audit
     - run: npm run build
     - name: Build Signed Release
@@ -57,25 +68,50 @@ jobs:
       env:
         WINDOWS_SIGNING_PASSPHRASE: ${{ secrets.WINDOWS_SIGNING_PASSPHRASE }}
         WINDOWS_SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_SIGNING_PFX_BASE64 }}
-    - name: Extract branch name
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
-      shell: bash
     - name: Set up Python (needed for Google Cloud Platform)
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Setup Google Cloud Platform
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       env:
         CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
       with:
         version: '290.0.1'
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
         service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_RELEASES }}
+    - if: ${{ startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
+      name: "Set bucket path (if this is a release candidate)"
+      run: echo "BUCKET_PATH=gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/windows" >> $GITHUB_ENV
+      shell: bash
+    - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
+      name: "Set bucket path (if this is an ad hoc build)"
+      run: echo "BUCKET_PATH=gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ env.ADHOC_VERSION_STRING  }}/windows" >> $GITHUB_ENV
+      shell: bash
+    - name: "Set publicly-available bucket path"
+      run: echo "PUBLIC_BUCKET_PATH=${BUCKET_PATH/gs:\/\//https://storage.googleapis.com/}" >> $GITHUB_ENV
+      shell: bash
     - name: Upload release artifacts to Google Cloud Storage bucket
       env:
         CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
       run: |
-        gsutil rm -rf gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/windows || true
-        gsutil mv dist\installers\ gs://${{ secrets.GCLOUD_BUCKET_RELEASES }}/brim/${{ steps.extract_branch.outputs.branch }}/windows
+        gsutil rm -rf ${{ env.BUCKET_path }} || true
+        gsutil cp -r dist\installers\ ${{ env.BUCKET_path }}
+    - name: Assemble Slack message that points to multiple artifacts
+      run: |
+        echo "SLACK_TEXT<<EOF" >> $GITHUB_ENV
+        echo "New Windows release available -" >> $GITHUB_ENV
+        for FILENAME in $(find dist/installers -type f -name \*.exe -exec basename {} \;)
+        do
+          echo "\n<${{ env.PUBLIC_BUCKET_PATH }}/$FILENAME|${{ env.BUCKET_PATH }}/$FILENAME>" >> $GITHUB_ENV
+        done
+        echo "EOF" >> $GITHUB_ENV
+      shell: bash
+    - name: Inform Slack users at Brim HQ of the new artifact
+      uses: tiloio/slack-webhook-action@v1.1.2
+      with:
+        slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_RELEASES }}
+        slack_json: '{
+                       "username": "release-automation",
+                       "text": "${{ env.SLACK_TEXT }}"
+                     }'


### PR DESCRIPTION
## tl;dr

This PR allows for creation of "ad hoc builds" based on the current state of Brim `master`. These are signed and made available for all supported platforms just like our regular GA builds.

## Triggers for build creation

There's two ways these are currently triggered:

1. On-demand, by clicking the **Run workflow** pull-down on Actions (aka "workflow_dispatch" mode)

![image](https://user-images.githubusercontent.com/5934157/104781317-1dd13600-5737-11eb-8205-6b871af74ecf.png)

2. Automatically every night at 12:05 AM Pacific time (aka "schedule" mode)

## Build availability

Once the builds are created and available, a message is sent to a **#releases** channel on Slack where users are notified of the availability. Link text offered is of the format `gs://` to reflect that they're on a Google Cloud Storage bucket, but they're hyperlinked to point to the `https://` path which publicly-expose buckets.

![image](https://user-images.githubusercontent.com/5934157/104781626-aa7bf400-5737-11eb-9f39-0341f91ab5a4.png)

I've tested this all out on a personal fork of the Brim repo at https://github.com/philrz/brim, where I changed the necessary secret to point to a temporary public bucket `gs://phil-releases`. If this PR is approved, I'll plan to open up our other "release" bucket publicly as well, since its contents do not seem to be sensitive, and it should be convenient for us to download these directly via the Slack hyperlinks and also offer them to community users in Support contexts as needed, e.g. to test bug fixes or get early feedback on new features. If we should ever want to, we could extend the workflow to also publish the nightly build links on the community Slack system.

# Functional description

A part of the functionality I've carefully tested is the handling of version strings, specifically this portion:

```
ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid master-${GITHUB_SHA:0:8})
```

This has the effect of advancing the base version number to the next minor one, and then appending an additional string that includes a reference to the `master` commit. I rigged it up this way so the user will always see a meaningful version string they can share with us in Support contexts (the commit being the most important part in this case) while the base version string tries to best accommodate expected auto-update behaviors. Here's some specific examples that illustrate this.

In the first case, the `version` string in `package.json` and `package-lock.json` is set to `0.21.0`. An ad hoc build was created when the tip of `master` was commit `676b15ee`, so the above `npm` command then has the effect of advancing the version string to `0.22.0-master-676b15ee.0`. Right now the newest GA Brim release has version string `0.22.0`. Therefore, when running this particular ad hoc release, the auto-update _does_ initiate the download of the GA `0.22.0` release.

<img width="1247" alt="Brim-v0 22 0-master-676b15ee 0" src="https://user-images.githubusercontent.com/5934157/104782594-52de8800-5739-11eb-9b1b-3eaa81e0e94e.png">

In the next case, the `version` string in `package.json` and `package-lock.json` is set to `0.22.0`, which happens to be the current state of official Brim `master` right now. An ad hoc build was created when the tip of `master` was at commit `7657b80a`, so the above `npm` command then has the effect of advancing the version string to `0.23.0-master-7657b80a.0`. Since the newest GA Brim release of `0.22.0` is "older" than that base number, I was able to have that ad hoc version open and running on my desktop indefinitely _without_ any auto-update firing. I think this is key behavior that we want to have. Let's say that we'd given this release to a community user to fix a bug or be an early tester/user of upcoming new functionality. We'd want them to be able to keep running this ad hoc build without interruption until the next minor GA release is published (`0.23.0` in this example) which would be expected to deliver the "official" bug fix or enhancement they've already been using.

<img width="1247" alt="Brim-v0 23 0-master-7657b80a 0" src="https://user-images.githubusercontent.com/5934157/104782870-c7192b80-5739-11eb-89b0-0b770b414ae3.png">

Finally, the previous functionality for handling "release candidates" is unaffected. Branch names starting with `rc-v*` still have significance in that they trigger the creation of a build while preserving whatever `version` string is in `package.json` and `package-lock.json`. The creation of a "Release" on GitHub is still what triggers the "promotion" of such RC builds to the Releases page. These RC builds are still announced via the Slack channel in the same way, though, which should be convenient for those who want to participate in smoke testing as GA releases are being finalized.

<img width="1247" alt="Brim-rc-v0 23 0" src="https://user-images.githubusercontent.com/5934157/104783215-63dbc900-573a-11eb-9e48-875d976ab6f3.png">

![image](https://user-images.githubusercontent.com/5934157/104783238-6d653100-573a-11eb-9c43-eb129a3d161a.png)