### PR TITLE
Disable Mac Tags on Export

### DIFF
--- a/src/js/components/ExportModal.tsx
+++ b/src/js/components/ExportModal.tsx
@@ -54,7 +54,8 @@ const showDialog = (format) => {
     title: `Export Results as ${format.toUpperCase()}`,
     buttonLabel: "Export",
     defaultPath: `results.${format}`,
-    properties: ["createDirectory"]
+    properties: ["createDirectory"],
+    showsTagField: false
   })
 }
 


### PR DESCRIPTION
fixes #1332 

I guess the Mac tags feature doesn't work with the current electron. So I'm disabling here.

https://www.electronjs.org/docs/api/dialog#dialogshowsavedialogbrowserwindow-options

Before
<img width="908" alt="Screen Shot 2021-01-20 at 11 54 52 AM" src="https://user-images.githubusercontent.com/3460638/105227633-65c8d200-5b16-11eb-9dfb-26c9a75e2558.png">

After
<img width="783" alt="Screen Shot 2021-01-20 at 11 54 21 AM" src="https://user-images.githubusercontent.com/3460638/105227658-6b261c80-5b16-11eb-961c-8938402dd41c.png">
