### PR TITLE
Robust Detail Pane

### DIFF
--- a/ppl/detail/Correlation.tsx
+++ b/ppl/detail/Correlation.tsx
@@ -13,7 +13,7 @@ import {Data, Name, Value} from "app/core/Data"
 import formatDur from "ppl/detail/util/formatDur"
 import {isEqual} from "lodash"
 import Panel from "app/detail/Panel"
-import {getCorrelationQuery} from "./flows/getCorrelationQuery"
+import {getCorrelationQuery} from "./flows/get-correlation-query"
 import EventLimit from "./EventLimit"
 import {showContextMenu} from "src/js/lib/System"
 

--- a/ppl/detail/flows/fetch.ts
+++ b/ppl/detail/flows/fetch.ts
@@ -1,7 +1,7 @@
 import {zng} from "zealot"
 import {search} from "src/js/flows/search/mod"
 import {Correlation} from "../models/Correlation"
-import {getCorrelationQuery} from "./getCorrelationQuery"
+import {getCorrelationQuery} from "./get-correlation-query"
 
 const id = "RELATED_EVENTS"
 

--- a/ppl/detail/flows/get-correlation-query.test.ts
+++ b/ppl/detail/flows/get-correlation-query.test.ts
@@ -1,0 +1,73 @@
+import {
+  cidCorrelation,
+  connCorrelation,
+  uidCorrelation
+} from "src/js/searches/programs"
+import {zjson, zng} from "zealot"
+import {getCorrelationQuery} from "./get-correlation-query"
+
+test("returns uid query if ts and duration are missing", () => {
+  const type = [
+    {name: "_path", type: "string"},
+    {name: "uid", type: "string"},
+    {name: "community_id", type: "string"}
+  ] as zjson.Column[]
+  const value = ["conn", "CHem0e2rJqHiwjhgq7", "1:NYgcI8mLerCC20GwJVV5AftL0uY="]
+  const record = new zng.Record(type, value)
+
+  expect(getCorrelationQuery(record)).toBe(
+    uidCorrelation(record.get("uid") as zng.Primitive)
+  )
+})
+
+test("returns conn query if ts and duration are present", () => {
+  const type = [
+    {name: "_path", type: "string"},
+    {name: "uid", type: "string"},
+    {name: "community_id", type: "string"},
+    {name: "ts", type: "time"},
+    {name: "duration", type: "interval"}
+  ] as zjson.Column[]
+  const value = [
+    "conn",
+    "CHem0e2rJqHiwjhgq7",
+    "1:NYgcI8mLerCC20GwJVV5AftL0uY=",
+    "1585852166.003543",
+    null
+  ]
+  const record = new zng.Record(type, value)
+
+  expect(getCorrelationQuery(record)).toBe(connCorrelation(record))
+})
+
+test("returns cid query if only cid present", () => {
+  const type = [
+    {name: "_path", type: "string"},
+    {name: "community_id", type: "string"},
+    {name: "ts", type: "time"},
+    {name: "duration", type: "interval"}
+  ] as zjson.Column[]
+  const value = [
+    "conn",
+    "1:NYgcI8mLerCC20GwJVV5AftL0uY=",
+    "1585852166.003543",
+    null
+  ]
+  const record = new zng.Record(type, value)
+
+  expect(getCorrelationQuery(record)).toBe(
+    cidCorrelation(record.get("community_id") as zng.Primitive)
+  )
+})
+
+test("returns null if no cid or uid", () => {
+  const type = [
+    {name: "_path", type: "string"},
+    {name: "ts", type: "time"},
+    {name: "duration", type: "interval"}
+  ] as zjson.Column[]
+  const value = ["conn", "1585852166.003543", null]
+  const record = new zng.Record(type, value)
+
+  expect(getCorrelationQuery(record)).toBe(null)
+})

