### PR TITLE
Missing workspace bug

### DIFF
--- a/app/workspaces/show.tsx
+++ b/app/workspaces/show.tsx
@@ -21,6 +21,12 @@ const SpinnerWrap = styled.div`
   justify-content: center;
 `
 
+function GetWorkspace({children}) {
+  const workspace = useSelector(Current.getWorkspace)
+  if (!workspace) return <Redirect to="/workspaces" />
+  else return children
+}
+
 function InitWorkspace({children}) {
   const dispatch = useDispatch()
   const workspace = useSelector(Current.mustGetWorkspace)
@@ -50,18 +56,20 @@ function InitWorkspace({children}) {
 export default function WorkspaceShow() {
   const match = useRouteMatch<{workspaceId: string}>()
   return (
-    <InitWorkspace>
-      <Switch>
-        <Route path={lakeImport.path}>
-          <LakeHome />
-        </Route>
-        <Route path={lakeShow.path}>
-          <LakeShow />
-        </Route>
-        <Route default>
-          <Redirect to={lakeImportPath(match.params.workspaceId)} />
-        </Route>
-      </Switch>
-    </InitWorkspace>
+    <GetWorkspace>
+      <InitWorkspace>
+        <Switch>
+          <Route path={lakeImport.path}>
+            <LakeHome />
+          </Route>
+          <Route path={lakeShow.path}>
+            <LakeShow />
+          </Route>
+          <Route default>
+            <Redirect to={lakeImportPath(match.params.workspaceId)} />
+          </Route>
+        </Switch>
+      </InitWorkspace>
+    </GetWorkspace>
   )
 }

--- a/itest/lib/createTestBrim.ts
+++ b/itest/lib/createTestBrim.ts
@@ -2,6 +2,7 @@ import {htmlContextMenu} from "src/js/test/locators"
 import lib from "../../src/js/lib"
 import {Locator} from "../../src/js/test/createLocator"
 import appStep from "./appStep/api"
+import takeScreenshot from "./appStep/api/takeScreenshot"
 import waitForHook from "./appStep/api/waitForHook"
 // TODO in a future PR: remove direct logStep uses here.
 import logStep from "./appStep/util/logStep"
@@ -28,6 +29,11 @@ export default (name: string) => {
 
     hook(name, opts?) {
       return waitForHook(app, name, opts)
+    },
+
+    navTo(path: string) {
+      // @ts-ignore
+      return app.client.execute((path) => navTo(path), path)
     },
 
     getApp() {
@@ -65,6 +71,10 @@ export default (name: string) => {
       })
     },
 
+    takeScreenshot() {
+      return takeScreenshot(app)
+    },
+
     clickAppMenuItem(id: string) {
       return app.mainProcess.emit("spectron:clickAppMenuItem", id)
     },
@@ -87,10 +97,13 @@ export default (name: string) => {
       return appStep.rightClick(app, locator.css)
     },
 
-    waitForText(locator: string, regex: RegExp) {
+    hasText(input: string | RegExp, locator: Locator | string = "body") {
       return retryUntil(
-        async () => (await app.client.$(locator)).getText(),
-        (s) => regex.test(s)
+        () =>
+          app.client
+            .$(typeof locator === "string" ? locator : locator.css)
+            .then((el) => el.getText()),
+        (s) => (typeof input === "string" ? s.includes(input) : input.test(s))
       )
     },
 

--- a/itest/tests/workspaces.test.ts
+++ b/itest/tests/workspaces.test.ts
@@ -1,0 +1,15 @@
+import createTestBrim from "itest/lib/createTestBrim"
+
+describe("Workspace routes", () => {
+  const brim = createTestBrim("workspaces.test")
+
+  test("visiting a workspace that doesn't exist", async () => {
+    try {
+      await brim.navTo("/workspaces/none")
+      await brim.hasText("Choose a Workspace")
+    } catch (e) {
+      await brim.takeScreenshot()
+      throw e
+    }
+  })
+})

--- a/src/js/@types/global.d.ts
+++ b/src/js/@types/global.d.ts
@@ -15,6 +15,7 @@ declare global {
       feature: (name: FeatureName, value: boolean) => void
       tabHistories: Histories
       windowHistory: BrowserHistory
+      navTo: (path: string) => void
     }
 
     interface Process {

--- a/src/js/components/WorkspacePicker.tsx
+++ b/src/js/components/WorkspacePicker.tsx
@@ -75,7 +75,7 @@ export default function WorkspacePicker() {
   const current = useSelector(Workspaces.id(workspaceId))
   return (
     <WorkspacePickerWrapper onClick={() => dispatch(showWorkspaceMenu())}>
-      <label>{`${current.name}`}</label>
+      <label>{`${current?.name}`}</label>
       <DropdownArrow />
     </WorkspacePickerWrapper>
   )

--- a/src/js/initializers/initGlobals.ts
+++ b/src/js/initializers/initGlobals.ts
@@ -5,6 +5,7 @@ import Feature from "../state/Feature"
 import TabHistories from "../state/TabHistories"
 import {Store} from "../state/types"
 import {createMemoryHistory} from "history"
+import tabHistory from "app/router/tab-history"
 
 export default function initGlobals(store: Store) {
   global.getState = store.getState
@@ -14,6 +15,7 @@ export default function initGlobals(store: Store) {
   global.tabHistories = new Histories(TabHistories.selectAll(store.getState()))
   global.windowHistory = createMemoryHistory()
   global.windowHistory.replace(getUrlSearchParams().href)
+  global.navTo = (path) => store.dispatch(tabHistory.push(path))
 }
 
 function getWindowName() {


### PR DESCRIPTION
Added a global function called `navTo(path)`. You can use this in the dev tools to go to a specific url. 

If you open the dev tools and type `navTo("/workspaces/does-not-exist")`, then you will reproduce the bug reported at #1529.

A simple null check fixed it. An integration test has been added to check for this now.