### PR TITLE
clear current spaceId if partial deleting

### DIFF
--- a/src/js/flows/deletePartialSpaces.test.ts
+++ b/src/js/flows/deletePartialSpaces.test.ts
@@ -1,0 +1,50 @@
+import {createZealotMock} from "zealot"
+
+import Workspaces from "../state/Workspaces"
+import Current from "../state/Current"
+import fixtures from "../test/fixtures"
+import deletePartialSpaces from "./deletePartialSpaces"
+import initTestStore from "../test/initTestStore"
+import Handlers from "../state/Handlers"
+
+const testSpaceId1 = "testSpaceId1"
+const testSpaceId2 = "testSpaceId2"
+
+let store, zealot
+beforeEach(() => {
+  zealot = createZealotMock()
+  const ws = fixtures("workspace1")
+  store = initTestStore(zealot.zealot)
+  store.dispatch(Workspaces.add(ws))
+  store.dispatch(Current.setWorkspaceId(ws.id))
+})
+
+test("reset current space id if mid-ingest", async () => {
+  zealot.stubPromise("spaces.delete", true)
+  store.dispatch(
+    Handlers.register("id-1", {type: "INGEST", spaceId: testSpaceId1})
+  )
+  zealot.stubPromise("spaces.delete", true)
+  store.dispatch(
+    Handlers.register("id-2", {type: "INGEST", spaceId: testSpaceId2})
+  )
+  store.dispatch(Current.setSpaceId(testSpaceId1))
+
+  await store.dispatch(deletePartialSpaces())
+
+  expect(zealot.calls("spaces.delete")).toHaveLength(2)
+  expect(Current.getSpaceId(store.getState())).toEqual(null)
+})
+
+test("dont reset current id if not mid-ingest", async () => {
+  zealot.stubPromise("spaces.delete", true)
+  store.dispatch(
+    Handlers.register("id-2", {type: "INGEST", spaceId: testSpaceId2})
+  )
+  store.dispatch(Current.setSpaceId(testSpaceId1))
+
+  await store.dispatch(deletePartialSpaces())
+
+  expect(zealot.calls("spaces.delete")).toHaveLength(1)
+  expect(Current.getSpaceId(store.getState())).toEqual(testSpaceId1)
+})

--- a/src/js/flows/deletePartialSpaces.ts
+++ b/src/js/flows/deletePartialSpaces.ts
@@ -10,6 +10,11 @@ export default (): Thunk<Promise<any[]>> => (dispatch, getState) => {
 
   const zealot = dispatch(getZealot())
   const spaceIds = Handlers.getIngestSpaceIds(getState())
+
+  // if current space id is among ingesting spaces, clear it
+  const currentSpaceId = Current.getSpaceId(getState())
+  if (spaceIds.includes(currentSpaceId)) dispatch(Current.setSpaceId(null))
+
   return Promise.all(
     spaceIds.map((id) => {
       return zealot.spaces.delete(id).catch((e) => {


### PR DESCRIPTION
fixes #1337 (th3 m05t l337 t1ck3t 3v3r)

When closing brim and deleting partial spaces, check if the current spaceId is among those being cleaned up, if so then clear it's current spaceId.

Signed-off-by: Mason Fish <mason@looky.cloud>