### PR TITLE
Provide the correct data to the sidebar sections

### DIFF
--- a/src/pkg/sectional/components/Sectional.tsx
+++ b/src/pkg/sectional/components/Sectional.tsx
@@ -60,7 +60,7 @@ export function Sectional({sections, children, onChange}: Props) {
 
   return (
     <div ref={ref} style={{width: "100%", height: "100%"}}>
-      {sections.map((data, index) =>
+      {ctl.map((data, index) =>
         children(data, {
           style: getStyle(index),
           toggleProps: {


### PR DESCRIPTION
Fixes #1384 

They previously were not providing the default isOpen value. They were using the data passed in which omitted the isOpen value.