### PR TITLE
Global Dispatch Design Update

### DIFF
--- a/ppl/summary/flows/update-tile-layout.ts
+++ b/ppl/summary/flows/update-tile-layout.ts
@@ -1,9 +1,9 @@
 import Tiles from "src/js/state/Tiles"
 
-export default (layout) => (_d, _gs, {globalDispatch}) => {
+export default (layout) => (_d, _gs, {dispatch}) => {
   const updates = layout.map(({x, y, h, w, i}) => ({
     id: i,
     changes: {layout: {x, y, h, w}}
   }))
-  globalDispatch(Tiles.updateMany(updates))
+  dispatch(Tiles.updateMany(updates))
 }

--- a/src/js/components/FilterTree.tsx
+++ b/src/js/components/FilterTree.tsx
@@ -4,7 +4,6 @@ import React from "react"
 import classNames from "classnames"
 
 import {createInvestigationTree, InvestigationNode} from "./FilterTree/helpers"
-import {globalDispatch} from "../state/GlobalContext"
 import {submitSearch} from "../flows/submitSearch/mod"
 import BookIcon from "../icons/BookSvgIcon"
 import Current from "../state/Current"
@@ -70,9 +69,7 @@ function NodeRow({node, i, workspaceId, spaceId}: Props) {
         const multiTs = node
           .all(() => true)
           .map((node) => node.model.finding.ts)
-        globalDispatch(
-          Investigation.deleteFindingByTs(workspaceId, spaceId, multiTs)
-        )
+        dispatch(Investigation.deleteFindingByTs(workspaceId, spaceId, multiTs))
       }
     },
     {type: "separator"},
