### PR TITLE
Upgrade eletron to 11.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9298,9 +9298,9 @@
       "dev": true
     },
     "electron": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.4.tgz",
-      "integrity": "sha512-5wiiGsif8jd1lS3Qhe9j8oQvUMnoWCvqBwYzzn+BGXGDq8aN8oTdM+j/2NY35Ktt3JrJdjKWcu9b7pDo8kNjbw==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-11.2.2.tgz",
+      "integrity": "sha512-+OitkBrnCFwOF5LXAeNnfIJDKhdBm77jboc16WCIpDsCyT+JpGsKK4y6o30nRZq3zC+wZggUm5w6Ujw5n76CGg==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -9309,9 +9309,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.70",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.70.tgz",
-          "integrity": "sha512-i5y7HTbvhonZQE+GnUM2rz1Bi8QkzxdQmEv1LKOv4nWyaQk/gdeiTApuQR3PDJHX7WomAbpx2wlWSEpxXGZ/UQ==",
+          "version": "12.19.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
+          "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5442,6 +5442,15 @@
         "@types/node": "*"
       }
     },
+    "@types/puppeteer-core": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-5.4.0.tgz",
+      "integrity": "sha512-yqRPuv4EFcSkTyin6Yy17pN6Qz2vwVwTCJIDYMXbE3j8vTPhv0nCQlZOl5xfi0WHUkqvQsjAR8hAfjeMCoetwg==",
+      "dev": true,
+      "requires": {
+        "@types/puppeteer": "*"
+      }
+    },
     "@types/react": {
       "version": "16.9.49",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
@@ -8595,6 +8604,12 @@
         "nth-check": "~1.0.1"
       }
     },
+    "css-shorthand-properties": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
+      "integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==",
+      "dev": true
+    },
     "css-to-react-native": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
@@ -9317,9 +9332,9 @@
       }
     },
     "electron-chromedriver": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-10.0.0.tgz",
-      "integrity": "sha512-6jvMnQNHsIFTnvSn8kYQk8dRXFjqtp7E4QVIP4Cc6xR7SM8QI0/EmAqfuysd8CGJOpa8wFkEYxCT2dbHGp3bDw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-11.0.0.tgz",
+      "integrity": "sha512-ayMJPBbB4puU0SqYbcD9XvF3/7GWIhqKE1n5lG2/GQPRnrZkNoPIilsrS0rQcD50Xhl69KowatDqLhUznZWtbA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.12.2",
@@ -9327,9 +9342,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -22346,16 +22361,285 @@
       "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
     },
     "spectron": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/spectron/-/spectron-12.0.0.tgz",
