### PR TITLE
Notify slack on master branch ci failure

### DIFF
--- a/.github/workflows/notify-master-failure.yml
+++ b/.github/workflows/notify-master-failure.yml
@@ -1,0 +1,25 @@
+name: 'Notify master failure'
+
+on:
+  workflow_run:
+    branches: 
+      - master
+    workflows:
+      - '**'
+    types:
+      - completed
+
+jobs:
+  slackNotify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Brim HQ of failure on master
+        uses: tiloio/slack-webhook-action@v1.1.2
+        with:
+          slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_TEST }}
+          slack_json: |
+            {
+              "username": "github-actions",
+              "text": "brimsec/brim workflow \"${{ github.event.workflow_run.name }}\" failed on master.\n${{ github.event.workflow_run.html_url }}"
+            }  


### PR DESCRIPTION
Add job that will notify HQ Slack should a failure occur on brim master.