--- a/ppl/detail/flows/get-correlation-query.test.ts
+++ b/ppl/detail/flows/get-correlation-query.test.ts
@@ -37,7 +37,14 @@ test("returns conn query if ts and duration are present", () => {
   ]
   const record = new zng.Record(type, value)
 
-  expect(getCorrelationQuery(record)).toBe(connCorrelation(record))
+  expect(getCorrelationQuery(record)).toBe(
+    connCorrelation(
+      record.get("uid") as zng.Primitive,
+      record.get("community_id") as zng.Primitive,
+      record.get("ts") as zng.Primitive,
+      record.get("duration") as zng.Primitive
+    )
+  )
 })
 
 test("returns cid query if only cid present", () => {

--- a/ppl/detail/flows/get-correlation-query.ts
+++ b/ppl/detail/flows/get-correlation-query.ts
@@ -9,7 +9,7 @@ import {Correlation} from "../models/Correlation"
 export function getCorrelationQuery(record: zng.Record) {
   const {uid, cid} = new Correlation(record).getIds()
 
-  if (cid && uid) {
+  if (cid && uid && record.has("ts") && record.has("duration")) {
     return connCorrelation(record)
   } else if (uid) {
     return uidCorrelation(uid)

--- a/ppl/detail/flows/get-correlation-query.ts
+++ b/ppl/detail/flows/get-correlation-query.ts
@@ -10,7 +10,12 @@ export function getCorrelationQuery(record: zng.Record) {
   const {uid, cid} = new Correlation(record).getIds()
 
   if (cid && uid && record.has("ts") && record.has("duration")) {
-    return connCorrelation(record)
+    return connCorrelation(
+      record.get("uid") as zng.Primitive,
+      record.get("community_id") as zng.Primitive,
+      record.get("ts") as zng.Primitive,
+      record.get("duration") as zng.Primitive
+    )
   } else if (uid) {
     return uidCorrelation(uid)
   } else if (cid) {

--- a/src/css/_error-boundary.scss
+++ b/src/css/_error-boundary.scss
@@ -2,6 +2,7 @@
   overflow: auto;
   height: 100%;
   background-color: var(--ivory);
+  background: linear-gradient(to bottom right, #f8eee3, #fae1e0);
   padding: 24px;
   line-height: 1.5;
 
@@ -22,7 +23,8 @@
 
   pre,
   li,
-  code {
+  code, 
+  a {
     overflow: auto;
     font-size: 11px;
   }

--- a/src/css/_error-boundary.scss
+++ b/src/css/_error-boundary.scss
@@ -23,7 +23,7 @@
 
   pre,
   li,
-  code, 
+  code,
   a {
     overflow: auto;
     font-size: 11px;

--- a/src/js/components/AppErrorBoundary.tsx
+++ b/src/js/components/AppErrorBoundary.tsx
@@ -1,11 +1,9 @@
 import React from "react"
-
-import {Dispatch} from "../state/types"
-import {LatestError} from "./LatestError"
 import ErrorFactory from "../models/ErrorFactory"
-import Warn from "./icons/warning-md.svg"
+import Link from "./common/Link"
+import {LatestError} from "./LatestError"
 
-type Props = {children: any; dispatch: Dispatch}
+type Props = {children: any}
 type State = {error: Error | null | undefined}
 
 export default class AppErrorBoundary extends React.Component<Props, State> {
@@ -25,12 +23,10 @@ export default class AppErrorBoundary extends React.Component<Props, State> {
     return (
       <div className="error-boundary">
         <LatestError error={ErrorFactory.create(error)} />
-        <div className="body-content">
-          <h1>
-            <Warn />
-            Error
-          </h1>
+        <div>
+          <h1>Error</h1>
           <pre>{error.stack}</pre>
+          <Link href="mailto:support@brimsecurity.com">Contact Support</Link>
         </div>
       </div>
     )

--- a/src/js/components/RightPane.tsx
+++ b/src/js/components/RightPane.tsx
@@ -1,27 +1,27 @@
-import {connect} from "react-redux"
+import DetailPane from "app/detail/Pane"
 import React from "react"
-
-import {DispatchProps} from "../state/types"
-import {Space} from "../state/Spaces/types"
-import {XRightPaneExpander} from "./RightPaneExpander"
+import {connect} from "react-redux"
+import {zng} from "zealot"
 import {openLogDetailsWindow} from "../flows/openLogDetailsWindow"
-import CloseButton from "./CloseButton"
-import Current from "../state/Current"
 import ExpandWindow from "../icons/ExpandWindow"
-import HistoryButtons from "./common/HistoryButtons"
+import dispatchToProps from "../lib/dispatchToProps"
+import Current from "../state/Current"
 import Layout from "../state/Layout"
 import LogDetails from "../state/LogDetails"
-import DetailPane from "app/detail/Pane"
+import {Space} from "../state/Spaces/types"
+import {DispatchProps} from "../state/types"
+import AppErrorBoundary from "./AppErrorBoundary"
+import CloseButton from "./CloseButton"
+import HistoryButtons from "./common/HistoryButtons"
 import Pane, {
+  Center,
+  Left,
+  PaneBody,
   PaneHeader,
   PaneTitle,
-  Left,
-  Right,
-  Center,
-  PaneBody
+  Right
 } from "./Pane"
-import dispatchToProps from "../lib/dispatchToProps"
-import {zng} from "zealot"
+import {XRightPaneExpander} from "./RightPaneExpander"
 
 type StateProps = {
   currentLog: zng.Record
@@ -85,7 +85,9 @@ export default class RightPane extends React.Component<Props, S> {
           </PaneHeader>
         )}
         <PaneBody>
-          <DetailPane />
+          <AppErrorBoundary>
+            <DetailPane />
+          </AppErrorBoundary>
         </PaneBody>
       </Pane>
     )

--- a/src/js/detail.tsx
+++ b/src/js/detail.tsx
@@ -17,7 +17,7 @@ import BrimTooltip from "./components/BrimTooltip"
 initDetail()
   .then((store) => {
     ReactDOM.render(
-      <AppErrorBoundary dispatch={store.dispatch}>
+      <AppErrorBoundary>
         <div id="modal-dialog-root" />
         <Provider store={store}>
           <ThemeProvider theme={theme}>

--- a/src/js/search.tsx
+++ b/src/js/search.tsx
@@ -19,7 +19,7 @@ initialize()
       store.dispatch(deletePartialSpaces())
     }
     ReactDOM.render(
-      <AppErrorBoundary dispatch={store.dispatch}>
+      <AppErrorBoundary>
         <Provider store={store}>
           <ThemeProvider theme={theme}>
             <App />

--- a/src/js/searches/programs.test.ts
+++ b/src/js/searches/programs.test.ts
@@ -94,7 +94,14 @@ test("conn correlation", () => {
   }
   const record = zng.Record.deserialize(conn)
 
-  expect(connCorrelation(record)).toBe(
+  expect(
+    connCorrelation(
+      record.get("uid") as zng.Primitive,
+      record.get("community_id") as zng.Primitive,
+      record.get("ts") as zng.Primitive,
+      record.get("duration") as zng.Primitive
+    )
+  ).toBe(
     'uid="CbOjYpkXn9LfqV51c" or "CbOjYpkXn9LfqV51c" in conn_uids or "CbOjYpkXn9LfqV51c" in uids or referenced_file.uid="CbOjYpkXn9LfqV51c" or (community_id = "1:h09VUfAoDYfBA0xGKuKCQ7nOxqU=" and ts >= 1425568032.998 and ts < 1425568123.707) | head 100'
   )
 })

--- a/src/js/searches/programs.ts
+++ b/src/js/searches/programs.ts
@@ -21,8 +21,8 @@ export function uidFilter(uid: string | zng.Primitive) {
   return zql`uid=${uid} or ${uid} in conn_uids or ${uid} in uids or referenced_file.uid=${uid}`
 }
 
-export function cidFilter(cid: string) {
-  return `community_id="${cid}"`
+export function cidFilter(cid: string | zng.Primitive) {
+  return zql`community_id="${cid}"`
 }
 
 export const UID_CORRELATION_LIMIT = 100
@@ -42,11 +42,11 @@ export function correlationIds({uid, cid}: RelatedIds) {
   return [filters.join(" or "), correlationLimit()].join(" | ")
 }
 
-export function uidCorrelation(uid: string) {
+export function uidCorrelation(uid: string | zng.Primitive) {
   return `${uidFilter(uid)} | ${correlationLimit()}`
 }
 
-export function cidCorrelation(cid: string) {
+export function cidCorrelation(cid: string | zng.Primitive) {
   return `${cidFilter(cid)} | ${correlationLimit()}`
 }
 

--- a/src/js/searches/programs.ts
+++ b/src/js/searches/programs.ts
@@ -22,7 +22,7 @@ export function uidFilter(uid: string | zng.Primitive) {
 }
 
 export function cidFilter(cid: string | zng.Primitive) {
-  return zql`community_id="${cid}"`
+  return zql`community_id=${cid}`
 }
 
 export const UID_CORRELATION_LIMIT = 100

--- a/src/js/searches/programs.ts
+++ b/src/js/searches/programs.ts
@@ -50,14 +50,15 @@ export function cidCorrelation(cid: string | zng.Primitive) {
   return `${cidFilter(cid)} | ${correlationLimit()}`
 }
 
-export function connCorrelation(conn: zng.Record) {
-  const uid = conn.get("uid") as zng.Primitive
-  const cid = conn.get("community_id") as zng.Primitive
-  const ts = (conn.get("ts") as zng.Primitive).toDate()
-  const dur = (conn.get("duration") as zng.Primitive).toFloat() + 90 // Add a 1.5 minute buffer for events that get logged late
-  const endTs = new Date(new Date(ts).getTime() + dur * 1000)
-
-  const cidFilter = zql`community_id = ${cid} and ts >= ${ts} and ts < ${endTs}`
-
+export function connCorrelation(
+  uid: zng.Primitive,
+  cid: zng.Primitive,
+  ts: zng.Primitive,
+  duration: zng.Primitive
+) {
+  const tsDate = ts.toDate()
+  const dur = duration.toFloat() + 90 // Add a 1.5 minute buffer for events that get logged late
+  const endTsDate = new Date(new Date(tsDate).getTime() + dur * 1000)
+  const cidFilter = zql`community_id = ${cid} and ts >= ${tsDate} and ts < ${endTsDate}`
   return `${uidFilter(uid)} or (${cidFilter}) | ${correlationLimit()}`
 }


### PR DESCRIPTION
Fixes #1475

This PR adds a check for the "ts" and "duration" fields before trying to access them. This is done when fetching data for the waterfall. We can't assume that data has a certain shape anymore, now that we can accept multiple sources.

I also added an error boundary around the log detail pane. If an error like this occurs again in the detail pane, the rest of the app will still be usable. Here is what it looks like:

<img width="1362" alt="Screen Shot 2021-03-03 at 3 50 45 PM" src="https://user-images.githubusercontent.com/3460638/109892111-2fb35d80-7c3f-11eb-9a81-7cef0d9ae044.png">
