### PR TITLE
Fix link to immerjs.github.io

### DIFF
--- a/docs/Code-Base-Walkthrough.md
+++ b/docs/Code-Base-Walkthrough.md
@@ -112,7 +112,7 @@ Additionally, we rely heavily on the node modules listed here:
 
 - [Redux](https://redux.js.org/introduction/getting-started)
 - [Redux Thunk](https://github.com/reduxjs/redux-thunk) A small utility to allow for async actions
-- [Immer](https://immerjs.github.io/immer/docs/introduction) Used in reducers to work with immutable state in a more convenient way
+- [Immer](https://immerjs.github.io/immer/) Used in reducers to work with immutable state in a more convenient way
 
 **Testing**
 


### PR DESCRIPTION
The markdown link checker caught this as broken last night. It's still broken now and I clicked around and found what I think is a new home for the same page we used to link to.