### PR TITLE
Account for No Windows when Migrating Queries

### DIFF
--- a/src/js/electron/tron/migrations.ts
+++ b/src/js/electron/tron/migrations.ts
@@ -42,7 +42,7 @@ export default async function migrations(
 
     run(state: VersionedData, migrations: Migration[]) {
       for (const {version, migrate} of migrations) {
-        state.data = migrate(state.data)
+        state.data = state.data ? migrate(state.data) : undefined
         state.version = version
       }
       return state

--- a/src/js/state/migrations/202101201109_moveQueriesStateToGlobal.test.ts
+++ b/src/js/state/migrations/202101201109_moveQueriesStateToGlobal.test.ts
@@ -1,6 +1,14 @@
 import getTestState from "../../test/helpers/getTestState"
 import migrate from "./202101201109_moveQueriesStateToGlobal"
 
+test("when there are no windows", () => {
+  const {data} = getTestState("v0.22.0")
+  data.windows = {}
+  data.order = []
+  const next = migrate(data)
+  expect(next.globalState.queries).toBe(undefined)
+})
+
 test("migrating 202101201109_moveQueriesStateToGlobal", () => {
   let {data} = getTestState("v0.22.0")
 

--- a/src/js/state/migrations/202101201109_moveQueriesStateToGlobal.ts
+++ b/src/js/state/migrations/202101201109_moveQueriesStateToGlobal.ts
@@ -4,6 +4,13 @@ export default function moveQueriesStateToGlobal(state: any) {
   // Migrate state here
   const mergedQueryMap = {}
   const mergedQueryItems = []
+  const windows = Object.values(state.windows)
+
+  if (windows.length === 0) {
+    state.globalState.queries = undefined
+    return state
+  }
+
   for (const s of getAllStates(state)) {
     if (!s.queries) continue
     s.queries.items.forEach((q) => {


### PR DESCRIPTION
fixes #1386

This edit's an existing migration. Since migrations don't go backwards, you'll need to clear you app state, open v0.22.0, then save the state with no windows, then upgrade to v0.23.0 and see that the query library is populated.