### PR TITLE
Don't burn the toast 🔥 🍞 

### DIFF
--- a/src/js/components/ExportModal.tsx
+++ b/src/js/components/ExportModal.tsx
@@ -14,6 +14,7 @@ import {SearchFormat} from "../../../zealot"
 import InputLabel from "./common/forms/InputLabel"
 import {defaultModalButton} from "../test/locators"
 import {toast} from "react-hot-toast"
+import {AppDispatch} from "../state/types"
 
 const RadioButtons = styled.div`
   display: flex;
@@ -60,22 +61,32 @@ const showDialog = (format) => {
 }
 
 const ExportModal = ({onClose}) => {
-  const dispatch = useDispatch()
+  const dispatch = useDispatch<AppDispatch>()
   const [format, setFormat] = useState("zng")
 
   const onExport = async () => {
     const {canceled, filePath} = await showDialog(format)
     if (canceled) return
 
-    // do not wait to close modal
     toast.promise(
-      Promise.resolve(
-        dispatch(exportResults(filePath, format as SearchFormat))
-      ),
+      dispatch(exportResults(filePath, format as SearchFormat)),
       {
         loading: "Exporting...",
         success: "Export Complete",
         error: "Error Exporting"
+      },
+      {
+        loading: {
+          // setTimeout's maximum value is a 32-bit int, so we explicitly specify here
+          // also, once https://github.com/timolins/react-hot-toast/pull/37 merges, we can set this to -1
+          duration: 2 ** 31 - 1
+        },
+        success: {
+          duration: 3000
+        },
+        error: {
+          duration: 5000
+        }
       }
     )
 


### PR DESCRIPTION
fixes #1346 

The `react-hot-toast` component we use to indicate the loading state during export has a default timeout of 30s, after which it will dismiss itself. This comes off as an indication to the user that the export is complete even though it may not be (and then when it finally does complete the "Export Complete" toast happens but the user would not expect it since the loading was already dismissed). Allowing the toast to persist indefinitely is not yet a feature of the toast lib, though this happened to have been requested a couple of days ago and there is already a PR to enable it in their pipeline (see https://github.com/timolins/react-hot-toast/pull/37 and https://github.com/timolins/react-hot-toast/issues/36). In the meantime, we can set the duration to int32 max which is the highest value that setTimeout will accept. `Number.MAX_VALUE`, and `Number.MAX_SAFE_INTEGER` could both be too large and overflow, so we define it explicitly now.

I also added another second to each of the default values for the success and error cases, since I thought the defaults were a tad short for my taste. 

Signed-off-by: Mason Fish <mason@looky.cloud>