### PR TITLE
fixes for new "every" duration syntax

### DIFF
--- a/src/js/brim/program.test.ts
+++ b/src/js/brim/program.test.ts
@@ -220,13 +220,13 @@ describe("#hasAnalytics()", () => {
   })
 
   test("every proc does contain analytics", () => {
-    expect(brim.program("* | every 1hr count()").hasAnalytics()).toBe(true)
+    expect(brim.program("* | every 1h count()").hasAnalytics()).toBe(true)
   })
 
   test("parallel procs when one does have analytics", () => {
     expect(
       brim
-        .program("* | split ( => every 1hr count() => count() by id.resp_h)")
+        .program("* | split ( => every 1h count() => count() by id.resp_h)")
         .hasAnalytics()
     ).toBe(true)
   })

--- a/src/js/flows/submitSearch/__tests__/events.test.ts
+++ b/src/js/flows/submitSearch/__tests__/events.test.ts
@@ -54,7 +54,7 @@ describe("table search", () => {
 
     const calls = zealot.calls("search")
     expect(calls.length).toBe(2)
-    expect(calls[0].args).toEqual("dns query | every 1sec count() by _path")
+    expect(calls[0].args).toEqual("dns query | every 1s count() by _path")
     expect(calls[1].args).toEqual("dns query | head 500")
   })
 

--- a/src/js/searches/histogramSearch.ts
+++ b/src/js/searches/histogramSearch.ts
@@ -4,11 +4,12 @@ import histogramInterval from "../lib/histogramInterval"
 export function addEveryCountProc(program: string, span: DateSpan) {
   const BOOM_INTERVALS = {
     millisecond: "ms",
-    second: "sec",
-    minute: "min",
-    hour: "hr",
-    day: "day",
-    month: "month"
+    second: "s",
+    minute: "m",
+    hour: "h",
+    day: "d",
+    week: "w",
+    year: "y"
   }
   const {number, unit} = histogramInterval(span)
 

--- a/src/js/state/Search/test.ts
+++ b/src/js/state/Search/test.ts
@@ -86,7 +86,7 @@ describe("selectors", () => {
     const state = store.getState()
 
     expect(Search.getArgs(state)).toEqual({
-      chartProgram: "* | every 1sec count() by _path",
+      chartProgram: "* | every 1s count() by _path",
       spaceId: "1",
       spaceName: "default",
       span: [new Date(0), new Date(1000)],


### PR DESCRIPTION
This commit fixes up brim with changes to deal with the changes
in zq for the new duration syntax used by "every".