@@ -88,7 +85,7 @@ function NodeRow({node, i, workspaceId, spaceId}: Props) {
           })
           .then(({response}) => {
             if (response === 0)
-              globalDispatch(
+              dispatch(
                 Investigation.clearSpaceInvestigation(workspaceId, spaceId)
               )
           })

--- a/src/js/components/IngestWarningsModal.tsx
+++ b/src/js/components/IngestWarningsModal.tsx
@@ -1,8 +1,7 @@
-import {useSelector} from "react-redux"
+import {useDispatch, useSelector} from "react-redux"
 import React from "react"
 
 import {JSON_TYPE_CONFIG_DOCS} from "./Preferences/JSONTypeConfig"
-import {globalDispatch} from "../state/GlobalContext"
 import Current from "../state/Current"
 import Link from "./common/Link"
 import Spaces from "../state/Spaces"
@@ -18,11 +17,12 @@ import {
 import ToolbarButton from "../../../app/toolbar/button"
 
 export default function IngestWarningsModal({onClose}) {
+  const dispatch = useDispatch()
   useEnterKey(onClose)
   const id = useSelector(Current.getWorkspaceId)
   const spaceId = useSelector(Current.getSpaceId)
   const warnings = useSelector(Spaces.getIngestWarnings(id, spaceId))
-  const onClear = () => globalDispatch(Spaces.clearIngestWarnings(id, spaceId))
+  const onClear = () => dispatch(Spaces.clearIngestWarnings(id, spaceId))
 
   return (
     <Content width={800}>

--- a/src/js/components/Investigation/FindingCard.tsx
+++ b/src/js/components/Investigation/FindingCard.tsx
@@ -4,7 +4,6 @@ import classNames from "classnames"
 import styled from "styled-components"
 
 import {Finding} from "../../state/Investigation/types"
-import {globalDispatch} from "../../state/GlobalContext"
 import {submitSearch} from "../../flows/submitSearch/mod"
 import FindingProgram from "./FindingProgram"
 import Investigation from "../../state/Investigation"
@@ -40,7 +39,7 @@ export default React.memo<Props>(function FindingCard({
     {
       label: "Delete",
       click: () =>
-        globalDispatch(
+        dispatch(
           Investigation.deleteFindingByTs(workspaceId, spaceId, finding.ts)
         )
     },
@@ -57,7 +56,7 @@ export default React.memo<Props>(function FindingCard({
           })
           .then(({response}) => {
             if (response === 0)
-              globalDispatch(
+              dispatch(
                 Investigation.clearSpaceInvestigation(workspaceId, spaceId)
               )
           })

--- a/src/js/components/LeftPane/QueriesSection.tsx
+++ b/src/js/components/LeftPane/QueriesSection.tsx
@@ -9,7 +9,6 @@ import DropdownArrow from "../../icons/DropdownArrow"
 import MagnifyingGlass from "../../icons/MagnifyingGlass"
 import lib from "../../lib"
 import Current from "../../state/Current"
-import {globalDispatch} from "../../state/GlobalContext"
 import Modal from "../../state/Modal"
 import Notice from "../../state/Notice"
 import Queries from "../../state/Queries"
@@ -142,9 +141,8 @@ function QueriesSection({isOpen, style, resizeProps, toggleProps}) {
           .then(({response}) => {
             if (response === 0) {
               const {selections, item} = contextArgs
-              if (hasMultiSelected)
-                globalDispatch(Queries.removeItems(selections))
-              else globalDispatch(Queries.removeItems([item]))
+              if (hasMultiSelected) dispatch(Queries.removeItems(selections))
+              else dispatch(Queries.removeItems([item]))
             }
           })
       }
@@ -164,7 +162,7 @@ function QueriesSection({isOpen, style, resizeProps, toggleProps}) {
 
   function onItemMove(sourceItem, destIndex) {
     if (selectedTag !== "All") return
-    globalDispatch(Queries.moveItems([sourceItem], queriesRoot, destIndex))
+    dispatch(Queries.moveItems([sourceItem], queriesRoot, destIndex))
   }
 
   function onItemContextMenu(_, item, selections) {

--- a/src/js/components/Login.tsx
+++ b/src/js/components/Login.tsx
@@ -5,7 +5,6 @@ import styled from "styled-components"
 import {BrimWorkspace} from "../brim"
 import {activateWorkspace} from "../flows/workspace/activateWorkspace"
 import {login} from "../flows/workspace/login"
-import {globalDispatch} from "../state/GlobalContext"
 import {AppDispatch} from "../state/types"
 import Workspaces from "../state/Workspaces"
 
@@ -54,9 +53,7 @@ const Login = ({workspace}: Props) => {
       const accessToken = await dispatch(
         login(workspace, ctlRef.current.signal)
       )
-      await globalDispatch(
-        Workspaces.setWorkspaceToken(workspace.id, accessToken)
-      )
+      dispatch(Workspaces.setWorkspaceToken(workspace.id, accessToken))
       await dispatch(activateWorkspace(workspace.id))
     } catch {
       toast.error("Login failed")

--- a/src/js/components/Preferences/usePreferencesForm.ts
+++ b/src/js/components/Preferences/usePreferencesForm.ts
@@ -2,7 +2,6 @@ import {isEmpty} from "lodash"
 import {useDispatch, useSelector} from "react-redux"
 
 import {FormConfig, FormCheckResult} from "../../brim/form"
-import {globalDispatch} from "../../state/GlobalContext"
 import Prefs from "../../state/Prefs"
 import View from "../../state/View"
 import lib from "../../lib"
@@ -21,13 +20,13 @@ export default function usePreferencesForm(): FormConfig {
       name: "timeFormat",
       label: "Time Format",
       defaultValue: useSelector(Prefs.getTimeFormat),
-      submit: (value) => globalDispatch(Prefs.setTimeFormat(value))
+      submit: (value) => dispatch(Prefs.setTimeFormat(value))
     },
     suricataRunner: {
       name: "suricataRunner",
       label: "Suricata Runner",
       defaultValue: useSelector(Prefs.getSuricataRunner),
-      submit: (value) => globalDispatch(Prefs.setSuricataRunner(value)),
+      submit: (value) => dispatch(Prefs.setSuricataRunner(value)),
       check: (path) => {
         if (path === "") return [true, ""]
         return lib
@@ -40,7 +39,7 @@ export default function usePreferencesForm(): FormConfig {
       name: "suricataUpdater",
       label: "Suricata Updater",
       defaultValue: useSelector(Prefs.getSuricataUpdater),
-      submit: (value) => globalDispatch(Prefs.setSuricataUpdater(value)),
+      submit: (value) => dispatch(Prefs.setSuricataUpdater(value)),
       check: (path) => {
         if (path === "") return [true, ""]
         return lib
@@ -53,7 +52,7 @@ export default function usePreferencesForm(): FormConfig {
       name: "zeekRunner",
       label: "Zeek Runner",
       defaultValue: useSelector(Prefs.getZeekRunner),
-      submit: (value) => globalDispatch(Prefs.setZeekRunner(value)),
+      submit: (value) => dispatch(Prefs.setZeekRunner(value)),
       check: (path) => {
         if (path === "") return [true, ""]
         return lib
@@ -66,7 +65,7 @@ export default function usePreferencesForm(): FormConfig {
       name: "jsonTypeConfig",
       label: "JSON Type Config",
       defaultValue: useSelector(Prefs.getJSONTypeConfig),
-      submit: (value) => globalDispatch(Prefs.setJSONTypeConfig(value)),
+      submit: (value) => dispatch(Prefs.setJSONTypeConfig(value)),
       check: (path) => {
         if (path === "") return [true, ""]
         return lib
@@ -90,7 +89,7 @@ export default function usePreferencesForm(): FormConfig {
       name: "dataDir",
       label: "Data Directory",
       defaultValue: useSelector(Prefs.getDataDir),
-      submit: (value) => globalDispatch(Prefs.setDataDir(value)),
+      submit: (value) => dispatch(Prefs.setDataDir(value)),
       check: (path) => {
         if (path === "") return [true, ""]
         return lib

--- a/src/js/components/QueriesModals/QueryForm.tsx
+++ b/src/js/components/QueriesModals/QueryForm.tsx
@@ -14,7 +14,6 @@ import useEventListener from "../hooks/useEventListener"
 import {Query} from "../../state/Queries/types"
 import Queries from "../../state/Queries"
 import {cssVar} from "../../lib/cssVar"
-import {globalDispatch} from "../../state/GlobalContext"
 
 const QueryFormWrapper = styled.div`
   width: 100%;
@@ -163,7 +162,7 @@ const QueryForm = ({onClose, query, value}: Props) => {
         )
         // adding query
       } else {
-        globalDispatch(
+        dispatch(
           Queries.addItem(
             {
               id: nanoid(),

--- a/src/js/electron/ipc/globalStore/mainHandler.ts
+++ b/src/js/electron/ipc/globalStore/mainHandler.ts
@@ -13,8 +13,13 @@ export default function(brim: Brim) {
   ipcMain.handle("globalStore:dispatch", (e, {action}) => {
     brim.store.dispatch(action)
     for (const win of brim.windows.getWindows()) {
-      if (!win.ref.isDestroyed()) {
-        sendTo(win.ref.webContents, ipc.globalStore.dispatch(action))
+      // Don't send it back to the sender, their store will have already been updated.
+      if (!win.ref.isDestroyed() && e.sender !== win.ref.webContents) {
+        sendTo(
+          win.ref.webContents,
+          // Adding remote: true to prevent infinite loops
+          ipc.globalStore.dispatch({...action, remote: true})
+        )
       }
     }
   })

--- a/src/js/flows/deleteSpace.ts
+++ b/src/js/flows/deleteSpace.ts
@@ -6,14 +6,13 @@ import Spaces from "../state/Spaces"
 
 const deleteSpace = (id: string): Thunk<Promise<void>> => (
   dispatch,
-  getState,
-  {globalDispatch}
+  getState
 ) => {
   const zealot = dispatch(getZealot())
   const workspaceId = Current.getWorkspaceId(getState())
   return zealot.spaces.delete(id).then(() => {
-    globalDispatch(Investigation.clearSpaceInvestigation(workspaceId, id))
-    globalDispatch(Spaces.remove(workspaceId, id))
+    dispatch(Investigation.clearSpaceInvestigation(workspaceId, id))
+    dispatch(Spaces.remove(workspaceId, id))
   })
 }
 

--- a/src/js/flows/getZealot.ts
+++ b/src/js/flows/getZealot.ts
@@ -4,7 +4,6 @@ import {validateToken} from "../auth0/utils"
 import {BrimWorkspace} from "../brim"
 import ErrorFactory from "../models/ErrorFactory"
 import Current from "../state/Current"
-import {globalDispatch} from "../state/GlobalContext"
 import {Thunk} from "../state/types"
 import Workspaces from "../state/Workspaces"
 import WorkspaceStatuses from "../state/WorkspaceStatuses"
@@ -32,7 +31,7 @@ const createBrimFetcher = (dispatch, getState) => {
           return args
         }
 
-        await globalDispatch(Workspaces.setWorkspaceToken(ws.id, accessToken))
+        await dispatch(Workspaces.setWorkspaceToken(ws.id, accessToken))
       }
 
       const bearerToken = `Bearer ${accessToken}`

--- a/src/js/flows/ingestFiles.ts
+++ b/src/js/flows/ingestFiles.ts
@@ -18,8 +18,7 @@ import SystemTest from "../state/SystemTest"
 
 export default (files: File[]): Thunk<Promise<void>> => (
   dispatch,
-  getState,
-  {globalDispatch}
+  getState
 ) => {
   const ws = Current.mustGetWorkspace(getState())
   const workspaceId = ws.id
@@ -35,11 +34,11 @@ export default (files: File[]): Thunk<Promise<void>> => (
     .transaction([
       validateInput(files, dataDir, spaceNames),
       createDir(),
-      createSpace(zealot, globalDispatch, workspaceId),
+      createSpace(zealot, dispatch, workspaceId),
       setSpace(dispatch, tabId),
       registerHandler(dispatch, requestId),
       postFiles(zealot, ws, jsonTypeConfigPath),
-      trackProgress(zealot, globalDispatch, workspaceId),
+      trackProgress(zealot, dispatch, workspaceId),
       unregisterHandler(dispatch, requestId)
     ])
     .then(() => {

--- a/src/js/flows/initSpace.ts
+++ b/src/js/flows/initSpace.ts
@@ -1,6 +1,5 @@
 import {Thunk} from "../state/types"
 import {getZealot} from "./getZealot"
-import {globalDispatch} from "../state/GlobalContext"
 import {submitSearch} from "./submitSearch/mod"
 import Current from "../state/Current"
 import Search from "../state/Search"
@@ -20,7 +19,7 @@ export const initSpace = (spaceId: string): Thunk => (dispatch, getState) => {
     .then(brim.interop.spacePayloadToSpace)
     .then((data) => {
       const space = brim.space(data)
-      globalDispatch(Spaces.setDetail(workspaceId, data))
+      dispatch(Spaces.setDetail(workspaceId, data))
       dispatch(Current.setSpaceId(space.id))
       dispatch(Search.setSpanArgs(space.everythingSpan()))
       dispatch(SearchBar.removeAllSearchBarPins())

--- a/src/js/flows/refreshSpaceInfo.ts
+++ b/src/js/flows/refreshSpaceInfo.ts
@@ -1,5 +1,4 @@
 import {Thunk} from "../state/types"
-import {globalDispatch} from "../state/GlobalContext"
 import Current from "../state/Current"
 import Spaces from "../state/Spaces"
 import {getZealot} from "./getZealot"
@@ -12,7 +11,7 @@ export default function refreshSpaceInfo(): Thunk {
     return zealot.spaces.get(id).then((data: any) => {
       const id = Current.getWorkspaceId(getState())
       if (!id) return
-      globalDispatch(Spaces.setDetail(id, data))
+      dispatch(Spaces.setDetail(id, data))
     })
   }
 }

--- a/src/js/flows/refreshSpaceNames.ts
+++ b/src/js/flows/refreshSpaceNames.ts
@@ -4,12 +4,12 @@ import Spaces from "../state/Spaces"
 import {getZealot} from "./getZealot"
 
 export default function refreshSpaceNames(): Thunk<Promise<void>> {
-  return (dispatch, getState, {globalDispatch}) => {
+  return (dispatch, getState) => {
     const zealot = dispatch(getZealot())
     return zealot.spaces.list().then((spaces) => {
       spaces = spaces || []
       const id = Current.getWorkspaceId(getState())
-      if (id) globalDispatch(Spaces.setSpaces(id, spaces))
+      if (id) dispatch(Spaces.setSpaces(id, spaces))
     })
   }
 }

--- a/src/js/flows/renameSpace.ts
+++ b/src/js/flows/renameSpace.ts
@@ -8,13 +8,13 @@ export default (
   workspaceId: string,
   spaceId: string,
   name: string
-): Thunk<Promise<void>> => (dispatch, getState, {globalDispatch}) => {
+): Thunk<Promise<void>> => (dispatch, getState) => {
   const state = getState()
   const zealot = dispatch(getZealot())
   const tabs = Tabs.getData(state)
 
   return zealot.spaces.update(spaceId, {name}).then(() => {
-    globalDispatch(Spaces.rename(workspaceId, spaceId, name))
+    dispatch(Spaces.rename(workspaceId, spaceId, name))
     tabs.forEach((t) => {
       if (t.current.spaceId === spaceId)
         dispatch(Current.setSpaceId(spaceId, t.id))

--- a/src/js/flows/submitSearch/save.ts
+++ b/src/js/flows/submitSearch/save.ts
@@ -13,12 +13,12 @@ export function saveToHistory(
   opts: SaveOpts,
   ts: Date
 ): Thunk {
-  return (dispatch, _, {globalDispatch}) => {
+  return (dispatch, _) => {
     if (opts.history) {
       dispatch(History.push(record, brim.time(ts).toTs()))
     }
     if (opts.investigation) {
-      globalDispatch(
+      dispatch(
         Investigation.push(workspaceId, spaceId, record, brim.time(ts).toTs())
       )
     }

--- a/src/js/flows/workspace/activateWorkspace.ts
+++ b/src/js/flows/workspace/activateWorkspace.ts
@@ -1,7 +1,6 @@
 import {validateToken} from "../../auth0/utils"
 import brim from "../../brim"
 import Current from "../../state/Current"
-import {globalDispatch} from "../../state/GlobalContext"
 import Workspaces from "../../state/Workspaces"
 import WorkspaceStatuses from "../../state/WorkspaceStatuses"
 import refreshSpaceNames from "../refreshSpaceNames"
@@ -39,7 +38,6 @@ export const activateWorkspace = (workspaceId: string) => async (
 
   // update version
   dispatch(Workspaces.add(ws.serialize()))
-  await globalDispatch(Workspaces.add(ws.serialize()))
 
   // no auth required
   if (ws.authType === "none") {
@@ -59,7 +57,6 @@ export const activateWorkspace = (workspaceId: string) => async (
     const accessToken = await dispatch(getAuthCredentials(ws))
     if (accessToken) {
       dispatch(Workspaces.setWorkspaceToken(ws.id, accessToken))
-      await globalDispatch(Workspaces.setWorkspaceToken(ws.id, accessToken))
       activate()
       return
     }

--- a/src/js/flows/workspace/removeWorkspace.ts
+++ b/src/js/flows/workspace/removeWorkspace.ts
@@ -11,11 +11,7 @@ import Workspaces from "../../state/Workspaces"
 import {Workspace} from "../../state/Workspaces/types"
 import WorkspaceStatuses from "../../state/WorkspaceStatuses"
 
-const removeWorkspace = (ws: Workspace): Thunk => (
-  dispatch,
-  _getState,
-  {globalDispatch}
-) => {
+const removeWorkspace = (ws: Workspace): Thunk => (dispatch, _getState) => {
   const {name, id, authType} = ws
 
   if (isDefaultWorkspace(ws))
@@ -31,7 +27,7 @@ const removeWorkspace = (ws: Workspace): Thunk => (
   dispatch(Investigation.clearWorkspaceInvestigation(id))
   dispatch(Spaces.removeForWorkspace(id))
   dispatch(WorkspaceStatuses.remove(id))
-  globalDispatch(Workspaces.remove(id))
+  dispatch(Workspaces.remove(id))
   popNotice(`Removed workspace "${name}"`)
 }
 

--- a/src/js/flows/workspace/saveWorkspace.ts
+++ b/src/js/flows/workspace/saveWorkspace.ts
@@ -7,13 +7,11 @@ import refreshSpaceNames from "../refreshSpaceNames"
 
 export const saveWorkspace = (ws: BrimWorkspace, status: WorkspaceStatus) => (
   dispatch,
-  _gs,
-  {globalDispatch}
+  _gs
 ): void => {
   dispatch(Workspaces.add(ws.serialize()))
   dispatch(WorkspaceStatuses.set(ws.id, status))
-  globalDispatch(Workspaces.add(ws.serialize())).then(() => {
-    dispatch(Current.setWorkspaceId(ws.id))
-    dispatch(refreshSpaceNames())
-  })
+  dispatch(Workspaces.add(ws.serialize()))
+  dispatch(Current.setWorkspaceId(ws.id))
+  dispatch(refreshSpaceNames())
 }

--- a/src/js/initializers/initStore.ts
+++ b/src/js/initializers/initStore.ts
@@ -1,5 +1,5 @@
 import {createZealot} from "zealot"
-import {globalDispatch} from "../state/GlobalContext"
+import {globalDispatchMiddleware} from "../state/GlobalContext"
 import getUrlSearchParams from "../lib/getUrlSearchParams"
 import invoke from "../electron/ipc/invoke"
 import ipc from "../electron/ipc"
@@ -19,13 +19,15 @@ export default async () => {
   return configureStore({
     reducer: rootReducer,
     preloadedState: initialState,
-    middleware: (getDefaults) =>
-      getDefaults({
+    middleware: (getDefaults) => [
+      ...getDefaults({
         thunk: {
-          extraArgument: {globalDispatch, createZealot}
+          extraArgument: {createZealot}
         },
         serializableCheck: false,
         immutableCheck: false
-      })
+      }),
+      globalDispatchMiddleware
+    ]
   })
 }

--- a/src/js/initializers/initWorkspaceParams.ts
+++ b/src/js/initializers/initWorkspaceParams.ts
@@ -4,7 +4,7 @@ import Current from "../state/Current"
 import getUrlSearchParams from "../lib/getUrlSearchParams"
 import {Workspace} from "../state/Workspaces/types"
 
-const setupDefaultWorkspace = () => (dispatch, _, {globalDispatch}) => {
+const setupDefaultWorkspace = () => (dispatch, _) => {
   const host = "localhost"
   const port = "9867"
   const hostPort = [host, port].join(":")
@@ -16,7 +16,7 @@ const setupDefaultWorkspace = () => (dispatch, _, {globalDispatch}) => {
     authType: "none"
   }
   dispatch(Workspaces.add(ws))
-  globalDispatch(Workspaces.add(ws))
+  dispatch(Workspaces.add(ws))
   dispatch(Current.setWorkspaceId(ws.id))
 }
 

--- a/src/js/state/GlobalContext.ts
+++ b/src/js/state/GlobalContext.ts
@@ -1,6 +1,11 @@
 import invoke from "../electron/ipc/invoke"
 import ipc from "../electron/ipc"
 
-export const globalDispatch = (action: Object) => {
-  return invoke(ipc.globalStore.dispatch(action))
+export const globalDispatchMiddleware = (_store) => (next) => (action) => {
+  const result = next(action)
+  if (action.type.startsWith("$") && !action.remote) {
+    // Don't re-broadcast a message that was broadcast to you
+    invoke(ipc.globalStore.dispatch(action))
+  }
+  return result
 }

--- a/src/js/state/Investigation/actions.ts
+++ b/src/js/state/Investigation/actions.ts
@@ -15,7 +15,7 @@ export default {
     record: SearchRecord,
     ts: Ts = brim.time().toTs()
   ): INVESTIGATION_PUSH => ({
-    type: "INVESTIGATION_PUSH",
+    type: "$INVESTIGATION_PUSH",
     workspaceId,
     spaceId,
     entry: record,
@@ -27,7 +27,7 @@ export default {
     spaceId: string,
     ts: Ts[] | Ts
   ): FINDING_DELETE => ({
-    type: "FINDING_DELETE",
+    type: "$FINDING_DELETE",
     workspaceId,
     spaceId,
     ts: isArray(ts) ? ts : [ts]
@@ -37,7 +37,7 @@ export default {
     workspaceId: string,
     spaceId: string
   ): INVESTIGATION_CLEAR => ({
-    type: "INVESTIGATION_CLEAR",
+    type: "$INVESTIGATION_CLEAR",
     workspaceId,
     spaceId
   }),
@@ -45,7 +45,7 @@ export default {
   clearWorkspaceInvestigation: (
     workspaceId: string
   ): INVESTIGATION_WORKSPACE_CLEAR => ({
-    type: "INVESTIGATION_WORKSPACE_CLEAR",
+    type: "$INVESTIGATION_WORKSPACE_CLEAR",
     workspaceId
   })
 }

--- a/src/js/state/Investigation/reducer.ts
+++ b/src/js/state/Investigation/reducer.ts
@@ -10,7 +10,7 @@ const init = (): InvestigationState => ({})
 
 export default produce((draft, a: InvestigationAction) => {
   switch (a.type) {
-    case "INVESTIGATION_PUSH":
+    case "$INVESTIGATION_PUSH":
       if (!draft[a.workspaceId]) draft[a.workspaceId] = {}
       if (!draft[a.workspaceId][a.spaceId]) draft[a.workspaceId][a.spaceId] = []
 
@@ -20,7 +20,7 @@ export default produce((draft, a: InvestigationAction) => {
         a.ts
       )
       return
-    case "FINDING_DELETE":
+    case "$FINDING_DELETE":
       if (!draft[a.workspaceId] || !draft[a.workspaceId][a.spaceId]) return
 
       draft[a.workspaceId][a.spaceId] = draft[a.workspaceId][a.spaceId].filter(
@@ -30,12 +30,12 @@ export default produce((draft, a: InvestigationAction) => {
         }
       )
       return
-    case "INVESTIGATION_CLEAR":
+    case "$INVESTIGATION_CLEAR":
       if (!draft[a.workspaceId] || !draft[a.workspaceId][a.spaceId]) return
 
       delete draft[a.workspaceId][a.spaceId]
       return
-    case "INVESTIGATION_WORKSPACE_CLEAR":
+    case "$INVESTIGATION_WORKSPACE_CLEAR":
       delete draft[a.workspaceId]
       return
   }

--- a/src/js/state/Investigation/types.ts
+++ b/src/js/state/Investigation/types.ts
@@ -18,24 +18,24 @@ export type Finding = {
 }
 
 export type FINDING_DELETE = {
-  type: "FINDING_DELETE"
+  type: "$FINDING_DELETE"
   workspaceId: string
   spaceId: string
   ts: Ts[]
 }
 export type INVESTIGATION_CLEAR = {
-  type: "INVESTIGATION_CLEAR"
+  type: "$INVESTIGATION_CLEAR"
   workspaceId: string
   spaceId: string
 }
 
 export type INVESTIGATION_WORKSPACE_CLEAR = {
-  type: "INVESTIGATION_WORKSPACE_CLEAR"
+  type: "$INVESTIGATION_WORKSPACE_CLEAR"
   workspaceId: string
 }
 
 export type INVESTIGATION_PUSH = {
-  type: "INVESTIGATION_PUSH"
+  type: "$INVESTIGATION_PUSH"
   workspaceId: string
   spaceId: string
   entry: SearchRecord

--- a/src/js/state/Prefs/actions.ts
+++ b/src/js/state/Prefs/actions.ts
@@ -9,34 +9,34 @@ import {
 
 export default {
   setJSONTypeConfig: (path: string): PREFS_JSON_TYPES_CONFIG_SET => ({
-    type: "PREFS_JSON_TYPES_CONFIG_SET",
+    type: "$PREFS_JSON_TYPES_CONFIG_SET",
     path
   }),
 
   setTimeFormat: (format: string): PREFS_TIME_FORMAT_SET => ({
-    type: "PREFS_TIME_FORMAT_SET",
+    type: "$PREFS_TIME_FORMAT_SET",
     format
   }),
 
   setSuricataRunner: (suricataRunner: string): PREFS_SURICATA_RUNNER_SET => ({
-    type: "PREFS_SURICATA_RUNNER_SET",
+    type: "$PREFS_SURICATA_RUNNER_SET",
     suricataRunner
   }),
 
   setSuricataUpdater: (
     suricataUpdater: string
   ): PREFS_SURICATA_UPDATER_SET => ({
-    type: "PREFS_SURICATA_UPDATER_SET",
+    type: "$PREFS_SURICATA_UPDATER_SET",
     suricataUpdater
   }),
 
   setZeekRunner: (zeekRunner: string): PREFS_ZEEK_RUNNER_SET => ({
-    type: "PREFS_ZEEK_RUNNER_SET",
+    type: "$PREFS_ZEEK_RUNNER_SET",
     zeekRunner
   }),
 
   setDataDir: (dataDir: string): PREFS_DATA_DIR_SET => ({
-    type: "PREFS_DATA_DIR_SET",
+    type: "$PREFS_DATA_DIR_SET",
     dataDir
   })
 }

--- a/src/js/state/Prefs/reducer.ts
+++ b/src/js/state/Prefs/reducer.ts
@@ -14,32 +14,32 @@ export default function reducer(
   action: PrefsAction
 ): PrefsState {
   switch (action.type) {
-    case "PREFS_JSON_TYPES_CONFIG_SET":
+    case "$PREFS_JSON_TYPES_CONFIG_SET":
       return {
         ...state,
         jsonTypeConfig: action.path
       }
-    case "PREFS_TIME_FORMAT_SET":
+    case "$PREFS_TIME_FORMAT_SET":
       return {
         ...state,
         timeFormat: action.format
       }
-    case "PREFS_SURICATA_RUNNER_SET":
+    case "$PREFS_SURICATA_RUNNER_SET":
       return {
         ...state,
         suricataRunner: action.suricataRunner
       }
-    case "PREFS_SURICATA_UPDATER_SET":
+    case "$PREFS_SURICATA_UPDATER_SET":
       return {
         ...state,
         suricataUpdater: action.suricataUpdater
       }
-    case "PREFS_ZEEK_RUNNER_SET":
+    case "$PREFS_ZEEK_RUNNER_SET":
       return {
         ...state,
         zeekRunner: action.zeekRunner
       }
-    case "PREFS_DATA_DIR_SET":
+    case "$PREFS_DATA_DIR_SET":
       return {
         ...state,
         dataDir: action.dataDir

--- a/src/js/state/Prefs/types.ts
+++ b/src/js/state/Prefs/types.ts
@@ -16,31 +16,31 @@ export type PrefsAction =
   | PREFS_DATA_DIR_SET
 
 export type PREFS_JSON_TYPES_CONFIG_SET = {
-  type: "PREFS_JSON_TYPES_CONFIG_SET"
+  type: "$PREFS_JSON_TYPES_CONFIG_SET"
   path: string
 }
 
 export type PREFS_TIME_FORMAT_SET = {
-  type: "PREFS_TIME_FORMAT_SET"
+  type: "$PREFS_TIME_FORMAT_SET"
   format: string
 }
 
 export type PREFS_SURICATA_RUNNER_SET = {
-  type: "PREFS_SURICATA_RUNNER_SET"
+  type: "$PREFS_SURICATA_RUNNER_SET"
   suricataRunner: string
 }
 
 export type PREFS_SURICATA_UPDATER_SET = {
-  type: "PREFS_SURICATA_UPDATER_SET"
+  type: "$PREFS_SURICATA_UPDATER_SET"
   suricataUpdater: string
 }
 
 export type PREFS_ZEEK_RUNNER_SET = {
-  type: "PREFS_ZEEK_RUNNER_SET"
+  type: "$PREFS_ZEEK_RUNNER_SET"
   zeekRunner: string
 }
 
 export type PREFS_DATA_DIR_SET = {
-  type: "PREFS_DATA_DIR_SET"
+  type: "$PREFS_DATA_DIR_SET"
   dataDir: string
 }

--- a/src/js/state/Queries/actions.ts
+++ b/src/js/state/Queries/actions.ts
@@ -10,20 +10,20 @@ import {
 
 export default {
   setAll: (rootGroup: Group): QUERIES_SET_ALL => ({
-    type: "QUERIES_SET_ALL",
+    type: "$QUERIES_SET_ALL",
     rootGroup
   }),
   addItem: (item: Item, parentGroup: Group): QUERIES_ADD_ITEM => ({
-    type: "QUERIES_ADD_ITEM",
+    type: "$QUERIES_ADD_ITEM",
     item,
     parentGroup
   }),
   removeItems: (items: Item[]): QUERIES_REMOVE_ITEMS => ({
-    type: "QUERIES_REMOVE_ITEMS",
+    type: "$QUERIES_REMOVE_ITEMS",
     items
   }),
   editItem: (item: Item, itemId: string): QUERIES_EDIT_ITEM => ({
-    type: "QUERIES_EDIT_ITEM",
+    type: "$QUERIES_EDIT_ITEM",
     item,
     itemId
   }),
@@ -32,7 +32,7 @@ export default {
     parentGroup: Group,
     index: number
   ): QUERIES_MOVE_ITEMS => ({
-    type: "QUERIES_MOVE_ITEMS",
+    type: "$QUERIES_MOVE_ITEMS",
     items,
     parentGroup,
     index

--- a/src/js/state/Queries/reducer.ts
+++ b/src/js/state/Queries/reducer.ts
@@ -15,22 +15,22 @@ const getNodeById = (
 export default produce((draft: QueriesState, action: QueriesAction) => {
   const queriesTree = itemToNode(draft)
   switch (action.type) {
-    case "QUERIES_SET_ALL":
+    case "$QUERIES_SET_ALL":
       return action.rootGroup
-    case "QUERIES_ADD_ITEM":
+    case "$QUERIES_ADD_ITEM":
       getNodeById(queriesTree, action.parentGroup.id).addChild(
         itemToNode(action.item)
       )
       return queriesTree.model
-    case "QUERIES_REMOVE_ITEMS":
+    case "$QUERIES_REMOVE_ITEMS":
       action.items.forEach((item) => {
         getNodeById(queriesTree, item.id).drop()
       })
       return queriesTree.model
-    case "QUERIES_EDIT_ITEM":
+    case "$QUERIES_EDIT_ITEM":
       Object.assign(getNodeById(queriesTree, action.itemId).model, action.item)
       return queriesTree.model
-    case "QUERIES_MOVE_ITEMS":
+    case "$QUERIES_MOVE_ITEMS":
       moveItems(queriesTree, action)
       return queriesTree.model
   }

--- a/src/js/state/Queries/types.ts
+++ b/src/js/state/Queries/types.ts
@@ -24,29 +24,29 @@ export type QueriesAction =
   | QUERIES_MOVE_ITEMS
 
 export interface QUERIES_SET_ALL {
-  type: "QUERIES_SET_ALL"
+  type: "$QUERIES_SET_ALL"
   rootGroup: Group
 }
 
 export interface QUERIES_ADD_ITEM {
-  type: "QUERIES_ADD_ITEM"
+  type: "$QUERIES_ADD_ITEM"
   item: Item
   parentGroup: Group
 }
 
 export interface QUERIES_REMOVE_ITEMS {
-  type: "QUERIES_REMOVE_ITEMS"
+  type: "$QUERIES_REMOVE_ITEMS"
   items: Item[]
 }
 
 export interface QUERIES_EDIT_ITEM {
-  type: "QUERIES_EDIT_ITEM"
+  type: "$QUERIES_EDIT_ITEM"
   item: Item
   itemId: string
 }
 
 export interface QUERIES_MOVE_ITEMS {
-  type: "QUERIES_MOVE_ITEMS"
+  type: "$QUERIES_MOVE_ITEMS"
   items: Item[]
   parentGroup: Group
   index: number

--- a/src/js/state/Spaces/actions.ts
+++ b/src/js/state/Spaces/actions.ts
@@ -12,13 +12,13 @@ import {
 
 export default {
   setSpaces: (workspaceId: string, spaces: Partial<Space>[]): SPACES_SET => ({
-    type: "SPACES_SET",
+    type: "$SPACES_SET",
     workspaceId,
     spaces: spaces || []
   }),
 
   setDetail: (workspaceId: string, space: any): SPACES_DETAIL => ({
-    type: "SPACES_DETAIL",
+    type: "$SPACES_DETAIL",
     workspaceId,
     space
   }),
@@ -28,20 +28,20 @@ export default {
     spaceId: string,
     newName: string
   ): SPACES_RENAME => ({
-    type: "SPACES_RENAME",
+    type: "$SPACES_RENAME",
     workspaceId,
     spaceId,
     newName
   }),
 
   remove: (workspaceId: string, spaceId: string): SPACES_REMOVE => ({
-    type: "SPACES_REMOVE",
+    type: "$SPACES_REMOVE",
     workspaceId,
     spaceId
   }),
 
   removeForWorkspace: (workspaceId: string): SPACES_WORKSPACE_REMOVE => ({
-    type: "SPACES_WORKSPACE_REMOVE",
+    type: "$SPACES_WORKSPACE_REMOVE",
     workspaceId
   }),
 
@@ -50,7 +50,7 @@ export default {
     spaceId: string,
     value: number | null
   ): SPACES_INGEST_PROGRESS => ({
-    type: "SPACES_INGEST_PROGRESS",
+    type: "$SPACES_INGEST_PROGRESS",
     workspaceId,
     spaceId,
     value
@@ -61,7 +61,7 @@ export default {
     spaceId: string,
     warning: string
   ): SPACES_INGEST_WARNING_APPEND => ({
-    type: "SPACES_INGEST_WARNING_APPEND",
+    type: "$SPACES_INGEST_WARNING_APPEND",
     workspaceId,
     spaceId,
     warning
@@ -71,7 +71,7 @@ export default {
     workspaceId: string,
     spaceId: string
   ): SPACES_INGEST_WARNING_CLEAR => ({
-    type: "SPACES_INGEST_WARNING_CLEAR",
+    type: "$SPACES_INGEST_WARNING_CLEAR",
     workspaceId,
     spaceId
   })

--- a/src/js/state/Spaces/actionsFor.ts
+++ b/src/js/state/Spaces/actionsFor.ts
@@ -13,18 +13,18 @@ export default function actionsFor(workspaceId: string, spaceId: string) {
       return actions.clearIngestWarnings(workspaceId, spaceId)
     },
     setIngestSnapshot: (count: number): SPACES_INGEST_SNAPSHOT => ({
-      type: "SPACES_INGEST_SNAPSHOT",
+      type: "$SPACES_INGEST_SNAPSHOT",
       workspaceId,
       spaceId,
       count
     }),
     remove: (): SPACES_REMOVE => ({
-      type: "SPACES_REMOVE",
+      type: "$SPACES_REMOVE",
       workspaceId,
       spaceId
     }),
     create: (): SPACES_DETAIL => ({
-      type: "SPACES_DETAIL",
+      type: "$SPACES_DETAIL",
       workspaceId,
       space: {id: spaceId}
     })

--- a/src/js/state/Spaces/reducer.ts
+++ b/src/js/state/Spaces/reducer.ts
@@ -9,13 +9,13 @@ const spacesReducer = produce((draft, action: SpacesAction): {
   [id: string]: Space
 } => {
   switch (action.type) {
-    case "SPACES_SET":
+    case "$SPACES_SET":
       return action.spaces.reduce<{[id: string]: Space}>((next, space) => {
         next[space.id] = defaults(space, draft[space.id])
         return next
       }, {})
 
-    case "SPACES_DETAIL":
+    case "$SPACES_DETAIL":
       var {id} = action.space // XXX adapter hack to support span payloads from zqd as well as min/max
       // time. In the future brim.Span type should mimic the formatted
       // transmitted over the wire.
@@ -24,27 +24,27 @@ const spacesReducer = produce((draft, action: SpacesAction): {
       draft[id] = defaults(space, draft[id])
       break
 
-    case "SPACES_RENAME":
+    case "$SPACES_RENAME":
       getSpace(draft, action.spaceId).name = action.newName
       break
 
-    case "SPACES_INGEST_PROGRESS":
+    case "$SPACES_INGEST_PROGRESS":
       getSpace(draft, action.spaceId).ingest.progress = action.value
       break
 
-    case "SPACES_INGEST_WARNING_APPEND":
+    case "$SPACES_INGEST_WARNING_APPEND":
       getSpace(draft, action.spaceId).ingest.warnings.push(action.warning)
       break
 
-    case "SPACES_INGEST_WARNING_CLEAR":
+    case "$SPACES_INGEST_WARNING_CLEAR":
       getSpace(draft, action.spaceId).ingest.warnings = []
       break
 
-    case "SPACES_INGEST_SNAPSHOT":
+    case "$SPACES_INGEST_SNAPSHOT":
       getSpace(draft, action.spaceId).ingest.snapshot = action.count
       break
 
-    case "SPACES_REMOVE":
+    case "$SPACES_REMOVE":
       delete draft[action.spaceId]
       break
   }
@@ -54,10 +54,10 @@ export default function reducer(
   state: SpacesState = init,
   action: SpacesAction
 ): SpacesState {
-  if (action.type === "SPACES_WORKSPACE_REMOVE") {
+  if (action.type === "$SPACES_WORKSPACE_REMOVE") {
     delete state[action.workspaceId]
     return state
-  } else if (action.type.startsWith("SPACES_")) {
+  } else if (action.type.startsWith("$SPACES_")) {
     return {
       ...state,
       [action.workspaceId]: spacesReducer(

--- a/src/js/state/Spaces/types.ts
+++ b/src/js/state/Spaces/types.ts
@@ -37,57 +37,57 @@ type SpaceIngest = {
 }
 
 export type SPACES_SET = {
-  type: "SPACES_SET"
+  type: "$SPACES_SET"
   workspaceId: string
   spaces: Partial<Space>[]
 }
 
 export type SPACES_DETAIL = {
-  type: "SPACES_DETAIL"
+  type: "$SPACES_DETAIL"
   workspaceId: string
   space: Partial<Space>
 }
 
 export type SPACES_RENAME = {
-  type: "SPACES_RENAME"
+  type: "$SPACES_RENAME"
   workspaceId: string
   spaceId: string
   newName: string
 }
 
 export type SPACES_INGEST_PROGRESS = {
-  type: "SPACES_INGEST_PROGRESS"
+  type: "$SPACES_INGEST_PROGRESS"
   workspaceId: string
   spaceId: string
   value: number | null
 }
 
 export type SPACES_INGEST_WARNING_APPEND = {
-  type: "SPACES_INGEST_WARNING_APPEND"
+  type: "$SPACES_INGEST_WARNING_APPEND"
   warning: string
   spaceId: string
   workspaceId: string
 }
 
 export type SPACES_INGEST_WARNING_CLEAR = {
-  type: "SPACES_INGEST_WARNING_CLEAR"
+  type: "$SPACES_INGEST_WARNING_CLEAR"
   spaceId: string
   workspaceId: string
 }
 
 export type SPACES_REMOVE = {
-  type: "SPACES_REMOVE"
+  type: "$SPACES_REMOVE"
   workspaceId: string
   spaceId: string
 }
 
 export type SPACES_WORKSPACE_REMOVE = {
-  type: "SPACES_WORKSPACE_REMOVE"
+  type: "$SPACES_WORKSPACE_REMOVE"
   workspaceId: string
 }
 
 export type SPACES_INGEST_SNAPSHOT = {
-  type: "SPACES_INGEST_SNAPSHOT"
+  type: "$SPACES_INGEST_SNAPSHOT"
   workspaceId: string
   spaceId: string
   count: number

--- a/src/js/state/Workspaces/actions.ts
+++ b/src/js/state/Workspaces/actions.ts
@@ -7,15 +7,15 @@ import {
 
 export default {
   add(workspace: Workspace): WORKSPACE_ADD {
-    return {type: "WORKSPACE_ADD", workspace}
+    return {type: "$WORKSPACE_ADD", workspace}
   },
   setWorkspaceToken(
     workspaceId: string,
     accessToken: string
   ): WORKSPACE_SET_AUTH0_TOKEN {
-    return {type: "WORKSPACE_SET_AUTH0_TOKEN", workspaceId, accessToken}
+    return {type: "$WORKSPACE_SET_AUTH0_TOKEN", workspaceId, accessToken}
   },
   remove(id: string): WORKSPACE_REMOVE {
-    return {type: "WORKSPACE_REMOVE", id}
+    return {type: "$WORKSPACE_REMOVE", id}
   }
 }

--- a/src/js/state/Workspaces/reducer.ts
+++ b/src/js/state/Workspaces/reducer.ts
@@ -7,13 +7,13 @@ const init = (): WorkspacesState => {
 
 export default produce((draft: WorkspacesState, action: WorkspaceAction) => {
   switch (action.type) {
-    case "WORKSPACE_ADD":
+    case "$WORKSPACE_ADD":
       draft[action.workspace.id] = action.workspace
       return
-    case "WORKSPACE_REMOVE":
+    case "$WORKSPACE_REMOVE":
       delete draft[action.id]
       return
-    case "WORKSPACE_SET_AUTH0_TOKEN":
+    case "$WORKSPACE_SET_AUTH0_TOKEN":
       if (draft[action.workspaceId] && draft[action.workspaceId].authData) {
         draft[action.workspaceId].authData.accessToken = action.accessToken
       }

--- a/src/js/state/Workspaces/types.ts
+++ b/src/js/state/Workspaces/types.ts
@@ -28,17 +28,17 @@ export type WorkspaceAction =
   | WORKSPACE_SET_AUTH0_TOKEN
 
 export type WORKSPACE_REMOVE = {
-  type: "WORKSPACE_REMOVE"
+  type: "$WORKSPACE_REMOVE"
   id: string
 }
 
 export type WORKSPACE_ADD = {
-  type: "WORKSPACE_ADD"
+  type: "$WORKSPACE_ADD"
   workspace: Workspace
 }
 
 export type WORKSPACE_SET_AUTH0_TOKEN = {
-  type: "WORKSPACE_SET_AUTH0_TOKEN"
+  type: "$WORKSPACE_SET_AUTH0_TOKEN"
   workspaceId: string
   accessToken: string
 }

--- a/src/js/state/types.ts
+++ b/src/js/state/types.ts
@@ -21,7 +21,7 @@ export type GetState = () => State
 export type ThunkExtraArg = {
   zealot: Zealot
   createZealot: typeof createZealot
-  globalDispatch: AppDispatch
+  dispatch: AppDispatch
 }
 
 export type Action = ReduxAction<string>

--- a/src/js/test/initTestStore.ts
+++ b/src/js/test/initTestStore.ts
@@ -13,18 +13,14 @@ export type TestStore = {
 }
 
 export default (zealot?: Zealot): TestStore => {
-  let store
   const client = zealot || createZealotMock().zealot
-  // This is so that tests can use globalDispatch without actually making
-  // electron ipc calls. In the tests, globalDispatch is an alias for dispatch.
-  const globalDispatch = async (...args) => store.dispatch(...args)
   const createZealot = () => client
-  store = configureStore({
+  return configureStore({
     reducer: rootReducer,
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
         thunk: {
-          extraArgument: {createZealot, globalDispatch}
+          extraArgument: {createZealot}
         },
         serializableCheck: false,
         immutableCheck: false
@@ -34,8 +30,7 @@ export default (zealot?: Zealot): TestStore => {
       ...defaultEnhancers,
       applyActionHistory()
     ]
-  })
-  return store
+  }) as any
 }
 
 function applyDispatchAll() {


### PR DESCRIPTION
Instead of calling globalDispatch manually, mark which actions are intended to be global with a `$` prefix. Then have redux middleware look for the `$` prefix and make the ipc call.

I also changed the order in which the originating window receives the action. First the local store will get the action, _then_ the ipc call will be made to update the other stores. This fixes the annoying issue of dispatching an update and not being able to read that update until it makes the pic round trip.

The commits are organized in a helpful way for reviewing.