### PR TITLE
Global TabHistory & TabHistories

### DIFF
--- a/app/core/models/histories.test.ts
+++ b/app/core/models/histories.test.ts
@@ -1,0 +1,71 @@
+import Histories from "./histories"
+
+test("tab histories create / remove", () => {
+  const histories = new Histories()
+  histories.create("tab-id-1")
+  expect(histories.count()).toBe(1)
+
+  histories.delete("tab-id-1")
+  expect(histories.count()).toBe(0)
+})
+
+test("tab histories get ", () => {
+  const histories = new Histories()
+  histories.create("tab-id-1")
+
+  const tabHistory = histories.get("tab-id-1")
+  tabHistory.push("/home")
+
+  expect(tabHistory.entries.map((e) => e.pathname)).toEqual(["/", "/home"])
+})
+
+test("serialize", () => {
+  const histories = new Histories()
+  histories.create("tab-id-1")
+  histories.create("tab-id-2")
+  histories.get("tab-id-1").push("/home")
+  histories.get("tab-id-2").push("/run")
+
+  expect(histories.serialize()).toEqual([
+    {
+      id: "tab-id-1",
+      entries: [
+        {
+          hash: "",
+          key: expect.any(String),
+          pathname: "/",
+          search: "",
+          state: undefined
+        },
+        {
+          hash: "",
+          key: expect.any(String),
+          pathname: "/home",
+          search: "",
+          state: undefined
+        }
+      ],
+      index: 1
+    },
+    {
+      id: "tab-id-2",
+      entries: [
+        {
+          hash: "",
+          key: expect.any(String),
+          pathname: "/",
+          search: "",
+          state: undefined
+        },
+        {
+          hash: "",
+          key: expect.any(String),
+          pathname: "/run",
+          search: "",
+          state: undefined
+        }
+      ],
+      index: 1
+    }
+  ])
+})

--- a/app/core/models/histories.ts
+++ b/app/core/models/histories.ts
@@ -1,0 +1,63 @@
+import {createMemoryHistory} from "history"
+import {SerializedHistory} from "src/js/state/TabHistories/types"
+
+export interface HistoryEntry {
+  hash: string
+  key: string
+  pathname: string
+  search: string
+  state: object | undefined
+}
+
+export interface MemoryHistory {
+  push: (string) => void
+  replace: (string) => void
+  entries: HistoryEntry[]
+  index: number
+}
+
+export default class Histories {
+  histories = new Map<string, MemoryHistory>()
+
+  constructor(data: SerializedHistory[] = []) {
+    for (const item of data) {
+      this.histories.set(
+        item.id,
+        createMemoryHistory({
+          initialEntries: item.entries,
+          initialIndex: item.index
+        })
+      )
+    }
+  }
+
+  create(id: string) {
+    this.histories.set(id, createMemoryHistory())
+    return this.get(id)
+  }
+
+  delete(id: string) {
+    this.histories.delete(id)
+  }
+
+  getOrCreate(id: string) {
+    return this.get(id) || this.create(id)
+  }
+
+  get(id: string) {
+    return this.histories.get(id)
+  }
+
+  count() {
+    return this.histories.size
+  }
+
+  serialize() {
+    const array = Array.from(this.histories.entries())
+    return array.map(([id, {entries, index}]) => ({
+      id,
+      entries,
+      index
+    }))
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13348,6 +13348,19 @@
         }
       }
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -18386,6 +18399,25 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.18",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+          "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -20068,6 +20100,14 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -21070,6 +21110,23 @@
         "react-draggable": "^4.0.3"
       }
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-spring": {
       "version": "8.0.27",
       "resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
@@ -21616,6 +21673,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -23576,6 +23638,11 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
@@ -24146,6 +24213,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "react-hot-toast": "^1.0.1",
     "react-measure": "^2.3.0",
     "react-redux": "^7.2.0",
+    "react-router": "^5.2.0",
     "react-spring": "^8.0.27",
     "react-tooltip": "^4.2.7",
     "react-transition-group": "^2.9.0",

