### PR TITLE
Run the search each time the md5 changes

### DIFF
--- a/src/js/components/LogDetails/Md5Panel.tsx
+++ b/src/js/components/LogDetails/Md5Panel.tsx
@@ -32,7 +32,7 @@ export const Md5Panel = ({record}: Props) => {
       .chan(3, (records) => setTx(records))
 
     return abort
-  }, [])
+  }, [logMd5])
 
   function onRightClick(field, record) {
     dispatch(contextMenu(field, record))

--- a/src/js/electron/tron/session.test.ts
+++ b/src/js/electron/tron/session.test.ts
@@ -1,17 +1,19 @@
 import fsExtra from "fs-extra"
 
 import path from "path"
+import os from "os"
 
 import disableLogger from "../../test/helpers/disableLogger"
 import formatSessionState from "./formatSessionState"
 import initTestStore from "../../test/initTestStore"
 import tron from "./"
 
-const file = "tmp/appState.json"
-disableLogger()
+const dir = path.join(os.tmpdir(), "session.test.ts")
+const file = path.join(dir, "appState.json")
 
-beforeEach(() => fsExtra.ensureDir("tmp"))
-afterEach(() => fsExtra.remove("tmp"))
+disableLogger()
+beforeEach(() => fsExtra.ensureDir(dir))
+afterEach(() => fsExtra.remove(dir))
 
 test("session loading with migrations", async () => {
   const state = initTestStore().getState()

--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -1,5 +1,4 @@
 import {createZealotMock} from "zealot"
-import fsExtra from "fs-extra"
 
 import Clusters from "../state/Clusters"
 import Current from "../state/Current"

--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -33,10 +33,6 @@ beforeEach(() => {
   store.dispatchAll([Clusters.add(conn), Current.setConnectionId(conn.id)])
 })
 
-afterEach(() => {
-  return fsExtra.remove("tmp")
-})
-
 describe("success case", () => {
   beforeEach(() => {
     zealot.stubStream("pcaps.post", [


### PR DESCRIPTION
fixes #1361 

The md5 correlation search was only being run when the component was mounted. It now will correctly run each time the md5 value changes.

I think the whole detail pane was unmounted and remounted with the "key" attribute. Now it stays mounted and only updates what it needs to. This Md5 component was not updated to account for that.

UPDATE

CI bumped into the bug where the appState.json file is missing in the unit tests. We see this failure occasionally. I've discover that two test files are both competing to delete a top level "tmp" directory. Now, each tests creates its own tmp dir using os.tmpdir(). 

fixes #1295 