-      "integrity": "sha512-ZyDFS7I+4dWa/YXSQ/trbC4s1Rd0Ks5oi4MQ6XSJHULPasJhx5q2bM93Ae7BNUvwrGrbhjk7O6f14JwqJimLyA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/spectron/-/spectron-13.0.0.tgz",
+      "integrity": "sha512-7RPa6Fp8gqL4V0DubobnqIRFHIijkpjg6MFHcJlxoerWyvLJd+cQvOh756XpB1Z/U3DyA9jPcS+HE2PvYRP5+A==",
       "dev": true,
       "requires": {
         "dev-null": "^0.1.1",
-        "electron-chromedriver": "^10.0.0",
-        "request": "^2.87.0",
-        "split": "^1.0.0",
-        "webdriverio": "^6.1.20"
+        "electron-chromedriver": "^11.0.0",
+        "request": "^2.88.2",
+        "split": "^1.0.1",
+        "webdriverio": "^6.9.1"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
+          "dev": true
+        },
+        "@szmarczak/http-timer": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+          "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+          "dev": true,
+          "requires": {
+            "defer-to-connect": "^2.0.0"
+          }
+        },
+        "@wdio/config": {
+          "version": "6.12.1",
+          "resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.12.1.tgz",
+          "integrity": "sha512-V5hTIW5FNlZ1W33smHF4Rd5BKjGW2KeYhyXDQfXHjqLCeRiirZ9fABCo9plaVQDnwWSUMWYaAaIAifV82/oJCQ==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "6.10.10",
+            "deepmerge": "^4.0.0",
+            "glob": "^7.1.2"
+          }
+        },
+        "@wdio/logger": {
+          "version": "6.10.10",
+          "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.10.tgz",
+          "integrity": "sha512-2nh0hJz9HeZE0VIEMI+oPgjr/Q37ohrR9iqsl7f7GW5ik+PnKYCT9Eab5mR1GNMG60askwbskgGC1S9ygtvrSw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "loglevel": "^1.6.0",
+            "loglevel-plugin-prefix": "^0.8.4",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@wdio/protocols": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.12.0.tgz",
+          "integrity": "sha512-UhTBZxClCsM3VjaiDp4DoSCnsa7D1QNmI2kqEBfIpyNkT3GcZhJb7L+nL0fTkzCwi7+/uLastb3/aOwH99gt0A==",
+          "dev": true
+        },
+        "@wdio/repl": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.11.0.tgz",
+          "integrity": "sha512-FxrFKiTkFyELNGGVEH1uijyvNY7lUpmff6x+FGskFGZB4uSRs0rxkOMaEjxnxw7QP1zgQKr2xC7GyO03gIGRGg==",
+          "dev": true,
+          "requires": {
+            "@wdio/utils": "6.11.0"
+          }
+        },
+        "@wdio/utils": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.11.0.tgz",
+          "integrity": "sha512-vf0sOQzd28WbI26d6/ORrQ4XKWTzSlWLm9W/K/eJO0NASKPEzR+E+Q2kaa+MJ4FKXUpjbt+Lxfo+C26TzBk7tg==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "6.10.10"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "cacheable-lookup": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+          "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+          "dev": true
+        },
+        "decompress-response": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "defer-to-connect": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+          "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+          "dev": true
+        },
+        "devtools": {
+          "version": "6.12.1",
+          "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.12.1.tgz",
+          "integrity": "sha512-JyG46suEiZmld7/UVeogkCWM0zYGt+2ML/TI+SkEp+bTv9cs46cDb0pKF3glYZJA7wVVL2gC07Ic0iCxyJEnCQ==",
+          "dev": true,
+          "requires": {
+            "@wdio/config": "6.12.1",
+            "@wdio/logger": "6.10.10",
+            "@wdio/protocols": "6.12.0",
+            "@wdio/utils": "6.11.0",
+            "chrome-launcher": "^0.13.1",
+            "edge-paths": "^2.1.0",
+            "puppeteer-core": "^5.1.0",
+            "ua-parser-js": "^0.7.21",
+            "uuid": "^8.0.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "dev": true
+            }
+          }
+        },
+        "got": {
+          "version": "11.8.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
+          "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/is": "^4.0.0",
+            "@szmarczak/http-timer": "^4.0.5",
+            "@types/cacheable-request": "^6.0.1",
+            "@types/responselike": "^1.0.0",
+            "cacheable-lookup": "^5.0.3",
+            "cacheable-request": "^7.0.1",
+            "decompress-response": "^6.0.0",
+            "http2-wrapper": "^1.0.0-beta.5.2",
+            "lowercase-keys": "^2.0.0",
+            "p-cancelable": "^2.0.0",
+            "responselike": "^2.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "dev": true
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "responselike": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+          "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+          "dev": true,
+          "requires": {
+            "lowercase-keys": "^2.0.0"
+          }
+        },
+        "rgb2hex": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
+          "integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
+          "dev": true
+        },
+        "serialize-error": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.0.1.tgz",
+          "integrity": "sha512-r5o60rWFS+8/b49DNAbB+GXZA0SpDpuWE758JxDKgRTga05r3U5lwyksE91dYKDhXSmnu36RALj615E6Aj5pSg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        },
+        "webdriver": {
+          "version": "6.12.1",
+          "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.12.1.tgz",
+          "integrity": "sha512-3rZgAj9o2XHp16FDTzvUYaHelPMSPbO1TpLIMUT06DfdZjNYIzZiItpIb/NbQDTPmNhzd9cuGmdI56WFBGY2BA==",
+          "dev": true,
+          "requires": {
+            "@wdio/config": "6.12.1",
+            "@wdio/logger": "6.10.10",
+            "@wdio/protocols": "6.12.0",
+            "@wdio/utils": "6.11.0",
+            "got": "^11.0.2",
+            "lodash.merge": "^4.6.1"
+          }
+        },
+        "webdriverio": {
+          "version": "6.12.1",
+          "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.12.1.tgz",
+          "integrity": "sha512-Nx7ge0vTWHVIRUbZCT+IuMwB5Q0Q5nLlYdgnmmJviUKLuc3XtaEBkYPTbhHWHgSBXsPZMIc023vZKNkn+6iyeQ==",
+          "dev": true,
+          "requires": {
+            "@types/puppeteer-core": "^5.4.0",
+            "@wdio/config": "6.12.1",
+            "@wdio/logger": "6.10.10",
+            "@wdio/repl": "6.11.0",
+            "@wdio/utils": "6.11.0",
+            "archiver": "^5.0.0",
+            "atob": "^2.1.2",
+            "css-shorthand-properties": "^1.1.1",
+            "css-value": "^0.0.1",
+            "devtools": "6.12.1",
+            "fs-extra": "^9.0.1",
+            "get-port": "^5.1.1",
+            "grapheme-splitter": "^1.0.2",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.isobject": "^3.0.2",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.zip": "^4.2.0",
+            "minimatch": "^3.0.4",
+            "puppeteer-core": "^5.1.0",
+            "resq": "^1.9.1",
+            "rgb2hex": "0.2.3",
+            "serialize-error": "^8.0.0",
+            "webdriver": "6.12.1"
+          }
+        }
       }
     },
     "split": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",
-    "electron": "^10.1.4",
+    "electron": "^11.2.1",
     "electron-installer-dmg": "^3.0.0",
     "electron-notarize": "^0.2.1",
     "electron-packager": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.28.1",
     "set-tz": "^0.2.0",
-    "spectron": "^12.0.0",
+    "spectron": "^13.0.0",
     "sprintf-js": "^1.1.2",
     "tmp": "^0.1.0",
     "typescript": "^4.0.2",


### PR DESCRIPTION
The React DevTools are broken in version 8 - 11. The fix is in electron master. This helps us get up to speed when the fix is in.