### PR TITLE
Upgrade Migration Testing

### DIFF
--- a/bin/generator/migration.js
+++ b/bin/generator/migration.js
@@ -2,6 +2,7 @@ const {camelCase} = require("lodash")
 const moment = require("moment")
 const path = require("path")
 const {write} = require("../utils/file")
+const lastVersion = require("../../package.json").version
 
 async function handleMigration(input) {
   let name = camelCase(input)
@@ -25,14 +26,10 @@ export default function ${name}(state: any) {
 }
 
 function testContents(title, version) {
-  return `
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./${title}"
+  return `import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating ${title}", () => {
-  let {data} = getTestState("v0.0.0 (replace with last version)")
-
-  let next = migrate(data)
+test("migrating ${title}", async () => {
+  const next = await migrate({state: "${lastVersion}", to: "${version}"})
 
   expect(next).toBe("what you'd expect")
 })

--- a/src/js/electron/tron/migrations.test.ts
+++ b/src/js/electron/tron/migrations.test.ts
@@ -1,7 +1,7 @@
 import tron from "./"
 
 test("run", async () => {
-  const migrations = await tron.migrations(0)
+  const migrations = await tron.migrations({from: 0})
   const state = {version: 0, data: undefined}
 
   const newState = migrations.run(state, migrations.getPending())
@@ -10,7 +10,7 @@ test("run", async () => {
 })
 
 test("sorts the migrations by version", async () => {
-  const migrations = await tron.migrations(0)
+  const migrations = await tron.migrations()
   const versions = migrations.getAll().map((m) => m.version)
   const sorted = versions.slice().sort((a, b) => a - b)
 
@@ -18,10 +18,23 @@ test("sorts the migrations by version", async () => {
 })
 
 test("run pending", async () => {
-  const migrations = await tron.migrations(0)
+  const migrations = await tron.migrations()
   const state = {version: 0, data: undefined}
 
   const newState = migrations.runPending(state)
 
   expect(newState.version).toEqual(migrations.getLatestVersion())
+})
+
+test("only migration march migrations", async () => {
+  const migrations = await tron.migrations({
+    from: "202010191355",
+    to: "202011141515"
+  })
+  expect(migrations.getPending()).toHaveLength(3)
+  expect(migrations.getPending().map((m) => m.version)).toEqual([
+    202011060944, // remove cluster status
+    202011141515, // add suricata runner
+    202011141515 // add suricata updater
+  ])
 })

--- a/src/js/electron/tron/migrations.ts
+++ b/src/js/electron/tron/migrations.ts
@@ -24,10 +24,15 @@ export type Migrations = {
   setCurrentVersion: (arg0: number) => void
 }
 
+type Args = {
+  from: string | number
+  to?: string | number
+}
+
 export default async function migrations(
-  currentVersion: string | number = 0
+  args: Args = {from: 0}
 ): Promise<Migrations> {
-  let cv = parseInt(currentVersion.toString())
+  let cv = parseInt(args.from.toString())
 
   const files = await lib.file(dir).contents()
   const migrations = files
@@ -53,7 +58,10 @@ export default async function migrations(
     },
 
     getPending() {
-      return migrations.filter((m: Migration) => m.version > cv)
+      const upperBound = args.to ? parseInt(args.to.toString()) : Infinity
+      return migrations.filter(
+        (m: Migration) => m.version > cv && m.version <= upperBound
+      )
     },
 
     getAll() {

--- a/src/js/state/migrations/202007091803_forceLeftSidebarDefaultOpen.test.ts
+++ b/src/js/state/migrations/202007091803_forceLeftSidebarDefaultOpen.test.ts
@@ -1,10 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202007091803_forceLeftSidebarDefaultOpen"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202007091803_forceLeftSidebarDefaultOpen", () => {
-  const {data} = getTestState("v0.12.0")
-
-  const next = migrate(data)
+test("migrating 202007091803_forceLeftSidebarDefaultOpen", async () => {
+  const next = await migrate({state: "v0.12.0", to: "202007091803"})
 
   const windows = Object.values(next.windows)
 

--- a/src/js/state/migrations/202007140829_defaultColumnHeadersToAuto.test.ts
+++ b/src/js/state/migrations/202007140829_defaultColumnHeadersToAuto.test.ts
@@ -1,10 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202007140829_defaultColumnHeadersToAuto"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202007140829_defaultColumnHeadersToAuto", () => {
-  const {data} = getTestState("v0.12.0")
-
-  const next = migrate(data)
+test("migrating 202007140829_defaultColumnHeadersToAuto", async () => {
+  const next = await migrate({state: "v0.12.0", to: "202007140829"})
 
   // @ts-ignore
   for (const {state} of Object.values(next.windows)) {

--- a/src/js/state/migrations/202007151457_addScrollPosToSearchRecord.test.ts
+++ b/src/js/state/migrations/202007151457_addScrollPosToSearchRecord.test.ts
@@ -1,10 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202007151457_addScrollPosToSearchRecord"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202007151457_addScrollPosToSearchRecord", () => {
-  const {data} = getTestState("v0.13.1")
-
-  const next = migrate(data)
+test("migrating 202007151457_addScrollPosToSearchRecord", async () => {
+  const next = await migrate({state: "v0.13.1", to: "202007151457"})
 
   const windows = Object.values(next.windows)
 

--- a/src/js/state/migrations/202008031645_removeViewerSlice.test.ts
+++ b/src/js/state/migrations/202008031645_removeViewerSlice.test.ts
@@ -1,10 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202008031645_removeViewerSlice"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202008031645_removeViewerSlice", () => {
-  const {data} = getTestState("v0.14.0")
-
-  const next = migrate(data)
+test("migrating 202008031645_removeViewerSlice", async () => {
+  const next = await migrate({state: "v0.14.0", to: "202008031645"})
 
   const windows = Object.values(next.windows)
 

--- a/src/js/state/migrations/202008121645_moveDataFromSearchToCurrent.test.ts
+++ b/src/js/state/migrations/202008121645_moveDataFromSearchToCurrent.test.ts
@@ -1,10 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202008121645_moveDataFromSearchToCurrent"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202008121645_moveDataFromSearchToCurrent", () => {
-  const {data} = getTestState("v0.14.0")
-
-  const next = migrate(data)
+test("migrating 202008121645_moveDataFromSearchToCurrent", async () => {
+  const next = await migrate({state: "v0.14.0", to: "202008121645"})
 
   // @ts-ignore
   const tabs = Object.values(next.windows).flatMap((win) => win.state.tabs.data)

--- a/src/js/state/migrations/202008191031_changeZqdClusterIdToHostPort.test.ts
+++ b/src/js/state/migrations/202008191031_changeZqdClusterIdToHostPort.test.ts
@@ -1,12 +1,9 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202008191031_changeZqdClusterIdToHostPort"
+import {getAllStates, getAllTabs} from "src/js/test/helpers/getTestState"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202008191031_changeZqdClusterIdToHostPort", () => {
-  const {data} = getTestState("v0.15.1")
-
-  const next = migrate(data)
-
-  const windows = Object.values(next.windows)
+test("migrating 202008191031_changeZqdClusterIdToHostPort", async () => {
+  const next = await migrate({state: "v0.15.1", to: "202008191031"})
+  expect.assertions(7)
 
   const oldId = "zqd"
   const newId = "localhost:9867"
@@ -17,16 +14,13 @@ test("migrating 202008191031_changeZqdClusterIdToHostPort", () => {
   }
 
   // @ts-ignore
-  for (const {state} of windows) {
+  for (const state of getAllStates(next)) {
+    if (!state.clusters) continue
     expect(state.clusters[newId]).toEqual(newValue)
     expect(Object.keys(state.clusters)).not.toContain(oldId)
   }
 
-  // @ts-ignore
-  const tabsData = windows.flatMap((win) => win.state.tabs.data)
-
-  for (const td of tabsData) {
-    if (!td.current) continue
-    expect(td.current.workspaceId).toBe(newId)
+  for (const tab of getAllTabs(next)) {
+    expect(tab.current.connectionId).toBe(newId)
   }
 })

--- a/src/js/state/migrations/202008271352_addTargetToSearchRecord.test.ts
+++ b/src/js/state/migrations/202008271352_addTargetToSearchRecord.test.ts
@@ -1,10 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202008271352_addTargetToSearchRecord"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202008271352_addTargetToSearchRecord", () => {
-  const {data} = getTestState("v0.15.1")
-
-  const next = migrate(data)
+test("migrating 202008271352_addTargetToSearchRecord", async () => {
+  const next = await migrate({state: "v0.15.1", to: "202008271352"})
 
   // @ts-ignore
   for (const {state} of Object.values(next.windows)) {

--- a/src/js/state/migrations/202009121941_refactorInvestigations.test.ts
+++ b/src/js/state/migrations/202009121941_refactorInvestigations.test.ts
@@ -1,10 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202009121941_refactorInvestigations"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202009121941_refactorInvestigations", () => {
-  const {data} = getTestState("v0.17.0")
-
-  const next = migrate(data)
+test("migrating 202009121941_refactorInvestigations", async () => {
+  const next = await migrate({state: "v0.17.0", to: "202009121941"})
   const space1 = "sp_1hWwRQKtTnWlkr7w57k91Ofw2Sr"
   const space2 = "sp_1hWwT27GJg9kHqgrVanqvvO5Ke5"
   const space3 = "sp_1hWwTowuLDqnmIE4u5SrYIPq86k"

--- a/src/js/state/migrations/202009231326_removeLogDetails.test.ts
+++ b/src/js/state/migrations/202009231326_removeLogDetails.test.ts
@@ -1,10 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202009231326_removeLogDetails"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202009231326_removeLogDetails", () => {
-  const {data} = getTestState("v0.15.1")
-
-  const next = migrate(data)
+test("migrating 202009231326_removeLogDetails", async () => {
+  const next = await migrate({state: "v0.15.1", to: "202009231326"})
 
   // @ts-ignore
   for (const {state} of Object.values(next.windows)) {

--- a/src/js/state/migrations/202010191355_addConnectionNameDefault.test.ts
+++ b/src/js/state/migrations/202010191355_addConnectionNameDefault.test.ts
@@ -1,10 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202010191355_addConnectionNameDefault"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202010191355_addConnectionNameDefault", () => {
-  const {data} = getTestState("v0.17.0")
-
-  const next = migrate(data)
+test("migrating 202010191355_addConnectionNameDefault", async () => {
+  const next = await migrate({state: "v0.17.0", to: "202010191355"})
 
   const windowState = next.windows["7a2fd651bb"].state
   expect(windowState.clusters["localhost:9867"].name).toBe("localhost:9867")

--- a/src/js/state/migrations/202010191355_addConnectionNameDefault.ts
+++ b/src/js/state/migrations/202010191355_addConnectionNameDefault.ts
@@ -1,11 +1,10 @@
 import {getAllStates} from "../../test/helpers/getTestState"
-import {Workspace} from "../Workspaces/types"
 
 export default function addConnectionNameDefault(state: any) {
   // backfill connection names with id
   for (const s of getAllStates(state)) {
     if (!s.clusters) continue
-    Object.values(s.clusters).forEach((c: Workspace) => {
+    Object.values(s.clusters).forEach((c: any) => {
       c.name = c.id
     })
   }

--- a/src/js/state/migrations/202011060944_removeClustersStatus.test.ts
+++ b/src/js/state/migrations/202011060944_removeClustersStatus.test.ts
@@ -1,9 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202011060944_removeClustersStatus"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202011060944_removeClustersStatus", () => {
-  const {data} = getTestState("v0.17.0")
-  const next = migrate(data)
+test("migrating 202011060944_removeClustersStatus", async () => {
+  const next = await migrate({state: "v0.17.0", to: "202011060944"})
 
   const windows = Object.values(next.windows)
 

--- a/src/js/state/migrations/202011141515_addSuricataRunnerPref.test.ts
+++ b/src/js/state/migrations/202011141515_addSuricataRunnerPref.test.ts
@@ -1,13 +1,10 @@
-import Prefs from "../Prefs"
-import getTestState, {getAllStates} from "../../test/helpers/getTestState"
-import migrate from "./202011141515_addSuricataRunnerPref"
+import {getAllStates} from "src/js/test/helpers/getTestState"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202011141515_addSuricataRunnerPref", () => {
-  const prev = getTestState("v0.17.0")
-
-  const next = migrate(prev)
+test("migrating 202011141515_addSuricataRunnerPref", async () => {
+  const next = await migrate({state: "v0.17.0", to: "202011141515"})
 
   for (const state of getAllStates(next)) {
-    expect(Prefs.getSuricataRunner(state)).toEqual("")
+    expect(state.prefs.suricataRunner).toEqual("")
   }
 })

--- a/src/js/state/migrations/202011141515_addSuricataUpdaterPref.test.ts
+++ b/src/js/state/migrations/202011141515_addSuricataUpdaterPref.test.ts
@@ -1,13 +1,9 @@
-import Prefs from "../Prefs"
-import getTestState, {getAllStates} from "../../test/helpers/getTestState"
-import migrate from "./202011141515_addSuricataUpdaterPref"
+import {migrate} from "src/js/test/helpers/migrate"
+import {getAllStates} from "../../test/helpers/getTestState"
 
-test("migrating 202011141515_addSuricataUpdaterPref", () => {
-  const prev = getTestState("v0.17.0")
-
-  const next = migrate(prev)
-
+test("migrating 202011141515_addSuricataUpdaterPref", async () => {
+  const next = await migrate({state: "v0.17.0", to: "202011141515"})
   for (const state of getAllStates(next)) {
-    expect(Prefs.getSuricataUpdater(state)).toEqual("")
+    expect(state.prefs.suricataRunner).toEqual("")
   }
 })

--- a/src/js/state/migrations/202012011232_sidebarSections.test.ts
+++ b/src/js/state/migrations/202012011232_sidebarSections.test.ts
@@ -1,9 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202012011232_sidebarSections"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202012011232_sidebarSections", () => {
-  const {data} = getTestState("v0.17.0")
-  const next = migrate(data)
+test("migrating 202012011232_sidebarSections", async () => {
+  const next = await migrate({state: "v0.17.0", to: "202012011232"})
 
   const windows = Object.values(next.windows)
   // @ts-ignore

--- a/src/js/state/migrations/202012021127_addQuerySection.test.ts
+++ b/src/js/state/migrations/202012021127_addQuerySection.test.ts
@@ -1,11 +1,7 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202012021127_addQuerySection"
+import {migrate} from "src/js/test/helpers/migrate"
 
-test("migrating 202012021127_addQuerySection", () => {
-  let {data} = getTestState("v0.20.0")
-
-  let next = migrate(data)
-
+test("migrating 202012021127_addQuerySection", async () => {
+  const next = await migrate({state: "v0.20.0", to: "202012021127"})
   const windows = Object.values(next.windows)
   // @ts-ignore
   for (const {state} of windows) {

--- a/src/js/state/migrations/202101051511_initQueryLibrary.test.ts
+++ b/src/js/state/migrations/202101051511_initQueryLibrary.test.ts
@@ -1,10 +1,8 @@
-import getTestState, {getAllStates} from "../../test/helpers/getTestState"
-import migrate from "./202101051511_initQueryLibrary"
+import {migrate} from "src/js/test/helpers/migrate"
+import {getAllStates} from "../../test/helpers/getTestState"
 
-test("migrating 202101051511_initQueryLibrary", () => {
-  let {data} = getTestState("v0.21.1")
-
-  let next = migrate(data)
+test("migrating 202101051511_initQueryLibrary", async () => {
+  const next = await migrate({state: "v0.21.1", to: "202101051511"})
 
   for (const state of getAllStates(next)) {
     expect(state.queries).toBe(undefined)

--- a/src/js/state/migrations/202101151201_addMainView.test.ts
+++ b/src/js/state/migrations/202101151201_addMainView.test.ts
@@ -1,10 +1,8 @@
-import getTestState, {getAllTabs} from "../../test/helpers/getTestState"
-import migrate from "./202101151201_addMainView"
+import {migrate} from "src/js/test/helpers/migrate"
+import {getAllTabs} from "../../test/helpers/getTestState"
 
-test("migrating 202101151201_addMainView", () => {
-  let {data} = getTestState("v0.21.1")
-
-  let next = migrate(data)
+test("migrating 202101151201_addMainView", async () => {
+  const next = await migrate({state: "v0.21.1", to: "202101151201"})
 
   for (const tab of getAllTabs(next)) {
     expect(tab.layout.mainView).toBe("search")

--- a/src/js/state/migrations/202101201109_moveQueriesStateToGlobal.test.ts
+++ b/src/js/state/migrations/202101201109_moveQueriesStateToGlobal.test.ts
@@ -1,18 +1,17 @@
-import getTestState from "../../test/helpers/getTestState"
-import migrate from "./202101201109_moveQueriesStateToGlobal"
+import getTestState from "src/js/test/helpers/getTestState"
+import {migrate} from "src/js/test/helpers/migrate"
+import moveQueriesStateToGlobal from "./202101201109_moveQueriesStateToGlobal"
 
 test("when there are no windows", () => {
   const {data} = getTestState("v0.22.0")
   data.windows = {}
   data.order = []
-  const next = migrate(data)
+  const next = moveQueriesStateToGlobal(data)
   expect(next.globalState.queries).toBe(undefined)
 })
 
-test("migrating 202101201109_moveQueriesStateToGlobal", () => {
-  let {data} = getTestState("v0.22.0")
-
-  let next = migrate(data)
+test("migrating 202101201109_moveQueriesStateToGlobal", async () => {
+  const next = await migrate({state: "v0.22.0", to: "202101201109"})
 
   // default/initial brim queries
   const expectedQueries = {

--- a/src/js/state/migrations/202101210823_renameToWorkspace.test.ts
+++ b/src/js/state/migrations/202101210823_renameToWorkspace.test.ts
@@ -1,11 +1,9 @@
-import getTestState, {getAllStates} from "../../test/helpers/getTestState"
-import migrate from "./202101210823_renameToWorkspace"
+import {migrate} from "src/js/test/helpers/migrate"
+import {getAllStates} from "../../test/helpers/getTestState"
 
-test("migrating 202101210823_renameToWorkspace", () => {
+test("migrating 202101210823_renameToWorkspace", async () => {
   expect.assertions(16)
-  let {data} = getTestState("v0.21.1")
-
-  let next = migrate(data)
+  const next = await migrate({state: "v0.21.1", to: "202101210823"})
 
   expect(next.globalState.workspaces).toBeDefined()
   Object.values(next.globalState.workspaces).forEach((c: any) => {

--- a/src/js/test/helpers/migrate.ts
+++ b/src/js/test/helpers/migrate.ts
@@ -1,0 +1,12 @@
+import tron from "src/js/electron/tron"
+import getTestState from "./getTestState"
+
+export async function migrate({state: name, to}) {
+  const state = getTestState(name)
+  const migrator = await tron.migrations({from: state.version, to})
+  const nextState = migrator.runPending(state)
+  if (nextState.version.toString() !== to.toString()) {
+    throw new Error(`Was not able to migrate to: ${to}`)
+  }
+  return nextState.data
+}

--- a/src/js/test/helpers/migrate.ts
+++ b/src/js/test/helpers/migrate.ts
@@ -1,7 +1,7 @@
 import tron from "src/js/electron/tron"
 import getTestState from "./getTestState"
 
-export async function migrate({state: name, to}) {
+export async function migrate({state: name, to}): Promise<any> {
   const state = getTestState(name)
   const migrator = await tron.migrations({from: state.version, to})
   const nextState = migrator.runPending(state)


### PR DESCRIPTION
While reviewing the diff between the last release and master, I found a migration test that should have failed but was passing. The reason was because this particular migration was dependent on the previous migration and tests only exercise a single migration function at a time, so they did not catch the bug. 

In reality, a "batch" of migrations get applied at a time. So I've added a helper function in the migration tests.

```js
const nextState = await migrate({state: "v0.22.0", to: "20210101000"})
```

This function will read the test state file called "v0.22.0.json", look at the version attached that that state, then run all migrations between the version and the "to:" parameter, returning the migrated state.

This is much closer to the way migrations are run in production and should add to our migration confidence.

I updated all the tests from version v0.7.0 onward. Tests older than that rely on a different versioning system and it seems not worth the cost of accommodating it.