### PR TITLE
Say "prerelease" in version string, not "master"

### DIFF
--- a/.github/workflows/linux-release-candidate.yml
+++ b/.github/workflows/linux-release-candidate.yml
@@ -47,7 +47,7 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
     - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
       name: Set version string for ad hoc builds
-      run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid master-${GITHUB_SHA:0:8})" >> $GITHUB_ENV
+      run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid prerelease-${GITHUB_SHA:0:8})" >> $GITHUB_ENV
     - run: npm install --no-audit
     - run: npm run build
     - name: build packages

--- a/.github/workflows/macos-release-candidate.yml
+++ b/.github/workflows/macos-release-candidate.yml
@@ -50,7 +50,7 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
     - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
       name: Set version string for ad hoc builds
-      run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid master-${GITHUB_SHA:0:8})" >> $GITHUB_ENV
+      run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid prerelease-${GITHUB_SHA:0:8})" >> $GITHUB_ENV
     - run: npm install --no-audit
     - run: npm run build
     - name: create build keychain and import Developer ID certificate into it

--- a/.github/workflows/win-release-candidate.yml
+++ b/.github/workflows/win-release-candidate.yml
@@ -51,7 +51,7 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
     - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
       name: Set version string for ad hoc builds
-      run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid master-${GITHUB_SHA:0:8})" >> $GITHUB_ENV
+      run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid prerelease-${GITHUB_SHA:0:8})" >> $GITHUB_ENV
       shell: bash
     - run: npm install --no-audit
     - run: npm run build


### PR DESCRIPTION
This is just a cosmetic thing, but I think it kind of matters. When I was last overhauling the build system in #1358, I put the word `master` in the version strings for the ad hoc builds. This is correct most of the time since typically the ad hoc builds are triggered nightly based on the latest commit in `master`. However, when I recently used the "Workflow Dispatch" approach to trigger an ad hoc build on a Dev branch, I confused myself when I saw `master` in the build string next to a commit hash for that branch.

Here I'm instead using the word `prerelease`. I figure in the rare cases that we hand these builds to users for test/debug purposes and they happen to look at the "About" info, that word more clearly communicates its non-official nature. For those of us using these builds internally, I expect our attention will be drawn more to the commit hash anyway, which is what's usually most important.