### PR TITLE
Add right click "copy" to search and detail fields

### DIFF
--- a/app/core/Data.tsx
+++ b/app/core/Data.tsx
@@ -35,16 +35,18 @@ export const Data = styled.dl`
 
 export const Name = styled.dt`
   margin: 0;
-  margin-right: auto;
   white-space: nowrap;
 `
 
 export const Value = styled.dd`
+  flex: 1;
+  text-align: right;
   margin: 0 0 0 8px;
   color: var(--slate);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  user-select: all;
 
   &.addr,
   &.set\[addr\] {

--- a/app/detail/Fields.tsx
+++ b/app/detail/Fields.tsx
@@ -29,15 +29,14 @@ const DataPanel = React.memo<DTProps>(function DataTable({
   return (
     <Panel>
       {fields.map((field, index) => (
-        <Data
-          key={index}
-          onMouseEnter={() => onHover(field)}
-          onContextMenu={() => onRightClick(field)}
-        >
+        <Data key={index} onMouseEnter={() => onHover(field)}>
           <Name>
             <TooltipAnchor>{field.name}</TooltipAnchor>
           </Name>
-          <Value className={field.data.getType()}>
+          <Value
+            className={field.data.getType()}
+            onContextMenu={() => onRightClick(field)}
+          >
             {createCell(field).display()}
           </Value>
         </Data>
@@ -80,10 +79,7 @@ export default memo(function Fields({record}: Props) {
   }, [])
 
   const onRightClick = useCallback(
-    (field) => {
-      window.getSelection().removeAllRanges()
-      dispatch(contextMenu(field, record))
-    },
+    (field) => dispatch(contextMenu(field, record)),
     [record]
   )
 

--- a/ppl/detail/Correlation.tsx
+++ b/ppl/detail/Correlation.tsx
@@ -1,5 +1,5 @@
 import {useSelector} from "react-redux"
-import React, {memo, useMemo} from "react"
+import React, {memo, useCallback, useMemo} from "react"
 
 import {reactElementProps} from "src/js/test/integration"
 import LogDetails from "src/js/state/LogDetails"
@@ -15,6 +15,7 @@ import {isEqual} from "lodash"
 import Panel from "app/detail/Panel"
 import {getCorrelationQuery} from "./flows/getCorrelationQuery"
 import EventLimit from "./EventLimit"
+import {showContextMenu} from "src/js/lib/System"
 
 export default memo(function UidPanel({record}: {record: zng.Record}) {
   const query = useMemo(() => getCorrelationQuery(record), [record])
@@ -33,6 +34,10 @@ export default memo(function UidPanel({record}: {record: zng.Record}) {
     return events.findIndex((e) => isEqual(e.getRecord(), record))
   }, [record, events])
 
+  const onContextMenu = useCallback(() => {
+    showContextMenu([{role: "copy"}])
+  }, [])
+
   return (
     <section {...reactElementProps("correlationPanel")}>
       <PanelHeading isLoading={isLoading}>Correlation</PanelHeading>
@@ -44,7 +49,9 @@ export default memo(function UidPanel({record}: {record: zng.Record}) {
         <TableWrap>
           <Data>
             <Name>Duration</Name>
-            <Value>{formatDur(conn?.getTime(), conn?.getEndTime())}</Value>
+            <Value onContextMenu={onContextMenu}>
+              {formatDur(conn?.getTime(), conn?.getEndTime())}
+            </Value>
           </Data>
         </TableWrap>
       </Panel>

--- a/ppl/detail/RelatedAlerts.tsx
+++ b/ppl/detail/RelatedAlerts.tsx
@@ -1,5 +1,5 @@
 import {BrimEvent} from "ppl/detail/models/BrimEvent"
-import React, {memo, useMemo} from "react"
+import React, {memo, useCallback, useMemo} from "react"
 import brim from "src/js/brim"
 
 import EventTimeline from "./EventTimeline"
@@ -14,6 +14,7 @@ import zql from "src/js/zql"
 import EventLimit from "./EventLimit"
 import firstLast from "./util/firstLast"
 import useSearch from "app/core/hooks/useSearch"
+import {showContextMenu} from "src/js/lib/System"
 
 type Props = {
   record: zng.Record
@@ -40,6 +41,11 @@ export default memo(function RelatedAlerts({record}: Props) {
     ["Last ts", last ? brim.time(last.getTime()).format() : "Not available"],
     ["Duration", formatDur(first?.getTime(), last?.getTime())]
   ]
+
+  const onContextMenu = useCallback(() => {
+    showContextMenu([{role: "copy"}])
+  }, [])
+
   return (
     <section>
       <PanelHeading isLoading={isLoading}>Related Alerts</PanelHeading>
@@ -52,7 +58,7 @@ export default memo(function RelatedAlerts({record}: Props) {
           {data.map(([name, value]) => (
             <Data key={name}>
               <Name>{name}</Name>
-              <Value>{value}</Value>
+              <Value onContextMenu={onContextMenu}>{value}</Value>
             </Data>
           ))}
         </TableWrap>

--- a/ppl/detail/RelatedConns.tsx
+++ b/ppl/detail/RelatedConns.tsx
@@ -1,6 +1,6 @@
 import {Data, Name, Value} from "app/core/Data"
 import {BrimEvent, BrimEventInterface} from "ppl/detail/models/BrimEvent"
-import React, {memo, useMemo} from "react"
+import React, {memo, useCallback, useMemo} from "react"
 import brim from "src/js/brim"
 import EventTimeline from "./EventTimeline"
 import {TableWrap, ChartWrap, Caption} from "app/detail/Shared"
@@ -12,6 +12,7 @@ import EventLimit from "./EventLimit"
 import useSearch from "app/core/hooks/useSearch"
 import firstLast from "./util/firstLast"
 import zql from "src/js/zql"
+import {showContextMenu} from "src/js/lib/System"
 
 type Props = {
   record: zng.Record
@@ -34,6 +35,11 @@ export default memo(function RelatedConns({record}: Props) {
     ["Last ts", last ? brim.time(last.getTime()).format() : "Not available"],
     ["Duration", formatDur(first?.getTime(), last?.getTime())]
   ]
+
+  const onContextMenu = useCallback(() => {
+    showContextMenu([{role: "copy"}])
+  }, [])
+
   return (
     <section>
       <PanelHeading isLoading={isFetching}>Related Connections</PanelHeading>
@@ -46,7 +52,7 @@ export default memo(function RelatedConns({record}: Props) {
           {data.map(([name, value]) => (
             <Data key={name}>
               <Name>{name}</Name>
-              <Value>{value}</Value>
+              <Value onContextMenu={onContextMenu}>{value}</Value>
             </Data>
           ))}
         </TableWrap>

--- a/ppl/menus/detailFieldContextMenu.ts
+++ b/ppl/menus/detailFieldContextMenu.ts
@@ -1,3 +1,4 @@
+import {MenuItemConstructorOptions} from "electron/main"
 import {isEqual} from "lodash"
 import menu from "src/js/electron/menu"
 import {hasGroupByProc} from "src/js/lib/Program"
@@ -10,7 +11,11 @@ export default function detailFieldContextMenu(
   columns: string[],
   space: Space
 ) {
-  return function(field: zng.Field, log: zng.Record, compound: boolean) {
+  return function(
+    field: zng.Field,
+    log: zng.Record,
+    compound: boolean
+  ): MenuItemConstructorOptions[] {
     const isTime = field.data.getType() === "time"
     const isConn = log.try("_path")?.toString() === "conn"
     const isGroupBy = hasGroupByProc(program)
@@ -56,6 +61,8 @@ export default function detailFieldContextMenu(
         enabled: isGroupBy && sameCols
       }),
       detailMenuActions.countBy.menuItem([fieldData], {enabled: !isGroupBy}),
+      menu.separator(),
+      {role: "copy"},
       menu.separator(),
       detailMenuActions.sortAsc.menuItem([fieldData], {enabled: hasCol}),
       detailMenuActions.sortDesc.menuItem([fieldData], {enabled: hasCol}),

--- a/ppl/menus/searchFieldContextMenu.ts
+++ b/ppl/menus/searchFieldContextMenu.ts
@@ -64,6 +64,8 @@ export default function searchFieldContextMenu(
       }),
       searchMenuActions.countBy.menuItem([fieldData], {enabled: !isGroupBy}),
       menu.separator(),
+      {role: "copy"},
+      menu.separator(),
       searchMenuActions.sortAsc.menuItem([fieldData], {enabled: hasCol}),
       searchMenuActions.sortDesc.menuItem([fieldData], {enabled: hasCol}),
       menu.separator(),


### PR DESCRIPTION
Fixes #1304 

A simple but missing feature. 

<img width="351" alt="image" src="https://user-images.githubusercontent.com/3460638/105223492-b63d3100-5b10-11eb-91c4-78d598423772.png">

<img width="444" alt="image" src="https://user-images.githubusercontent.com/3460638/105223563-cc4af180-5b10-11eb-8dad-98cb6ae07fba.png">

<img width="769" alt="image" src="https://user-images.githubusercontent.com/3460638/105223623-e1278500-5b10-11eb-974a-d2eeb75b3fbc.png">

Also added a "Copy" menu option to all the values in the detail pane.

<img width="439" alt="image" src="https://user-images.githubusercontent.com/3460638/105224293-d91c1500-5b11-11eb-9343-17e6146422be.png">

There may be a better way to set a single context menu handler for all generic text, but this will do for now.