--- a/src/js/@types/global.d.ts
+++ b/src/js/@types/global.d.ts
@@ -1,3 +1,4 @@
+import Histories, {MemoryHistory} from "app/core/models/histories"
 import {FeatureName} from "../state/Feature"
 
 declare global {
@@ -11,6 +12,8 @@ declare global {
       windowName: "search" | "detail" | "about"
       getState: () => any
       feature: (name: FeatureName, value: boolean) => void
+      tabHistories: Histories
+      tabHistory: MemoryHistory
     }
 
     interface Process {

--- a/src/js/initializers/initGlobals.ts
+++ b/src/js/initializers/initGlobals.ts
@@ -2,6 +2,9 @@ import {Store} from "../state/types"
 import getUrlSearchParams from "../lib/getUrlSearchParams"
 import path from "path"
 import Feature from "../state/Feature"
+import Histories from "app/core/models/histories"
+import Tabs from "../state/Tabs"
+import TabHistories from "../state/TabHistories"
 
 export default function initGlobals(store: Store) {
   global.getState = store.getState
@@ -12,4 +15,9 @@ export default function initGlobals(store: Store) {
     | "detail"
 
   global.feature = (name, status) => store.dispatch(Feature.set(name, status))
+
+  const tabId = Tabs.getActive(store.getState())
+  /* TODO initialize the tab histories with entires in the state */
+  global.tabHistories = new Histories(TabHistories.selectAll(store.getState()))
+  global.tabHistory = global.tabHistories.getOrCreate(tabId)
 }

--- a/src/js/initializers/initIpcListeners.ts
+++ b/src/js/initializers/initIpcListeners.ts
@@ -9,6 +9,7 @@ import initNewSearchTab from "./initNewSearchTab"
 import confirmUnload from "../flows/confirmUnload"
 import deletePartialSpaces from "../flows/deletePartialSpaces"
 import {getWindowPersistable} from "../state/getPersistable"
+import TabHistories from "../state/TabHistories"
 
 export default (store: Store) => {
   const dispatch = store.dispatch as AppDispatch
@@ -21,6 +22,7 @@ export default (store: Store) => {
   })
 
   ipcRenderer.on("prepareClose", async (e, replyChannel) => {
+    store.dispatch(TabHistories.save(global.tabHistories.serialize()))
     await dispatch(deletePartialSpaces())
     ipcRenderer.send(replyChannel)
   })

--- a/src/js/search.tsx
+++ b/src/js/search.tsx
@@ -12,10 +12,14 @@ import initialize from "./initializers/initialize"
 import lib from "./lib"
 import theme from "./style-theme"
 import deletePartialSpaces from "./flows/deletePartialSpaces"
+import TabHistories from "./state/TabHistories"
 
 initialize()
   .then((store) => {
     window.onbeforeunload = () => {
+      // This runs during reload
+      // Visit initIpcListeners.ts#prepareClose for closing window
+      store.dispatch(TabHistories.save(global.tabHistories.serialize()))
       store.dispatch(deletePartialSpaces())
     }
     ReactDOM.render(

--- a/src/js/state/TabHistories/index.ts
+++ b/src/js/state/TabHistories/index.ts
@@ -1,0 +1,19 @@
+import {createEntityAdapter, createSlice} from "@reduxjs/toolkit"
+import {State} from "../types"
+import {SerializedHistory} from "./types"
+
+const adapter = createEntityAdapter<SerializedHistory>()
+
+const slice = createSlice({
+  name: "tabHistories",
+  initialState: adapter.getInitialState(),
+  reducers: {
+    save: adapter.setAll
+  }
+})
+
+export default {
+  reducer: slice.reducer,
+  ...slice.actions,
+  ...adapter.getSelectors((s: State) => s.tabHistories)
+}

--- a/src/js/state/TabHistories/redux-test.ts
+++ b/src/js/state/TabHistories/redux-test.ts
@@ -1,0 +1,13 @@
+import initTestStore from "src/js/test/initTestStore"
+
+export default function reduxTest(...args) {
+  let dispatch, select
+
+  beforeEach(() => {
+    const store = initTestStore(...args)
+    select = (f) => f(store.getState())
+    dispatch = store.dispatch
+  })
+
+  return {dispatch, select}
+}

--- a/src/js/state/TabHistories/test.ts
+++ b/src/js/state/TabHistories/test.ts
@@ -1,0 +1,35 @@
+import Histories from "app/core/models/histories"
+import initTestStore from "src/js/test/initTestStore"
+import TabHistories from "./index"
+
+let store
+beforeEach(() => {
+  store = initTestStore()
+})
+
+test("save and select", () => {
+  const h = new Histories()
+  h.create("1")
+  h.create("2")
+  h.create("3")
+
+  store.dispatch(TabHistories.save(h.serialize()))
+
+  expect(TabHistories.selectAll(store.getState())).toEqual([
+    {
+      id: "1",
+      entries: [{pathname: "/", search: "", hash: "", key: expect.any(String)}],
+      index: 0
+    },
+    {
+      id: "2",
+      entries: [{pathname: "/", search: "", hash: "", key: expect.any(String)}],
+      index: 0
+    },
+    {
+      id: "3",
+      entries: [{pathname: "/", search: "", hash: "", key: expect.any(String)}],
+      index: 0
+    }
+  ])
+})

--- a/src/js/state/TabHistories/types.ts
+++ b/src/js/state/TabHistories/types.ts
@@ -1,0 +1,10 @@
+import {EntityState} from "@reduxjs/toolkit"
+import {HistoryEntry} from "app/core/models/histories"
+
+export interface SerializedHistory {
+  id: string
+  index: number
+  entries: HistoryEntry[]
+}
+
+export type TabHistoriesState = EntityState<SerializedHistory>

--- a/src/js/state/Tabs/history.test.ts
+++ b/src/js/state/Tabs/history.test.ts
@@ -1,0 +1,39 @@
+import initTestStore from "src/js/test/initTestStore"
+import Tabs from "./"
+
+let store
+beforeEach(() => {
+  store = initTestStore()
+})
+
+const currentPathnames = () => global.tabHistory.entries.map((e) => e.pathname)
+
+test("adding a tab creates a history entry", () => {
+  expect(global.tabHistories.count()).toBe(1)
+  store.dispatch(Tabs.add("2"))
+  expect(global.tabHistories.count()).toBe(2)
+})
+
+test("activate sets the global.tabHistory", () => {
+  expect(global.tabHistories.count()).toBe(1)
+  global.tabHistory.push("/url-for-tab-1")
+  expect(currentPathnames()).toEqual(["/", "/url-for-tab-1"])
+
+  store.dispatch(Tabs.add("2"))
+  expect(currentPathnames()).toEqual(["/", "/url-for-tab-1"])
+
+  store.dispatch(Tabs.activate("2"))
+  global.tabHistory.push("/url-for-tab-2")
+  expect(currentPathnames()).toEqual(["/", "/url-for-tab-2"])
+  expect(global.tabHistories.count()).toBe(2)
+})
+
+test("removing a tab removes the history too", () => {
+  global.tabHistory.push("/url-for-tab-1")
+  store.dispatch(Tabs.add("2"))
+  store.dispatch(Tabs.activate("2"))
+  store.dispatch(Tabs.remove("2"))
+
+  expect(global.tabHistories.count()).toBe(1)
+  expect(currentPathnames()).toEqual(["/", "/url-for-tab-1"])
+})

--- a/src/js/state/Tabs/reducer.ts
+++ b/src/js/state/Tabs/reducer.ts
@@ -20,18 +20,20 @@ export default function reducer(state: TabsState = init, action: TabActions) {
 
   switch (action.type) {
     case "TABS_ACTIVATE":
-      if (state.data.map((t) => t.id).includes(action.id))
+      if (state.data.map((t) => t.id).includes(action.id)) {
+        global.tabHistory = global.tabHistories.get(action.id)
         return {
           ...state,
           active: action.id
         }
-      else {
+      } else {
         return state
       }
     case "TABS_REMOVE":
       if (state.data.length === 1) return state
       return removeTab(state, action.id)
     case "TABS_ADD":
+      global.tabHistories.create(action.id)
       return {
         active: state.active,
         data: addTabData(state.data, action)
@@ -71,12 +73,13 @@ function addTabData(stateData, {id, data}: {id: string; data: AddTabData}) {
 
 function removeTab(state: TabsState, id) {
   const data: TabState[] = state.data.filter((t) => t.id !== id)
-
+  global.tabHistories.delete(id)
   if (id === state.active) {
     const index = indexOf(state.data, id)
     const lastTab = index + 1 === state.data.length
     const active = lastTab ? last(data).id : data[index].id
 
+    global.tabHistory = global.tabHistories.get(active)
     return {data, active}
   } else {
     return {data, active: state.active}

--- a/src/js/state/rootReducer.ts
+++ b/src/js/state/rootReducer.ts
@@ -15,6 +15,7 @@ import Queries from "./Queries"
 import SystemTest from "./SystemTest"
 import Feature from "./Feature"
 import WorkspaceStatuses from "./WorkspaceStatuses"
+import TabHistories from "./TabHistories"
 
 export default combineReducers<any, any>({
   errors: Errors.reducer,
@@ -31,5 +32,6 @@ export default combineReducers<any, any>({
   systemTest: SystemTest.reducer,
   feature: Feature.reducer,
   workspaceStatuses: WorkspaceStatuses.reducer,
-  queries: Queries.reducer
+  queries: Queries.reducer,
+  tabHistories: TabHistories.reducer
 })

--- a/src/js/state/types.ts
+++ b/src/js/state/types.ts
@@ -16,6 +16,7 @@ import {SystemTestState} from "./SystemTest"
 import {FeatureState} from "./Feature"
 import {WorkspacesState} from "./Workspaces/types"
 import {WorkspaceStatusesState} from "./WorkspaceStatuses/types"
+import {TabHistoriesState} from "./TabHistories/types"
 
 export type GetState = () => State
 export type ThunkExtraArg = {
@@ -32,6 +33,7 @@ export type Dispatch = AppDispatch
 
 export type DispatchProps = {dispatch: Dispatch}
 export type State = {
+  tabHistories: TabHistoriesState
   handlers: HandlersState
   workspaces: WorkspacesState
   errors: ErrorsState

--- a/src/js/test/initTestStore.ts
+++ b/src/js/test/initTestStore.ts
@@ -1,5 +1,6 @@
 import {configureStore} from "@reduxjs/toolkit"
 import {createZealotMock, Zealot} from "zealot"
+import initGlobals from "../initializers/initGlobals"
 import rootReducer from "../state/rootReducer"
 import {Action, State} from "../state/types"
 
@@ -15,7 +16,7 @@ export type TestStore = {
 export default (zealot?: Zealot): TestStore => {
   const client = zealot || createZealotMock().zealot
   const createZealot = () => client
-  return configureStore({
+  const store = configureStore({
     reducer: rootReducer,
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
@@ -31,6 +32,8 @@ export default (zealot?: Zealot): TestStore => {
       applyActionHistory()
     ]
   }) as any
+  initGlobals(store)
+  return store
 }
 
 function applyDispatchAll() {


### PR DESCRIPTION
Needed for: https://github.com/brimsec/brim/pull/1473
Relates to: #1446 

### New Globals

In this PR, I introduce two new global variables to the search page.

1. tabHistory: this a [memory history instance](https://github.com/ReactTraining/history/blob/master/docs/api-reference.md#creatememoryhistory) and will always be associated with the active tab
2. tabHistories: a map of all the tab ids to their history instance

<img width="615" alt="image" src="https://user-images.githubusercontent.com/3460638/108778242-f3368200-7519-11eb-9980-3b1358f8db4a.png">

### Lifecycle

In the `Tabs.reducer`, I update the values of those two new globals whenever a new tab is added, activated, or removed. This is breaking the rules since side effects are not recommend in reducers, but also seems like the best place for it. I am open to other ideas. 

The tabHistory object doesn't do anything to app at the moment, that's in another branch.

### Persistance

1. During initialization, select all the persisted entries from the store and pass them to the constructor of the `Histories` class
2. During shutdown, serialize the `tabHistories` instance and save it to redux

While the app is being used, redux will not be synced with the entries. This is what [react-redux recommends](https://reactrouter.com/web/guides/deep-redux-integration).



