### PR TITLE
Fix links to jest docs

### DIFF
--- a/itest/README.md
+++ b/itest/README.md
@@ -28,7 +28,7 @@ You can also run individual files like:
 `npm run itest -- itest/tests/smoke.test.ts`
 
 See `npm run itest -- --help` for more, or see [Jest
-docs](https://jestjs.io/docs/en/24.x/getting-started).
+docs](https://jestjs.io/docs/getting-started).
 
 # Code Layout
 
@@ -72,7 +72,7 @@ The mechanism to do this is:
 
 Don't forget to `git add` any changes to snapshots. You must add
 mikesbrown as a reviewer when changing snapshots. [Jest
-docs](https://jestjs.io/docs/en/24.x/snapshot-testing#1-treat-snapshots-as-code)
+docs](https://jestjs.io/docs/snapshot-testing#1-treat-snapshots-as-code)
 even say to review these as carefully as code.
 
 If you want to patch JSON by hand, you're on your own to make Jest


### PR DESCRIPTION
The nightly markdown link checker flagged that these jest links started failing. Closer inspection shows they've been moved to an "archive.jestjs.io" URL. Since these were pointing to a 24.x version and I see our own `package.json` has us pointing at jest 26.x, pointing to an older static release was probably not serving us well. The new links I'm proposing here apparently resolve to whatever's the "Current version (Stable)", which I assume we'll probably stay roughly in sync with anyway (it happens to match the 26.x we're using at the moment in `package.json`, so, seems as good a choice as any.)