### PR TITLE
"Restart Required" text fix

### DIFF
--- a/src/css/_settings-modal.scss
+++ b/src/css/_settings-modal.scss
@@ -52,13 +52,16 @@
 
   .feedback {
     position: absolute;
-    right: 24px;
-    top: -11px;
+    right: 12px;
+    top: 1px;
+    margin: 0;
     @include label-small;
+    line-height: 14px;
     background: $blue;
     color: white;
     padding: 0 6px;
-    border-radius: 3px 3px 0 0;
+    border-radius: 4px;
     animation: fadein 300ms;
+    z-index: 1;
   }
 }


### PR DESCRIPTION
fixes #1364

The restart required text was previously obscured. It now is a little smaller, positioned better, and always above it's file input.

<img width="671" alt="image" src="https://user-images.githubusercontent.com/3460638/105225723-d5898d80-5b13-11eb-8653-ffb45e4586be.png">
