### PR TITLE
Right Click => Copy Fix

### DIFF
--- a/src/css/_field-cell.scss
+++ b/src/css/_field-cell.scss
@@ -1,6 +1,7 @@
 .field-cell {
   @include type-colors;
   cursor: default;
+  user-select: all;
 
   &.time {
     span {


### PR DESCRIPTION
fixes #1375 

Clicking right click then copy in the main viewer will now copy the whole value, instead of just a single word.