### PR TITLE
adjust ingest warning message

### DIFF
--- a/src/js/components/IngestWarningsModal.tsx
+++ b/src/js/components/IngestWarningsModal.tsx
@@ -30,14 +30,19 @@ export default function IngestWarningsModal({onClose}) {
       {warnings.length ? (
         <>
           <p>
+            {
+              "The data you've attempt to import was not recognized as any supported packet capture or log format. The errors returned by each log parser:"
+            }
+          </p>
+          <Scrollable>
+            <Pre>{warnings.join("\n")}</Pre>
+          </Scrollable>
+          <p>
             If you are trying to import JSON logs, please review the{" "}
             <Link href={JSON_TYPE_CONFIG_DOCS}>
               JSON type configuration docs.
             </Link>
           </p>
-          <Scrollable>
-            <Pre>{warnings.join("\n")}</Pre>
-          </Scrollable>
         </>
       ) : (
         <p>Warnings cleared.</p>

--- a/src/js/flows/deletePartialSpaces.ts
+++ b/src/js/flows/deletePartialSpaces.ts
@@ -10,11 +10,6 @@ export default (): Thunk<Promise<any[]>> => (dispatch, getState) => {
 
   const zealot = dispatch(getZealot())
   const spaceIds = Handlers.getIngestSpaceIds(getState())
-
-  // if current space id is among ingesting spaces, clear it
-  const currentSpaceId = Current.getSpaceId(getState())
-  if (spaceIds.includes(currentSpaceId)) dispatch(Current.setSpaceId(null))
-
   return Promise.all(
     spaceIds.map((id) => {
       return zealot.spaces.delete(id).catch((e) => {

--- a/src/js/flows/deletePartialSpaces.ts
+++ b/src/js/flows/deletePartialSpaces.ts
@@ -10,6 +10,11 @@ export default (): Thunk<Promise<any[]>> => (dispatch, getState) => {
 
   const zealot = dispatch(getZealot())
   const spaceIds = Handlers.getIngestSpaceIds(getState())
+
+  // if current space id is among ingesting spaces, clear it
+  const currentSpaceId = Current.getSpaceId(getState())
+  if (spaceIds.includes(currentSpaceId)) dispatch(Current.setSpaceId(null))
+
   return Promise.all(
     spaceIds.map((id) => {
       return zealot.spaces.delete(id).catch((e) => {


### PR DESCRIPTION
fixes #1070 

adjusts the ingest warning message and order, per the ticket's suggestion

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/14865533/108251945-e9bdac00-710c-11eb-8b9d-77acdd5a1512.png">
