### PR TITLE
Remove Security Summary From State Until Shipped

### DIFF
--- a/ppl/summary/summary.tsx
+++ b/ppl/summary/summary.tsx
@@ -1,9 +1,6 @@
-import React, {useMemo} from "react"
-import {useDispatch, useSelector} from "react-redux"
-import Boards from "src/js/state/Boards"
-import Tiles from "src/js/state/Tiles"
+import React from "react"
 import styled from "styled-components"
-import updateTileLayout from "./flows/update-tile-layout"
+import {initialTiles} from "./flows/initial-state"
 import Grid from "./grid"
 import Tile from "./tile"
 
@@ -60,19 +57,14 @@ const SummaryUI = ({title, tiles, onLayoutChange}) => {
 }
 
 export default function Summary() {
-  const dispatch = useDispatch()
-  const board = useSelector(Boards.all)[0]
-  const allTiles = useSelector(Tiles.entities)
-  const tiles = useMemo(() => {
-    return board.tiles.map((id) => allTiles[id])
-  }, [board.tiles, allTiles])
-  const onLayoutChange = (layout) => {
-    dispatch(updateTileLayout(layout))
+  const tiles = initialTiles
+  const onLayoutChange = (_layout) => {
+    /* Will do later */
   }
 
   return (
     <SummaryUI
-      title={board.title}
+      title="Security Summary"
       tiles={tiles}
       onLayoutChange={onLayoutChange}
     />

--- a/src/js/state/Boards/index.ts
+++ b/src/js/state/Boards/index.ts
@@ -6,6 +6,7 @@ export type Board = {id: string; title: string; tiles: string[]}
 export type BoardsState = ReturnType<typeof slice.reducer>
 
 const adapter = createEntityAdapter<Board>()
+// @ts-ignore Remove this once the security summary is merged
 const selectors = adapter.getSelectors((state: State) => state.boards)
 const slice = createSlice({
   name: "boards",

--- a/src/js/state/Boards/test.ts
+++ b/src/js/state/Boards/test.ts
@@ -8,7 +8,9 @@ beforeEach(() => {
   s = (f) => f(store.getState())
 })
 
-test("initial state", () => {
+/* Skipping tests until security summary is shipped */
+
+test.skip("initial state", () => {
   expect(s(Boards.all)).toHaveLength(1)
   expect(s(Boards.all)[0]).toEqual(
     expect.objectContaining({
@@ -17,7 +19,7 @@ test("initial state", () => {
   )
 })
 
-test("adding a board", () => {
+test.skip("adding a board", () => {
   d(Boards.create({id: "1", title: "hi", tiles: []}))
 
   expect(s(Boards.get("1"))).toEqual({
@@ -27,13 +29,13 @@ test("adding a board", () => {
   })
 })
 
-test("removing a board", () => {
+test.skip("removing a board", () => {
   d(Boards.create({id: "1", title: "hi", tiles: []}))
   d(Boards.delete("1"))
   expect(s(Boards.get("1"))).toBe(undefined)
 })
 
-test("add a tile id", () => {
+test.skip("add a tile id", () => {
   d(Boards.create({id: "1", title: "hi", tiles: []}))
   d(Boards.appendTile({id: "1", tileId: "100"}))
 

--- a/src/js/state/Tiles/index.ts
+++ b/src/js/state/Tiles/index.ts
@@ -24,6 +24,7 @@ export type Tile = {
 }
 
 const adapter = createEntityAdapter<Tile>()
+// @ts-ignore Remove this once the security summary is merged
 const selectors = adapter.getSelectors((s: State) => s.tiles)
 const slice = createSlice({
   name: "tiles",

--- a/src/js/state/Tiles/test.ts
+++ b/src/js/state/Tiles/test.ts
@@ -8,12 +8,14 @@ beforeEach(() => {
   s = (f) => f(store.getState())
 })
 
-test("initial state", () => {
+/* Skipping tests until security summary is shipped */
+
+test.skip("initial state", () => {
   const tiles = s(Tiles.all)
   expect(tiles.length).toBe(4)
 })
 
-test("Adding a tile", () => {
+test.skip("Adding a tile", () => {
   const tile: Tile = {
     id: "1",
     title: "Count by Path",
@@ -25,7 +27,7 @@ test("Adding a tile", () => {
   expect(s(Tiles.get(tile.id))).toEqual(tile)
 })
 
-test("Removing a tile", () => {
+test.skip("Removing a tile", () => {
   const tile: Tile = {
     id: "1",
     title: "Count by Path",

--- a/src/js/state/globalReducer.ts
+++ b/src/js/state/globalReducer.ts
@@ -8,24 +8,17 @@ import Queries from "./Queries"
 import {QueriesState} from "./Queries/types"
 import Workspaces from "./Workspaces"
 import {WorkspacesState} from "./Workspaces/types"
-import Boards from "./Boards"
-import {BoardsState} from "./Boards"
-import Tiles, {TilesState} from "./Tiles"
 
 export type GlobalState = {
   workspaces: WorkspacesState
   investigation: InvestigationState
   prefs: PrefsState
   queries: QueriesState
-  boards: BoardsState
-  tiles: TilesState
 }
 
 export default combineReducers<any, any>({
   workspaces: Workspaces.reducer,
   investigation: Investigation.reducer,
   prefs: Prefs.reducer,
-  queries: Queries.reducer,
-  boards: Boards.reducer,
-  tiles: Tiles.reducer
+  queries: Queries.reducer
 })

--- a/src/js/state/rootReducer.ts
+++ b/src/js/state/rootReducer.ts
@@ -15,12 +15,8 @@ import Queries from "./Queries"
 import SystemTest from "./SystemTest"
 import Feature from "./Feature"
 import WorkspaceStatuses from "./WorkspaceStatuses"
-import Boards from "./Boards"
-import Tiles from "./Tiles"
 
 export default combineReducers<any, any>({
-  tiles: Tiles.reducer,
-  boards: Boards.reducer,
   errors: Errors.reducer,
   workspaces: Workspaces.reducer,
   modal: Modal.reducer,

--- a/src/js/state/types.ts
+++ b/src/js/state/types.ts
@@ -16,8 +16,6 @@ import {SystemTestState} from "./SystemTest"
 import {FeatureState} from "./Feature"
 import {WorkspacesState} from "./Workspaces/types"
 import {WorkspaceStatusesState} from "./WorkspaceStatuses/types"
-import {BoardsState} from "./Boards"
-import {TilesState} from "./Tiles"
 
 export type GetState = () => State
 export type ThunkExtraArg = {
@@ -34,8 +32,6 @@ export type Dispatch = AppDispatch
 
 export type DispatchProps = {dispatch: Dispatch}
 export type State = {
-  tiles: TilesState
-  boards: BoardsState
   handlers: HandlersState
   workspaces: WorkspacesState
   errors: ErrorsState


### PR DESCRIPTION
Before we release, I'm backing out some changes we made to the state for the unfinished security summary feature. I'd rather avoid a migration when we ship the security summary.

This is all hidden behind a feature flag which still works. The tiles are now effectively hard-coded for the time being.

When the security summary ships:

- [ ] Remove the @ts-ignore comments in the Boards/test.ts and the Tiles/test.ts
- [ ] Remove the skip prefix from all the tests
- [ ] Add the reducers to the rootReducer
- [ ] Add the reducers to the globalReducer